### PR TITLE
Improve performance of System.arraycopy()

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/sh
 set -e
 mvn clean install
 mvn -f plugins/idea/pom.xml clean install

--- a/compiler/compiler/src/main/java/org/robovm/compiler/Intrinsics.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/Intrinsics.java
@@ -73,6 +73,9 @@ public class Intrinsics {
         SIMPLE_INTRINSICS.put("java/lang/Math/sin(D)D", 
                 new FunctionRef("intrinsics.java_lang_Math_sin", 
                         new FunctionType(DOUBLE, ENV_PTR, DOUBLE)));
+        SIMPLE_INTRINSICS.put("org/robovm/rt/VM/ptrsize()I", 
+                new FunctionRef("intrinsics.org_robovm_rt_VM_ptrsize",
+                        new FunctionType(I32, ENV_PTR)));
     }
     
     private static final FunctionRef LDC_PRIM_Z = new FunctionRef("intrinsics.ldc_prim_Z", new FunctionType(OBJECT_PTR, ENV_PTR));

--- a/compiler/compiler/src/main/resources/header.ll
+++ b/compiler/compiler/src/main/resources/header.ll
@@ -12,6 +12,7 @@
 %Method = type opaque
 %Field = type opaque
 %Object = type {%Class*, i8*}
+%Objectptr = type { %Object* }
 ; NOTE: The compiler assumes that %DataObject is a multiple of 8 in size (we don't need to pad it since it's already 8 bytes in size)
 %DataObject = type {%Object}
 %Array = type {%DataObject, i32}
@@ -357,6 +358,12 @@ define private void @intrinsics.java_lang_System_arraycopy_C(%Env* %env, %Object
     
     call void @_bcMoveMemory16(i8* %s1, i8* %s2, i64 %n)
     ret void
+}
+
+define private i32 @intrinsics.org_robovm_rt_VM_ptrsize(%Env* %env) alwaysinline {
+    %Ptr = getelementptr %Objectptr* null, i32 1
+    %Size = ptrtoint %Objectptr* %Ptr to i32
+    ret i32 %Size
 }
 
 define private void @intrinsics.org_robovm_rt_VM_memmove8(%Env* %env, i64 %s1, i64 %s2, i64 %n) alwaysinline {

--- a/compiler/rt/libcore/luni/src/main/java/java/lang/System.java
+++ b/compiler/rt/libcore/luni/src/main/java/java/lang/System.java
@@ -231,90 +231,58 @@ public final class System {
         }
     }
     
