### PR TITLE
* fixed #295. compiler crashes on kotlin data classes when compiling for debug + debugger crash

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/plugin/debug/DebugInformationPlugin.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/plugin/debug/DebugInformationPlugin.java
@@ -265,9 +265,15 @@ public class DebugInformationPlugin extends AbstractCompilerPlugin {
             }
         }
 
+        classBundle.diMethods.add(diSubprogram);
+        if (methodLineNumber == Integer.MAX_VALUE) {
+            // there was no debug information for this method
+            // it will be not possible to resolve variables, just return
+            return;
+        }
+
         diSubprogram.setScopeLineNo(methodLineNumber);
         diSubprogram.setDefLineNo(methodLineNumber);
-        classBundle.diMethods.add(diSubprogram);
 
         if (!includeDebuggerInfo) {
             return;

--- a/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/ClassInfoImpl.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/ClassInfoImpl.java
@@ -95,6 +95,18 @@ public class ClassInfoImpl extends ClassInfo {
         className = reader.readStringZAtPtr(ptr);
         signature = "L" + className + ";";
 
+        if (hasError()) {
+// Uncomment to get information what is broken
+//            int errorType = reader.readInt32();
+//            ptr = reader.readPointer(true);
+//            String errorMessage = null;
+//            if (ptr != 0) {
+//                errorMessage = reader.readStringZAtPtr(ptr);
+//            }
+//            System.out.println("!Class " + className + " has error " + errorType + " due " + errorMessage);
+            return;
+        }
+
         // read other fields
         reader.skip(pointerSize + //    void* initializer;
                 pointerSize + //    TypeInfo* typeInfo;
@@ -123,6 +135,10 @@ public class ClassInfoImpl extends ClassInfo {
     }
 
     void loadData(ClassInfoLoader loader) {
+        // skip if class is broken
+        if (hasError())
+            return;
+
         // set to zero if already read
         if (endOfHeaderPos == 0)
             return;


### PR DESCRIPTION
if there is no debug information -- dont try to fill in variable debug structures as they will receive wrong line numbers(Integer.MAX_VALUE) that will cause compiler to crash