### PR TITLE
Bugfix 286 285 and clear cache on new snapshot

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/SigningIdentity.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/SigningIdentity.java
@@ -33,7 +33,8 @@ public class SigningIdentity implements Comparable<SigningIdentity> {
 
     private final String name;
     private final String fingerprint;
-    
+    public static final SigningIdentity ADHOC = new SigningIdentity("ad-hoc (simulator only)", "-");
+
     SigningIdentity(String name, String fingerprint) {
         this.name = name;
         this.fingerprint = fingerprint;

--- a/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmRunProfileState.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmRunProfileState.java
@@ -127,11 +127,11 @@ public class RoboVmRunProfileState extends CommandLineState {
             } else if (getEnvironment().getExecutor().getId().equals(RoboVmRunner.DEBUG_EXECUTOR)) {
                 return executeRun();
             } else {
-                return null;
+                throw new ExecutionException("Unsupported executor " + getEnvironment().getExecutor().getId());
             }
         } catch(Throwable t) {
             RoboVmPlugin.logErrorThrowable(getEnvironment().getProject(), "Couldn't start application", t, true);
-            return null;
+            throw new ExecutionException(t);
         }
     }
 


### PR DESCRIPTION
there are three commits: 
1 - fixes #286 by completing #287 in sake of delivering the fix 
2- fixes #285 -- obeys not @NotNull otherwise idea halt the plugin 
3- adds logic not extracting same file on every launch and do clear cache when new files extracted just to avoid bug cases when incompatible data stays in cache, [check post by @dthommes](https://gitter.im/MobiVM/robovm?at=5ae44a7415c9b0311445a395)