### PR TITLE
Add support for Kotlin build dirs

### DIFF
--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMTask.java
@@ -226,6 +226,7 @@ abstract public class AbstractRoboVMTask extends DefaultTask {
         classpathEntries.add(new File(project.getBuildDir(), "classes/java/main"));
         classpathEntries.add(new File(project.getBuildDir(), "classes/groovy/main"));
         classpathEntries.add(new File(project.getBuildDir(), "classes/scala/main"));
+        classpathEntries.add(new File(project.getBuildDir(), "classes/kotlin/main"));
         classpathEntries.add(new File(project.getBuildDir(), "resources/main"));
 
         if (project.hasProperty("output.classesDir")) {


### PR DESCRIPTION
This enables Kotlin classes to be picked-up correctly with Gradle 4.0+

This used to work before Kotlin 1.1.4, but with the latest version they are now also following the new output directory convention:
https://youtrack.jetbrains.com/issue/KT-18544