### PR TITLE
Optimize System.arraycopy()

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/sh
 set -e
 mvn clean install
 mvn -f plugins/idea/pom.xml clean install

--- a/compiler/compiler/src/main/java/org/robovm/compiler/Intrinsics.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/Intrinsics.java
@@ -73,6 +73,9 @@ public class Intrinsics {
         SIMPLE_INTRINSICS.put("java/lang/Math/sin(D)D", 
                 new FunctionRef("intrinsics.java_lang_Math_sin", 
                         new FunctionType(DOUBLE, ENV_PTR, DOUBLE)));
+        SIMPLE_INTRINSICS.put("org/robovm/rt/VM/memmoveAtomic(JJJI)V", 
+                new FunctionRef("intrinsics.org_robovm_rt_VM_memmoveAtomic", 
+                        new FunctionType(VOID, ENV_PTR, I64, I64, I64, I32)));
     }
     
     private static final FunctionRef LDC_PRIM_Z = new FunctionRef("intrinsics.ldc_prim_Z", new FunctionType(OBJECT_PTR, ENV_PTR));

--- a/compiler/compiler/src/main/resources/header.ll
+++ b/compiler/compiler/src/main/resources/header.ll
@@ -118,6 +118,7 @@ declare void @_bcHookInstrumented(%Env*, i32, i32, i8*, i8*)
 declare i8* @llvm.frameaddress(i32) nounwind readnone
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 declare void @llvm.memmove.p0i8.p0i8.i64(i8*, i8*, i64, i32, i1)
+declare void @llvm.memmove.element.unordered.atomic.p0i8.p0i8.i64(i8*, i8*, i64, i32) 
 declare double @llvm.sqrt.f64(double)
 declare double @llvm.cos.f64(double)
 declare double @llvm.sin.f64(double)
@@ -356,6 +357,13 @@ define private void @intrinsics.java_lang_System_arraycopy_C(%Env* %env, %Object
     %n = sext i32 %length to i64
     
     call void @_bcMoveMemory16(i8* %s1, i8* %s2, i64 %n)
+    ret void
+}
+
+define private void @intrinsics.org_robovm_rt_VM_memmoveAtomic(%Env* %env, i64 %s1, i64 %s2, i64 %n, i32 %el) alwaysinline {
+    %dest = inttoptr i64 %s1 to i8*
+    %src = inttoptr i64 %s2 to i8*
+    call void @llvm.memmove.element.unordered.atomic.p0i8.p0i8.i64(i8* %dest, i8* %src, i64 %n, i32 %el)
     ret void
 }
 

