### PR TITLE
Enabling Maven debug options

### DIFF
--- a/plugins/debugger/src/main/java/org/robovm/debugger/DebuggerLaunchPlugin.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/DebuggerLaunchPlugin.java
@@ -82,7 +82,7 @@ public class DebuggerLaunchPlugin extends LaunchPlugin {
 
         String logDir = argumentValue(arguments, ARG_KEY_LOG_DIR, config.getTmpDir().getAbsolutePath());
         int jdwpPort = argumentIntValue(arguments, ARG_KEY_JDWP_PORT);
-        boolean jdwpClientMode = argumentBoolValue(arguments, ARG_KEY_CLIENT_MODE);
+        boolean jdwpClientMode = argumentValue(arguments, ARG_KEY_CLIENT_MODE, false);
         boolean logConsole = config.isDumpIntermediates() || argumentValue(arguments, ARG_KEY_LOG_CONSOLE, false);
 
         // common parameters to target

--- a/plugins/maven/plugin/pom.xml
+++ b/plugins/maven/plugin/pom.xml
@@ -73,13 +73,6 @@
     <dependency>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robovm-debugger</artifactId>
-        <version>${project.version}</version>
-        <exclusions>
-            <exclusion>
-                <groupId>com.mobidevelop.robovm</groupId>
-                <artifactId>robovm-compiler</artifactId>
-            </exclusion>
-        </exclusions>
     </dependency>
   </dependencies>
 

--- a/plugins/maven/plugin/pom.xml
+++ b/plugins/maven/plugin/pom.xml
@@ -69,6 +69,18 @@
       <version>3.0</version>
       <scope>compile</scope>
     </dependency>
+
+    <dependency>
+        <groupId>com.mobidevelop.robovm</groupId>
+        <artifactId>robovm-debugger</artifactId>
+        <version>${project.version}</version>
+        <exclusions>
+            <exclusion>
+                <groupId>com.mobidevelop.robovm</groupId>
+                <artifactId>robovm-compiler</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
   </dependencies>
 
   <build>
@@ -76,7 +88,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.2</version>
+        <version>3.5</version>
         <configuration>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
           <goalPrefix>robovm</goalPrefix>

--- a/plugins/maven/plugin/src/main/resources/META-INF/services/org.robovm.compiler.plugin.LaunchPlugin
+++ b/plugins/maven/plugin/src/main/resources/META-INF/services/org.robovm.compiler.plugin.LaunchPlugin
@@ -1,0 +1,1 @@
+org.robovm.debugger.DebuggerLaunchPlugin

--- a/plugins/maven/pom.xml
+++ b/plugins/maven/pom.xml
@@ -101,13 +101,24 @@
   </build>
 
   <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.mobidevelop.robovm</groupId>
-        <artifactId>robovm-dist-compiler</artifactId>
-        <version>${robovm.version}</version>
-      </dependency>
-    </dependencies>
+      <dependencies>
+          <dependency>
+              <groupId>com.mobidevelop.robovm</groupId>
+              <artifactId>robovm-dist-compiler</artifactId>
+              <version>${robovm.version}</version>
+          </dependency>
+          <dependency>
+              <groupId>com.mobidevelop.robovm</groupId>
+              <artifactId>robovm-debugger</artifactId>
+              <version>${robovm.version}</version>
+              <exclusions>
+                  <exclusion>
+                      <groupId>com.mobidevelop.robovm</groupId>
+                      <artifactId>robovm-compiler</artifactId>
+                  </exclusion>
+              </exclusions>
+          </dependency>
+      </dependencies>
   </dependencyManagement>
 
   <modules>


### PR DESCRIPTION
Contribution to #254 - enabling the `-Drobovm.debug` and `-Drobovm.debugPort` options again. The debugger seems to start and listens or connects.