### PR TITLE
Gradle maintenance

### DIFF
--- a/plugins/gradle/build.gradle
+++ b/plugins/gradle/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     compileOnly localGroovy()
     compile "org.apache.commons:commons-compress:1.5"
     compile "com.mobidevelop.robovm:robovm-dist-compiler:${roboVMVersion}"
+    compile "com.mobidevelop.robovm:robovm-debugger:${roboVMVersion}"
     compile 'org.sonatype.aether:aether:1.13.1'
     compile 'org.sonatype.aether:aether-connector-wagon:1.13.1'
     compile 'org.apache.maven:maven-aether-provider:3.0.4'

--- a/plugins/gradle/src/main/java/org/robovm/gradle/RoboVMPlugin.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/RoboVMPlugin.java
@@ -15,10 +15,9 @@
  */
 package org.robovm.gradle;
 
-import java.util.Collections;
-
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.robovm.compiler.Version;
 import org.robovm.gradle.tasks.ArchiveTask;
 import org.robovm.gradle.tasks.ConsoleTask;
@@ -26,6 +25,9 @@ import org.robovm.gradle.tasks.IOSDeviceTask;
 import org.robovm.gradle.tasks.IPadSimulatorTask;
 import org.robovm.gradle.tasks.IPhoneSimulatorTask;
 import org.robovm.gradle.tasks.InstallTask;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Gradle plugin that extends the Java plugin for RoboVM development.
@@ -41,12 +43,31 @@ public class RoboVMPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getExtensions().create(RoboVMPluginExtension.NAME, RoboVMPluginExtension.class, project);
-        project.task(Collections.singletonMap("type", IPhoneSimulatorTask.class), "launchIPhoneSimulator");
-        project.task(Collections.singletonMap("type", IPadSimulatorTask.class), "launchIPadSimulator");
-        project.task(Collections.singletonMap("type", IOSDeviceTask.class), "launchIOSDevice");
-        project.task(Collections.singletonMap("type", ConsoleTask.class), "launchConsole");
-        project.task(Collections.singletonMap("type", ArchiveTask.class), "createIPA");
-        project.task(Collections.singletonMap("type", ArchiveTask.class), "robovmArchive");
-        project.task(Collections.singletonMap("type", InstallTask.class), "robovmInstall");
+        project.task(params(IPhoneSimulatorTask.class, "Runs your iOS app in the iPhone simulator"),
+                "launchIPhoneSimulator");
+        project.task(params(IPadSimulatorTask.class,"Runs your iOS app in the iPad simulator"),
+                "launchIPadSimulator");
+        project.task(params(IOSDeviceTask.class, "Runs your iOS app on a connected iOS device."),
+                "launchIOSDevice");
+        project.task(params(ConsoleTask.class, "Runs a console app"),"launchConsole");
+        project.task(params(ArchiveTask.class, "Creates .ipa file. This is an alias for the robovmArchive task"),
+                "createIPA");
+        project.task(params(ArchiveTask.class, "Compiles a binary, archives it in a format suitable for distribution and saves it to build/robovm/"),
+                "robovmArchive");
+        project.task(params(InstallTask.class, "Compiles a binary and installs it to build/robovm/"),
+                "robovmInstall");
+    }
+
+    private Map<String, Object> params(Class<? extends  Task> task, String description) {
+        return params(task, description, "build"); // by default depends on build
+    }
+
+    private Map<String, Object> params(Class<? extends  Task> task, String description, String... dependencies) {
+        Map<String, Object> params = new HashMap<>();
+        params.put(Task.TASK_TYPE, task);
+        params.put(Task.TASK_DESCRIPTION, description);
+        if (dependencies != null)
+            params.put(Task.TASK_DEPENDS_ON, dependencies);
+        return params;
     }
 }

--- a/plugins/gradle/src/main/resources/META-INF/services/org.robovm.compiler.plugin.LaunchPlugin
+++ b/plugins/gradle/src/main/resources/META-INF/services/org.robovm.compiler.plugin.LaunchPlugin
@@ -1,0 +1,1 @@
+org.robovm.debugger.DebuggerLaunchPlugin

--- a/plugins/idea/src/main/java/org/robovm/idea/RoboVmPlugin.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/RoboVmPlugin.java
@@ -417,7 +417,6 @@ public class RoboVmPlugin {
     private static void extractArchive(String archive, File dest) {
         archive = "/" + archive;
         TarArchiveInputStream in = null;
-//        boolean isSnapshot = Version.getVersion().toLowerCase().contains("snapshot");
         try {
             boolean filesWereUpdated = false;
             in = new TarArchiveInputStream(new GZIPInputStream(RoboVmPlugin.class.getResourceAsStream(archive)));
@@ -427,7 +426,7 @@ public class RoboVmPlugin {
                 if (entry.isDirectory()) {
                     f.mkdirs();
                 } else {
-                    // skip extracting if file looks to be same as it archive (ts and size matches)
+                    // skip extracting if file looks to be same as in archive (ts and size matches)
                     if (f.exists() && f.lastModified() == entry.getLastModifiedDate().getTime() && f.length() == entry.getSize()) {
                         continue;
                     }
@@ -454,7 +453,7 @@ public class RoboVmPlugin {
 
             if (filesWereUpdated) {
                 File cacheLog = new File(System.getProperty("user.home"), ".robovm/cache");
-                logInfo(null, "Clearing cache log folder due SDK files changed.");
+                logInfo(null, "Clearing ~/.robovm/cache folder due SDK files changed.");
                 try {
                     FileUtils.deleteDirectory(cacheLog);
                 } catch (IOException ignored) {


### PR DESCRIPTION
this pr contains following changes: 
1. added dependency to `build` task to force java compilation for every RoboVM task. Otherwise commands like `launchIOSDevice` will fail as java classes are not generated.

2. [cosmetic] added description to tasks
```
> gradle tasks
MobiVM tasks
------------
createIPA - Creates .ipa file. This is an alias for the robovmArchive task
launchConsole - Runs a console app
launchIOSDevice - Runs your iOS app on a connected iOS device.
launchIPadSimulator - Runs your iOS app in the iPad simulator
launchIPhoneSimulator - Runs your iOS app in the iPhone simulator
robovmArchive - Compiles a binary, archives it in a format suitable for distribution and saves it to build/robovm/
robovmInstall - Compiles a binary and installs it to build/robovm/
```  
3. added logic not extracting same file on every launch and do clear cache when new files extracted just to avoid bug cases when incompatible data stays in cache, [check post by @dthommes](https://gitter.im/MobiVM/robovm?at=5ae44a7415c9b0311445a395). 
4. added support for launching debugger, similar as @dukescript did for ['maven plugin'](https://github.com/MobiVM/robovm/pull/258):  
```
.. start with
> gradle --no-daemon -i -Probovm.debug=true -Probovm.debugPort=7778 -Probovm.arch=x86_64 "-Probovm.device.name=iPhone SE" launchIPhoneSimulator
.. attach with
> jdb -attach 7778
```  