-    private static void arraycopyFast(Object src, int srcPos, Object dst, int dstPos, int length, int logElemSize) {
+    private static void arraycopyFast(Object src, int srcPos, Object dst, int dstPos, int length, int elemSize) {
         if (length > 0) {
-            long srcAddr = VM.getArrayValuesAddress(src) + (srcPos << logElemSize);
-            long dstAddr = VM.getArrayValuesAddress(dst) + (dstPos << logElemSize);
-            if (logElemSize == 0) {
-                VM.memmove8(dstAddr, srcAddr, length);
-            } else if (logElemSize == 1) {
-                VM.memmove16(dstAddr, srcAddr, length);
-            } else if (logElemSize == 2) {
-                VM.memmove32(dstAddr, srcAddr, length);
-            } else if (logElemSize == 3) {
-                VM.memmove64(dstAddr, srcAddr, length);
-            } else {
-                throw new AssertionError();
-            }
+            long srcAddr = VM.getArrayValuesAddress(src) + (srcPos * elemSize);
+            long dstAddr = VM.getArrayValuesAddress(dst) + (dstPos * elemSize);
+            length *= elemSize;
+            VM.memmove8(dstAddr, srcAddr, length);
         }
     }
     
     private static void arraycopy(Object[] src, int srcPos, Object[] dst, int dstPos, int length) {
         arraycopyCheckBounds(src.length, srcPos, dst.length, dstPos, length);
-        if (length > 0) {
-            // TODO: Use arraycopyFast() if src.class and dst.class have same dimensionality and (src instanceof dst)
-            int i = 0;
-            try {
-                // Check if this is a forward or backwards arraycopy
-                if (src != dst || srcPos > dstPos || srcPos + length <= dstPos) {
-                    for (i = 0; i < length; ++i) {
-                        dst[dstPos + i] = src[srcPos + i];
-                    }
-                } else {
-                    for (i = length - 1; i >= 0; --i) {
-                        dst[dstPos + i] = src[srcPos + i];
-                    }
-                }
-            } catch (ArrayStoreException e) {
-                // Throw a new one with a more descriptive message.
-                Class<?> srcElemClass = src[i + srcPos].getClass();
-                String srcElemTypeName = srcElemClass.isArray() 
-                                        ? srcElemClass.getCanonicalName() : srcElemClass.getName();
-                throw new ArrayStoreException(String.format(
-                        "source[%d] of type %s cannot be stored in destination array of type %s",
-                        i + srcPos, srcElemTypeName, dst.getClass().getCanonicalName()));
-            }
-        }
+        arraycopyFast(src, srcPos, dst, dstPos, length, VM.ptrsize());
     }
 
     private static void arraycopy(int[] src, int srcPos, int[] dst, int dstPos, int length) {
         arraycopyCheckBounds(src.length, srcPos, dst.length, dstPos, length);
-        arraycopyFast(src, srcPos, dst, dstPos, length, 2);
+        arraycopyFast(src, srcPos, dst, dstPos, length, 4);
     }
 
     private static void arraycopy(byte[] src, int srcPos, byte[] dst, int dstPos, int length) {
         arraycopyCheckBounds(src.length, srcPos, dst.length, dstPos, length);
-        arraycopyFast(src, srcPos, dst, dstPos, length, 0);
+        arraycopyFast(src, srcPos, dst, dstPos, length, 1);
     }
 
     private static void arraycopy(short[] src, int srcPos, short[] dst, int dstPos, int length) {
         arraycopyCheckBounds(src.length, srcPos, dst.length, dstPos, length);
-        arraycopyFast(src, srcPos, dst, dstPos, length, 1);
+        arraycopyFast(src, srcPos, dst, dstPos, length, 2);
     }
 
     private static void arraycopy(long[] src, int srcPos, long[] dst, int dstPos, int length) {
         arraycopyCheckBounds(src.length, srcPos, dst.length, dstPos, length);
-        arraycopyFast(src, srcPos, dst, dstPos, length, 3);
+        arraycopyFast(src, srcPos, dst, dstPos, length, 8);
     }
 
     private static void arraycopy(char[] src, int srcPos, char[] dst, int dstPos, int length) {
         arraycopyCheckBounds(src.length, srcPos, dst.length, dstPos, length);
-        arraycopyFast(src, srcPos, dst, dstPos, length, 1);
+        arraycopyFast(src, srcPos, dst, dstPos, length, 2);
     }
 
     private static void arraycopy(boolean[] src, int srcPos, boolean[] dst, int dstPos, int length) {
         arraycopyCheckBounds(src.length, srcPos, dst.length, dstPos, length);
-        arraycopyFast(src, srcPos, dst, dstPos, length, 0);
+        arraycopyFast(src, srcPos, dst, dstPos, length, 1);
     }
 
     private static void arraycopy(double[] src, int srcPos, double[] dst, int dstPos, int length) {
         arraycopyCheckBounds(src.length, srcPos, dst.length, dstPos, length);
-        arraycopyFast(src, srcPos, dst, dstPos, length, 3);
+        arraycopyFast(src, srcPos, dst, dstPos, length, 8);
     }
 
     private static void arraycopy(float[] src, int srcPos, float[] dst, int dstPos, int length) {
         arraycopyCheckBounds(src.length, srcPos, dst.length, dstPos, length);
-        arraycopyFast(src, srcPos, dst, dstPos, length, 2);
+        arraycopyFast(src, srcPos, dst, dstPos, length, 4);
     }
     
     /**

--- a/compiler/rt/robovm/src/main/java/org/robovm/rt/VM.java
+++ b/compiler/rt/robovm/src/main/java/org/robovm/rt/VM.java
@@ -174,6 +174,8 @@ public final class VM {
 
     public native static final void memset(long s, byte c, long n);
 
+    public native static final int ptrsize();
+
     public native static final long getCallbackMethodImpl(Method method);
 
     public native static final void bindBridgeMethod(Method method, long impl);


### PR DESCRIPTION
Add ptrsize function as an llvm intrinsic to allow Java code to determine pointer size.
Use this to optimise System.arraycopy() including dropping use of the
16/32/64 bit versions of memmove - these are coded in C and are slower
than the intrinsic memmove implemented by llvm .

Fixes #236