### PR TITLE
'RoboVM' menu position changed to one after ToolsMenu

### DIFF
--- a/plugins/idea/src/main/resources/META-INF/plugin.xml
+++ b/plugins/idea/src/main/resources/META-INF/plugin.xml
@@ -50,7 +50,7 @@
 
     <actions>
         <group id="org.robovm.idea.Menu" text="RoboVM" description="RoboVM Menu">
-            <add-to-group group-id="MainMenu" anchor="before" relative-to-action="HelpMenu" />
+            <add-to-group group-id="MainMenu" anchor="after" relative-to-action="ToolsMenu" />
 
             <action id="org.robovm.idea.create-ipa" class="org.robovm.idea.actions.CreateIpaAction" text="Create IPA"
                     description="Create an IPA for App Store or ad-hoc distribution"/>


### PR DESCRIPTION
menu was added as part of https://github.com/MobiVM/robovm/pull/253
and it location as following 
![](http://dkimitsa.github.io/assets/2018/01/12/robovm-idea-new-menu.png)

but after period of using I've found that it more preferable to have 'Window' menu at its place. 
As it is often being used to switch projects/arrange windows. 
So RoboVM menu was moved next after Tools menu and it doesn't affect things there much 