### PR TITLE
template fix, calculator-constructor method renamed to createCalculator from ARC dangerous one

### DIFF
--- a/plugins/templates/ios-framework/src/main/resources/archetype-resources/headers/__appName__.h
+++ b/plugins/templates/ios-framework/src/main/resources/archetype-resources/headers/__appName__.h
@@ -27,7 +27,7 @@ typedef NSObject<Calculator> Calculator;
 //
 NS_SWIFT_NAME(${mainClass})
 @protocol ${mainClass}
--(Calculator *) newCalculator;
+-(Calculator *) createCalculator;
 -(void) sayHello;
 -(NSString*) roboVmVersion;
 @end

--- a/plugins/templates/ios-framework/src/main/resources/archetype-resources/src/main/java/__packageInPathFormat__/Api.java
+++ b/plugins/templates/ios-framework/src/main/resources/archetype-resources/src/main/java/__packageInPathFormat__/Api.java
@@ -25,7 +25,7 @@ public final class Api {
          * create Calculator class as it is not possible now to create instances from obj, e.g. [[Calculator alloc] init]
          * will not work
          */
-        @Method Calculator newCalculator();
+        @Method Calculator createCalculator();
 
         /**
          * sample method implementation that take no params and returns nothing but prints hello to log

--- a/plugins/templates/ios-framework/src/main/resources/archetype-resources/src/main/java/__packageInPathFormat__/Api.java
+++ b/plugins/templates/ios-framework/src/main/resources/archetype-resources/src/main/java/__packageInPathFormat__/Api.java
@@ -24,6 +24,14 @@ public final class Api {
         /**
          * create Calculator class as it is not possible now to create instances from obj, e.g. [[Calculator alloc] init]
          * will not work
+         * IMPORTANT NOTE: avoid givinig method a name that begins with “alloc”, “new”, “copy”, or “mutableCopy”
+         * (for example newCalculator) as ARC at native side will consider this object to be owned by native code
+         * and will not retain it. If object is not retained anywhere at Java side this will cause EXC_BAD_ACCESS as
+         * not retained Java objects are subject for Garbage Collection. if such prefixes are higly required these objects
+         * MUST be extra retained before returning it from such method. E.g.
+         * calc = new CalculatorImpl();
+         * calc.reatain();
+         * return calc;
          */
         @Method Calculator createCalculator();
 

--- a/plugins/templates/ios-framework/src/main/resources/archetype-resources/src/main/java/__packageInPathFormat__/__mainClass__Impl.java
+++ b/plugins/templates/ios-framework/src/main/resources/archetype-resources/src/main/java/__packageInPathFormat__/__mainClass__Impl.java
@@ -23,7 +23,7 @@ public class ${mainClass}Impl extends NSObject implements Api.${mainClass} {
     }
 
     @Override
-    public Api.Calculator newCalculator() {
+    public Api.Calculator createCalculator() {
         return new CalculatorImpl();
     }
 

--- a/plugins/templates/ios-framework/src/main/resources/archetype-resources/src/main/java/__packageInPathFormat__/__mainClass__Impl.java
+++ b/plugins/templates/ios-framework/src/main/resources/archetype-resources/src/main/java/__packageInPathFormat__/__mainClass__Impl.java
@@ -22,6 +22,16 @@ public class ${mainClass}Impl extends NSObject implements Api.${mainClass} {
         return frameworkInstance;
     }
 
+    /**
+     * IMPORTANT NOTE: avoid givinig method a name that begins with “alloc”, “new”, “copy”, or “mutableCopy”
+     * (for example newCalculator) as ARC at native side will consider this object to be owned by native code
+     * and will not retain it. If object is not retained anywhere at Java side this will cause EXC_BAD_ACCESS as
+     * not retained Java objects are subject for Garbage Collection. if such prefixes are higly required these objects
+     * MUST be extra retained before returning it from such method. E.g.
+     * calc = new CalculatorImpl();
+     * calc.reatain();
+     * return calc;
+     */
     @Override
     public Api.Calculator createCalculator() {
         return new CalculatorImpl();


### PR DESCRIPTION
it is dangerous to expose method with prefix such as “alloc”, “new”, “copy”, or “mutableCopy” to native side as ARC could consider itself as owner and will not retain object. Which will cause EXC_BAD_ACCESS after GC