### PR TITLE
fixed: app-extension code sign and auto signature/provisioning profile pickup

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/AppExtension.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/AppExtension.java
@@ -1,0 +1,25 @@
+package org.robovm.compiler.config;
+
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Text;
+
+/**
+ * Specifies app extension value object for configuration object.
+ * Separate file is required as beside the name it would be required to configure also provisioning profile to
+ * be used with app extension
+ */
+
+public class AppExtension {
+    @Attribute(name = "profile", required = false)
+    String profile;
+    @Text
+    String name;
+
+    public String getProfile() {
+        return profile;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -153,7 +153,7 @@ public class Config {
     @ElementList(required = false, entry = "path")
     private ArrayList<File> frameworkPaths;
     @ElementList(required = false, entry = "extension")
-    private ArrayList<String> appExtensions;
+    private ArrayList<AppExtension> appExtensions;
     @ElementList(required = false, entry = "path")
     private ArrayList<File> appExtensionPaths;
     @ElementList(required = false, entry = "resource")
@@ -419,8 +419,8 @@ public class Config {
                 : Collections.unmodifiableList(frameworkPaths);
     }
 
-    public List<String> getAppExtensions() {
-        return appExtensions == null ? Collections.<String> emptyList()
+    public List<AppExtension> getAppExtensions() {
+        return appExtensions == null ? Collections.<AppExtension> emptyList()
                 : Collections.unmodifiableList(appExtensions);
     }
 
@@ -1406,10 +1406,13 @@ public class Config {
             return this;
         }
 
-        public Builder addExtension(String extension) {
+        public Builder addExtension(String name, String profile) {
             if (config.appExtensions == null) {
                 config.appExtensions = new ArrayList<>();
             }
+            AppExtension extension = new AppExtension();
+            extension.name = name;
+            extension.profile = profile;
             config.appExtensions.add(extension);
             return this;
         }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
@@ -45,6 +45,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.robovm.compiler.clazz.Path;
+import org.robovm.compiler.config.AppExtension;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
 import org.robovm.compiler.config.OS;
@@ -405,7 +406,8 @@ public abstract class AbstractTarget implements Target {
     protected void copyAppExtensions(File destDir) throws IOException {
         File pluginsDir = new File(destDir, "PlugIns");
 
-        for (String extension : config.getAppExtensions()) {
+        for (AppExtension extensionVo : config.getAppExtensions()) {
+            String extension = extensionVo.getName();
             File extensionDir = null;
             for (File path : config.getAppExtensionPaths()) {
                 File extPath = new File(path, extension + ".appex");

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -39,13 +39,14 @@ import org.apache.commons.io.filefilter.AndFileFilter;
 import org.apache.commons.io.filefilter.PrefixFileFilter;
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.apache.commons.io.filefilter.SuffixFileFilter;
+import org.apache.commons.lang3.tuple.Pair;
 import org.robovm.compiler.CompilerException;
+import org.robovm.compiler.config.AppExtension;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
 import org.robovm.compiler.config.OS;
 import org.robovm.compiler.config.Resource;
 import org.robovm.compiler.log.Logger;
-import org.robovm.compiler.log.LoggerProxy;
 import org.robovm.compiler.target.AbstractTarget;
 import org.robovm.compiler.target.LaunchParameters;
 import org.robovm.compiler.target.Launcher;
@@ -358,7 +359,8 @@ public class IOSTarget extends AbstractTarget {
                 copyProvisioningProfile(provisioningProfile, installDir);
                 boolean getTaskAllow = provisioningProfile.getType() == Type.Development;
                 signFrameworks(signIdentity, installDir);
-                signAppExtensions(signIdentity, installDir);
+                provisionAppExtensions(signIdentity, installDir);
+                signAppExtensions(signIdentity, installDir, getTaskAllow);
                 codesignApp(signIdentity, getOrCreateEntitlementsPList(getTaskAllow, getBundleId()), installDir);
             }
         }
@@ -392,7 +394,8 @@ public class IOSTarget extends AbstractTarget {
                 copyProvisioningProfile(provisioningProfile, appDir);
                 boolean getTaskAllow = provisioningProfile.getType() == Type.Development;
                 signFrameworks(signIdentity, appDir);
-                signAppExtensions(signIdentity, appDir);
+                provisionAppExtensions(signIdentity, appDir);
+                signAppExtensions(signIdentity, appDir, getTaskAllow);
                 // sign the app
                 codesignApp(signIdentity, getOrCreateEntitlementsPList(getTaskAllow, getBundleId()), appDir);
             }
@@ -400,7 +403,7 @@ public class IOSTarget extends AbstractTarget {
             if (sdk.getVersionCode() >= 0x0B0300) {
                 // code signing of frameworks and app extensions are required since iOS 11.3
                 signFrameworks(SigningIdentity.ADHOC, appDir);
-                signAppExtensions(SigningIdentity.ADHOC, appDir);
+                signAppExtensions(SigningIdentity.ADHOC, appDir, true);
             }
         }
     }
@@ -425,17 +428,86 @@ public class IOSTarget extends AbstractTarget {
         }
     }
 
-    private void signAppExtensions(SigningIdentity identity, File appDir) throws IOException {
+    private void signAppExtensions(SigningIdentity identity, File appDir, boolean getTaskAllow) throws IOException {
         // sign dynamic frameworks first
         File extensionsDir = new File(appDir, "PlugIns");
         if (extensionsDir.exists() && extensionsDir.isDirectory()) {
             // sign embedded app-extensions
             for (File extension : extensionsDir.listFiles()) {
                 if (extension.isDirectory() && extension.getName().endsWith(".appex")) {
+                    File entitlements = null;
+                    if (provisioningProfile != null) {
+                        String bundleId =  provisioningProfile.getAppIdPrefix() + "." + getBundleId() + "." + extension.getName().replace(".appex", "");
+                        entitlements = createEntitlementForAppEx(getTaskAllow, bundleId);
+                    }
+
                     // now sign
-                    codesignAppExtension(identity, extension);
+                    codesignAppExtension(identity, entitlements, extension);
                 }
             }
+        }
+    }
+
+    /**
+     * generates simple emtitlement plist which is required for AppEx during submit to app store
+     */
+    private File createEntitlementForAppEx(boolean getTaskAllow, String bundleId) throws IOException {
+        try {
+            File destFile = new File(config.getTmpDir(), "AppExtEntitlements.plist");
+            NSDictionary dict = (NSDictionary) PropertyListParser.parse(IOUtils.toByteArray(getClass().getResourceAsStream(
+                        "/Entitlements.plist")));
+            dict.put("application-identifier", bundleId);
+            dict.put("get-task-allow", getTaskAllow);
+            PropertyListParser.saveAsXML(dict, destFile);
+            return destFile;
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * finds and copies provisioning profile for AppExtension
+     * @param signIdentity that matches profile
+     * @param installDir of application
+     */
+    private void provisionAppExtensions(SigningIdentity signIdentity, File installDir) throws IOException {
+        File pluginsDir = new File(installDir, "PlugIns");
+
+        for (AppExtension extension : config.getAppExtensions()) {
+            // find extension
+            ProvisioningProfile appExtProfile;
+            String profileName = extension.getProfile();
+            if (profileName != null) {
+                // profile is specified in robovm.xml
+                appExtProfile = ProvisioningProfile.find(ProvisioningProfile.list(), profileName);
+            } else {
+                // find profile that matches app ext bundle id
+                String bundleId = getBundleId() + "." + extension.getName();
+                appExtProfile = ProvisioningProfile.find(ProvisioningProfile.list(), signIdentity, bundleId);
+            }
+
+
+            if (appExtProfile != null) {
+                File extPath = new File(pluginsDir, extension.getName() + ".appex");
+                config.getLogger().info("Copying %s provisioning profile for : %s (%s)",
+                        appExtProfile.getType(),
+                        appExtProfile.getName(),
+                        appExtProfile.getEntitlements().objectForKey("application-identifier"));
+                FileUtils.copyFile(appExtProfile.getFile(), new File(extPath, "embedded.mobileprovision"));
+            } else {
+
+            }
+            if (provisioningProfile == null) {
+                String bundleId = "*";
+                if (config.getIosInfoPList() != null && config.getIosInfoPList().getBundleIdentifier() != null) {
+                    bundleId = config.getIosInfoPList().getBundleIdentifier();
+                }
+                provisioningProfile = ProvisioningProfile.find(ProvisioningProfile.list(), signIdentity, bundleId);
+            }
+
+
         }
     }
 
@@ -457,10 +529,10 @@ public class IOSTarget extends AbstractTarget {
         codesign(identity, null, true, false, true, frameworkDir);
     }
 
-    private void codesignAppExtension(SigningIdentity identity, File extensionDir) throws IOException {
+    private void codesignAppExtension(SigningIdentity identity, File entitlementsPList, File extensionDir) throws IOException {
         config.getLogger().info("Code signing app-extension '%s' using identity '%s' with fingerprint %s", extensionDir.getName(), identity.getName(),
                 identity.getFingerprint());
-        codesign(identity, null, false, false, true, extensionDir);
+        codesign(identity, entitlementsPList, false, false, true, extensionDir);
     }
 
     private void codesign(SigningIdentity identity, File entitlementsPList, boolean preserveMetadata, boolean verbose, boolean allocate, File target) throws IOException {
@@ -877,28 +949,29 @@ public class IOSTarget extends AbstractTarget {
             arch = config.getArch();
         }
 
-        if (isDeviceArch(arch)) {
-            if (!config.isSkipLinking() && !config.isIosSkipSigning()) {
-                signIdentity = config.getIosSignIdentity();
-                if (signIdentity == null) {
-                    signIdentity = SigningIdentity.find(SigningIdentity.list(),
-                            "/(?i)iPhone Developer|iOS Development/");
-                }
-            }
-        }
-
         if (config.getIosInfoPList() != null) {
             config.getIosInfoPList().parse(config.getProperties());
         }
 
         if (isDeviceArch(arch)) {
-            if (!config.isSkipLinking() &&!config.isIosSkipSigning()) {
+            if (!config.isSkipLinking() && !config.isIosSkipSigning()) {
+                signIdentity = config.getIosSignIdentity();
                 provisioningProfile = config.getIosProvisioningProfile();
-                if (provisioningProfile == null) {
-                    String bundleId = "*";
-                    if (config.getIosInfoPList() != null && config.getIosInfoPList().getBundleIdentifier() != null) {
-                        bundleId = config.getIosInfoPList().getBundleIdentifier();
-                    }
+                String bundleId = "*";
+                if (config.getIosInfoPList() != null && config.getIosInfoPList().getBundleIdentifier() != null) {
+                    bundleId = config.getIosInfoPList().getBundleIdentifier();
+                }
+
+                if (signIdentity == null && provisioningProfile == null) {
+                    // both identity and provisioningProfile are set to auto, start with picking profile s
+                    Pair<SigningIdentity, ProvisioningProfile> pair = ProvisioningProfile.find(ProvisioningProfile.list(), SigningIdentity.list(), bundleId);
+                    signIdentity = pair.getLeft();
+                    provisioningProfile = pair.getRight();
+                } else if (signIdentity == null) {
+                    // provisioning profile was specified, need to find a signing identity that matches it
+                    signIdentity = SigningIdentity.find(SigningIdentity.list(), "/(?i)iPhone Developer|iOS Development/", provisioningProfile);
+                } else if (provisioningProfile == null) {
+                    // find profile that matches identity and bundle id
                     provisioningProfile = ProvisioningProfile.find(ProvisioningProfile.list(), signIdentity, bundleId);
                 }
             }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -720,22 +720,16 @@ public class IOSTarget extends AbstractTarget {
                     // for stickers extension
                     config.getLogger().info("Copying support files for Stickers app extension");
                     File xcodePath = new File(ToolchainUtil.findXcodePath());
-                    File stickersSupportStub = new File(xcodePath, "Platforms/iPhoneOS.platform/Library/" +
-                            "Application Support/MessagesApplicationStub/MessagesApplicationStub");
                     File stickersExtSupportStub = new File(xcodePath, "Platforms/iPhoneOS.platform/Library/" +
                             "Application Support/MessagesApplicationExtensionStub/MessagesApplicationExtensionStub");
-                    if (!stickersSupportStub.exists() || !stickersExtSupportStub.exists()) {
+                    if (stickersExtSupportStub.exists()) {
                         throw new FileNotFoundException("Stickers support: bi MessagesApplicationStub or MessagesApplicationExtensionStub found in "
                                 + new File(xcodePath, "Platforms/iPhoneOS.platform/Library/Application Support/").getAbsolutePath());
                     }
 
-                    File stickersSupportDestDir = new File(tmpDir, "MessagesApplicationSupport");
                     File stickersExtSupportDestDir = new File(tmpDir, "MessagesApplicationExtensionSupport");
 
-                    stickersSupportDestDir.mkdirs();
                     stickersExtSupportDestDir.mkdir();
-                    Files.copy(stickersSupportStub.toPath(), new File(stickersSupportDestDir, stickersSupportStub.getName()).toPath(),
-                            StandardCopyOption.COPY_ATTRIBUTES);
                     Files.copy(stickersExtSupportStub.toPath(), new File(stickersExtSupportDestDir, stickersExtSupportStub.getName()).toPath(),
                             StandardCopyOption.COPY_ATTRIBUTES);
                 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -722,7 +722,7 @@ public class IOSTarget extends AbstractTarget {
                     File xcodePath = new File(ToolchainUtil.findXcodePath());
                     File stickersExtSupportStub = new File(xcodePath, "Platforms/iPhoneOS.platform/Library/" +
                             "Application Support/MessagesApplicationExtensionStub/MessagesApplicationExtensionStub");
-                    if (stickersExtSupportStub.exists()) {
+                    if (!stickersExtSupportStub.exists()) {
                         throw new FileNotFoundException("Stickers support: bi MessagesApplicationStub or MessagesApplicationExtensionStub found in "
                                 + new File(xcodePath, "Platforms/iPhoneOS.platform/Library/Application Support/").getAbsolutePath());
                     }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/ProvisioningProfile.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/ProvisioningProfile.java
@@ -16,6 +16,18 @@
  */
 package org.robovm.compiler.target.ios;
 
+import com.dd.plist.NSArray;
+import com.dd.plist.NSData;
+import com.dd.plist.NSDate;
+import com.dd.plist.NSDictionary;
+import com.dd.plist.NSNumber;
+import com.dd.plist.NSObject;
+import com.dd.plist.PropertyListParser;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.bouncycastle.cms.CMSSignedData;
+
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -29,18 +41,10 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
-
-import org.apache.commons.io.IOUtils;
-import org.bouncycastle.cms.CMSSignedData;
-
-import com.dd.plist.NSArray;
-import com.dd.plist.NSData;
-import com.dd.plist.NSDate;
-import com.dd.plist.NSDictionary;
-import com.dd.plist.NSNumber;
-import com.dd.plist.NSObject;
-import com.dd.plist.PropertyListParser;
+import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Represents a provisioning profile.
@@ -64,7 +68,7 @@ public class ProvisioningProfile implements Comparable<ProvisioningProfile> {
     private final Date creationDate;
     private final Date expirationDate;
     private final NSDictionary entitlements;
-    private final List<String> certFingerprints = new ArrayList<String>();
+    private final Set<String> certFingerprints = new TreeSet<>();
     
     ProvisioningProfile(File file, NSDictionary dict) {
         this.file = file;
@@ -163,6 +167,10 @@ public class ProvisioningProfile implements Comparable<ProvisioningProfile> {
         return entitlements;
     }
 
+    public Set<String> getCertFingerprints() {
+        return certFingerprints;
+    }
+
     private static ProvisioningProfile create(File file) {
         InputStream in = null;
         try {
@@ -207,38 +215,67 @@ public class ProvisioningProfile implements Comparable<ProvisioningProfile> {
     }
     
     public static ProvisioningProfile find(List<ProvisioningProfile> profiles, SigningIdentity signingIdentity, String bundleId) {
-        return find(profiles, signingIdentity, bundleId, bundleId);
+        Pair<SigningIdentity, ProvisioningProfile> pair = find(profiles, Collections.singletonList(signingIdentity), bundleId, true);
+        return pair.getRight();
     }
-    
-    private static ProvisioningProfile find(List<ProvisioningProfile> profiles, SigningIdentity signingIdentity, String bundleId, String origBundleId) {
+
+
+    public static Pair<SigningIdentity, ProvisioningProfile> find(List<ProvisioningProfile> profiles, List<SigningIdentity> identities,
+                                                                   String bundleId) {
+        return find(profiles, identities, bundleId, false);
+    }
+
+    private static Pair<SigningIdentity, ProvisioningProfile> find(List<ProvisioningProfile> profiles, List<SigningIdentity> identities,
+                                                                   String bundleId, boolean exactIdentityMatch) {
+        // get list of all available fingerprints into set for simple intersection match
+        Set<String> knownFingerprints = new HashSet<>();
+        for (SigningIdentity i : identities)
+            knownFingerprints.add(i.getFingerprint());
+
+        // looking for both direct and wildcard matches
+        ProvisioningProfile longestWildCard = null;
+        ProvisioningProfile exactProfile = null;
+
         // Try a direct match first
         for (ProvisioningProfile p : profiles) {
-            if (p.appId.equals(p.appIdPrefix + "." + bundleId)) {
-                for (String fp : p.certFingerprints) {
-                    if (fp.equals(signingIdentity.getFingerprint())) {
-                        return p;
-                    }
+            String bundleIdWithPrefix = p.appIdPrefix + "." + bundleId;
+            if (p.appId.equals(bundleIdWithPrefix)) {
+                if(!Collections.disjoint(knownFingerprints, p.certFingerprints)) {
+                    exactProfile = p;
+                    break;
+                }
+            } else if (p.appId.endsWith(".*") && (longestWildCard == null || p.appId.length() > longestWildCard.appId.length()) &&
+                    bundleIdWithPrefix.startsWith(p.appId.substring(0, p.appId.length() - 1))) {
+                // its wildcard, and it longer than last found one (if any), and it (without * but with .) matches bundleId
+                // check for certificate
+                if(!Collections.disjoint(knownFingerprints, p.certFingerprints)) {
+                    longestWildCard = p;
                 }
             }
         }
-        if (!bundleId.equals("*")) {
-            // Try with the last component replaced with a wildcard
-            if (bundleId.endsWith(".*")) {
-                bundleId = bundleId.substring(0, bundleId.length() - 2);
-            }
-            int lastDot = bundleId.lastIndexOf('.');
-            if (lastDot != -1) {
-                bundleId = bundleId.substring(0, lastDot) + ".*";
+
+        if (exactProfile == null)
+            exactProfile = longestWildCard;
+        if (exactProfile == null) {
+            if (exactIdentityMatch) {
+                // it was called for very specific identity and not for list with one item
+                throw new IllegalArgumentException("No provisioning profile found "
+                        + "matching signing identity '" + identities.get(0).getName()
+                        + "' and app bundle ID '" + bundleId + "'");
             } else {
-                bundleId = "*";
+                throw new IllegalArgumentException("No provisioning profile and signing identity found that matches bundle ID '" + bundleId + "'");
             }
-            return find(profiles, signingIdentity, bundleId, origBundleId);
         }
-        throw new IllegalArgumentException("No provisioning profile found " 
-                + "matching signing identity '" + signingIdentity.getName() 
-                + "' and app bundle ID '" + origBundleId + "'");
+
+        // now find identity that matches the profile
+        for (SigningIdentity identity : identities) {
+            if (exactProfile.certFingerprints.contains(identity.getFingerprint()))
+                return new ImmutablePair<>(identity, exactProfile);
+        }
+
+        throw new Error("Shell never happen");
     }
-    
+
     @Override
     public String toString() {
         return "ProvisioningProfile [type=" + type + ", file=" + file

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/SigningIdentity.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/SigningIdentity.java
@@ -39,7 +39,7 @@ public class SigningIdentity implements Comparable<SigningIdentity> {
         this.name = name;
         this.fingerprint = fingerprint;
     }
-    
+
     public String getName() {
         return name;
     }
@@ -60,16 +60,21 @@ public class SigningIdentity implements Comparable<SigningIdentity> {
     }
 
     public static SigningIdentity find(List<SigningIdentity> ids, String search) {
+        return find(ids, search, null);
+    }
+
+    public static SigningIdentity find(List<SigningIdentity> ids, String search, ProvisioningProfile profile) {
         if (search.startsWith("/") && search.endsWith("/")) {
             Pattern pattern = Pattern.compile(search.substring(1, search.length() - 1));
             for (SigningIdentity id : ids) {
-                if (pattern.matcher(id.name).find()) {
+                if (pattern.matcher(id.name).find() && (profile  == null || profile.getCertFingerprints().contains(id.getFingerprint()))) {
                     return id;
                 }
             }
         } else {
             for (SigningIdentity id : ids) {
-                if (id.name.startsWith(search) || id.fingerprint.equals(search.toUpperCase())) {
+                if ((id.name.startsWith(search) || id.fingerprint.equals(search.toUpperCase())) &&
+                        (profile  == null || profile.getCertFingerprints().contains(id.getFingerprint()))) {
                     return id;
                 }
             }

--- a/compiler/compiler/src/test/java/org/robovm/compiler/target/ios/ProvisioningProfileTest.java
+++ b/compiler/compiler/src/test/java/org/robovm/compiler/target/ios/ProvisioningProfileTest.java
@@ -22,7 +22,7 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import org.junit.Test;
@@ -117,7 +117,7 @@ public class ProvisioningProfileTest {
         ProvisioningProfile profile = new ProvisioningProfile(new File(""), dict);
         Field f = ProvisioningProfile.class.getDeclaredField("certFingerprints");
         f.setAccessible(true);
-        List<String> certFingerprints = (List<String>) f.get(profile);
+        Set<String> certFingerprints = (Set<String>) f.get(profile);
         certFingerprints.add(fingerprint);
         return profile;
     }


### PR DESCRIPTION
this PR contains two related to each-other parts: 
1. it fixes auto signature/provisioning profile pickup as it was broken when was trying to pickup signature -- it resulted in random first one that matches `iPhone Developer|iOS Development` and often it doesn't match profile
2. fix for code-sign of app-extension: it is required to embed own extension provisioning profile and entitlements
3. provisioning profile is auto picked up but config was extended to allow custom profile to be specified for extension:
 ```xml
 <appExtensions>
     <extension profile="3AED05A9-5F1F-4120-9276-11980B9C88EE">OneSignalNotificationServiceExtension</extension>
 </appExtensions>
 ```