### PR TITLE
#221 fix

### DIFF
--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSObject.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSObject.java
@@ -121,8 +121,9 @@ import org.robovm.apple.dispatch.*;
     /*<bind>*/static { ObjCRuntime.bind(NSObject.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     private NSKeyValueCoder keyValueCoder;
-    
-    
+
+
+    @Method(selector = "init")
     public NSObject() {
         if (!forceSkipInit)
             initObject(init());


### PR DESCRIPTION
fix consists of two parts:
1) added @method annotation to NSObject.init which enables constructor callback for init method as well
2) to fix #221 would be enough to annotate UIApplicationDelegate with @CustomClass but it would require lot of people to pay attention to this. So instead sugar was added to generate these callbacks during the compilation which will not require any action from user