--- a/compiler/rt/libcore/luni/src/main/java/java/lang/reflect/Array.java
+++ b/compiler/rt/libcore/luni/src/main/java/java/lang/reflect/Array.java
@@ -241,28 +241,7 @@ public final class Array {
      * @throws IllegalArgumentException
      *             if {@code array} is not an array
      */
-    public static int getLength(Object array) {
-        if (array instanceof Object[]) {
-            return ((Object[]) array).length;
-        } else if (array instanceof boolean[]) {
-            return ((boolean[]) array).length;
-        } else if (array instanceof byte[]) {
-            return ((byte[]) array).length;
-        } else if (array instanceof char[]) {
-            return ((char[]) array).length;
-        } else if (array instanceof double[]) {
-            return ((double[]) array).length;
-        } else if (array instanceof float[]) {
-            return ((float[]) array).length;
-        } else if (array instanceof int[]) {
-            return ((int[]) array).length;
-        } else if (array instanceof long[]) {
-            return ((long[]) array).length;
-        } else if (array instanceof short[]) {
-            return ((short[]) array).length;
-        }
-        throw badArray(array);
-      }
+    public static native int getLength(Object array);
 
     /**
      * Returns the long at the given index in the given array.

--- a/compiler/rt/robovm/src/main/java/org/robovm/rt/VM.java
+++ b/compiler/rt/robovm/src/main/java/org/robovm/rt/VM.java
@@ -162,6 +162,10 @@ public final class VM {
 
     public native static final ByteBuffer newDirectByteBuffer(long address, long capacity);
 
+    public native static final void memmoveAtomic(long s1, long s2, long n, int elementSize);
+
+    public native static final int getArrayElementSize(Class<?> cls);
+
     public native static final void memcpy(long s1, long s2, long n);
 
     public native static final void memmove8(long s1, long s2, long n);

--- a/compiler/vm/rt/robovm/java_lang_reflect_Array.c
+++ b/compiler/vm/rt/robovm/java_lang_reflect_Array.c
@@ -29,3 +29,15 @@ Object* Java_java_lang_reflect_Array_createMultiArray(Env* env, Class* cls, Clas
     Class* clazz = rvmFindClassByDescriptor(env, desc, componentType->classLoader);
     return (Object*) rvmNewMultiArray(env, dimensions->length, dimensions->values, clazz);
 }
+
+jint Java_java_lang_reflect_Array_getLength(Env* env, Class* cls, Object* object) {
+    if(object == NULL) {
+        rvmThrowNullPointerException(env);
+        return 0;
+    }
+    if(!CLASS_IS_ARRAY(object->clazz)) {
+        rvmThrowIllegalArgumentException(env, "Not an array");
+        return 0;
+    }
+    return ((Array*) object)->length;
+}

--- a/compiler/vm/rt/robovm/org_robovm_rt_VM.c
+++ b/compiler/vm/rt/robovm/org_robovm_rt_VM.c
@@ -187,6 +187,18 @@ Object* Java_org_robovm_rt_VM_newDirectByteBuffer(Env* env, Class* c, jlong addr
     return rvmNewDirectByteBuffer(env, LONG_TO_PTR(address), capacity);
 }
 
+jint Java_org_robovm_rt_VM_getArrayElementSize(Env* env, Class* c, Class* cls) {
+    if(cls == NULL) {
+        rvmThrowNullPointerException(env);
+        return 0;
+    }
+    if(!CLASS_IS_ARRAY(cls)) {
+        rvmThrowIllegalArgumentException(env, "Not an array");
+        return 0;
+    }
+    return rvmGetArrayElementSize(env, cls);
+}
+
 void Java_org_robovm_rt_VM_memcpy(Env* env, Class* c, jlong s1, jlong s2, jlong n) {
     memcpy(LONG_TO_PTR(s1), LONG_TO_PTR(s2), (size_t) n);
 }
@@ -205,6 +217,11 @@ void Java_org_robovm_rt_VM_memmove32(Env* env, Class* c, jlong s1, jlong s2, jlo
 
 void Java_org_robovm_rt_VM_memmove64(Env* env, Class* c, jlong s1, jlong s2, jlong n) {
     rvmMoveMemory32(LONG_TO_PTR(s1), LONG_TO_PTR(s2), (size_t) (n << 1));
+}
+
+// placeholder - will be replaced by instrinsic call. This entry is required however to satisfy link requirements
+void Java_org_robovm_rt_VM_memmoveAtomic(Env* env, Class* c, jlong s1, jlong s2, jlong n, jint sz) {
+    rvmThrowNewf(env, java_lang_UnsupportedOperationException, "compiler error - memmoveAtomic not replaced by intrinsic");
 }
 
 void Java_org_robovm_rt_VM_memset(Env* env, Class* cls, jlong s, jbyte c, jlong n) {

--- a/compiler/vm/rt/robovm/org_robovm_rt_VM.c
+++ b/compiler/vm/rt/robovm/org_robovm_rt_VM.c
@@ -221,7 +221,7 @@ void Java_org_robovm_rt_VM_memmove64(Env* env, Class* c, jlong s1, jlong s2, jlo
 
 // placeholder - will be replaced by instrinsic call. This entry is required however to satisfy link requirements
 void Java_org_robovm_rt_VM_memmoveAtomic(Env* env, Class* c, jlong s1, jlong s2, jlong n, jint sz) {
-    rvmThrowNewf(env, java_lang_UnsupportedOperationException, "compiler error - memmoveAtomic not replaced by intrinsic");
+    memmove(LONG_TO_PTR(s1), LONG_TO_PTR(s2), (size_t)n);
 }
 
 void Java_org_robovm_rt_VM_memset(Env* env, Class* cls, jlong s, jbyte c, jlong n) {

--- a/plugins/idea/src/main/java/org/robovm/idea/compilation/RoboVmCompileTask.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/compilation/RoboVmCompileTask.java
@@ -60,6 +60,10 @@ import java.util.*;
  * or if we perform an ad-hoc/IPA build from the RoboVM menu.
  */
 public class RoboVmCompileTask implements CompileTask {
+    // A list of languages (other than java) for which we might expect to find .class files. Idea compiles these into separate directories,
+    // but only provides the /classes/java/main in the list of classpaths.
+    private static final String[] jvmLangs = {"groovy", "scala", "kotlin"};
+
     @Override
     public boolean execute(CompileContext context) {
         if(context.getMessageCount(CompilerMessageCategory.ERROR) > 0) {
@@ -330,6 +334,15 @@ public class RoboVmCompileTask implements CompileTask {
         for(String path: classes.getPathsList().getPathList()) {
             if(!RoboVmPlugin.isSdkLibrary(path)) {
                 classPaths.add(new File(path));
+                // if this refers to a java class path, add paths for other JVM languages as well
+                if(path.contains("/classes/java/")) {
+                    for(String jvmLang: jvmLangs) {
+                        File filePath = new File(path.replace("/java/", "/" + jvmLang + "/"));
+                        if(filePath.exists()) {
+                            classPaths.add(filePath);
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
This change makes use of the LLVM intrinsic function
llvm.memmove.element.unordered.atomic to perform array copies, thereby
significantly improving performance of most array copies.
The llvm.memmove.element.unordered.atomic intrinsic provides the
required guarantees of atomicity for all required data types (object
references, and primitives other than double and long) and correctly handles
forward and backward copies within the same array.

The result is an increase in performance of around 4 times for arrays of integers,
and 50 times for arrays of object references.

Copying arrays where the base types are not assignable is still done
with a loop in Java code to correctly throw exceptions where
required. No increase in performance for this corner case is achieved.

The code in System.arraycopy() has been cleaned up to reduce the use of
hardcoded constants and accurately mirror the semantics described in the
Java language specification. Readability changes have also been made.

The shebang in the build script has been fixed for the benefit of users of shells other than bash.