### PR TITLE
Debugger - broken step over and crashed when using labda

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/plugin/lambda/LambdaPlugin.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/plugin/lambda/LambdaPlugin.java
@@ -58,6 +58,7 @@ import soot.jimple.DynamicInvokeExpr;
 import soot.jimple.IntConstant;
 import soot.jimple.Jimple;
 import soot.jimple.NullConstant;
+import soot.tagkit.LineNumberTag;
 import soot.util.Switch;
 
 public class LambdaPlugin extends AbstractCompilerPlugin {
@@ -232,6 +233,19 @@ public class LambdaPlugin extends AbstractCompilerPlugin {
                                                         samType, true),
                                                 expr.getArgs())));
                             }
+
+                            // dkimitsa: attach LineNumberTag to all new units that are inserted instead of DynamicInvokeExpr
+                            // as it would break variable resolution in debuger information plugin
+                            for (Object o : unit.getTags()) {
+                                if (o instanceof LineNumberTag) {
+                                    // attach same line number to all units in new units
+                                    LineNumberTag ln = (LineNumberTag) o;
+                                    for (Unit u : newUnits)
+                                        u.addTag(new LineNumberTag(ln.getLineNumber()));
+                                    break;
+                                }
+                            }
+
                             units.insertAfter(newUnits, unit);
                             units.remove(unit);
                             unit = newUnits.getLast();

--- a/plugins/debugger/src/main/java/org/robovm/debugger/delegates/RuntimeUtils.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/delegates/RuntimeUtils.java
@@ -175,13 +175,13 @@ public class RuntimeUtils {
         delegates.hooksApi().threadStep(thread.threadPtr(), pclow, pchigh, pclow2, pchigh2);
 
         // return reference
-        return new RuntimeStepReference(pclow, pchigh, pclow2, pchigh2);
+        return new RuntimeStepReference(thread, pclow, pchigh, pclow2, pchigh2);
     }
 
 
-    public void restep(VmThread thread, RuntimeStepReference ref) {
+    public void restep(RuntimeStepReference ref) {
         // apply to target
-        delegates.hooksApi().threadStep(thread.threadPtr(), ref.pclow, ref.pchigh, ref.pclow2, ref.pchigh2);
+        delegates.hooksApi().threadStep(ref.thread.threadPtr(), ref.pclow, ref.pchigh, ref.pclow2, ref.pchigh2);
     }
 
 
@@ -228,17 +228,23 @@ public class RuntimeUtils {
      * container to keep configuration of step performed as step often required to reproduce
      */
     public static class RuntimeStepReference {
+        private final VmThread thread;
         private final long pclow;
         private final long pchigh;
         private final long pclow2;
         private final long pchigh2;
         private Object payload;
 
-        private RuntimeStepReference(long pclow, long pchigh, long pclow2, long pchigh2) {
+        private RuntimeStepReference(VmThread thread, long pclow, long pchigh, long pclow2, long pchigh2) {
+            this.thread = thread;
             this.pclow = pclow;
             this.pchigh = pchigh;
             this.pclow2 = pclow2;
             this.pchigh2 = pchigh2;
+        }
+
+        public VmThread thread() {
+            return thread;
         }
 
         public <T> T payload() {


### PR DESCRIPTION
1. It was not possible to step over code if this code was generating exception (even if it was handling it)
2. Debugger was incorrectly resolving scope of local variables if their usage was starting with invoking of lambda