### PR TITLE
* fixed issue when breakpoint were not working in kotlin

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/plugin/debug/DebugInformationPlugin.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/plugin/debug/DebugInformationPlugin.java
@@ -120,7 +120,7 @@ public class DebugInformationPlugin extends AbstractCompilerPlugin {
     	super.beforeClass(config, clazz, mb);
 
         ClassDataBundle classBundle = clazz.getAttachment(ClassDataBundle.class);
-        classBundle.diFile = new DIItemList(mb, v(getSourceFile(clazz)), v(getSourceFilePath(clazz)));
+        classBundle.diFile = new DIItemList(mb, v(getDwarfSourceFile(clazz)), v(getDwarfSourceFilePath(clazz)));
         classBundle.diFileDescriptor = new DIFileDescriptor(mb, classBundle.diFile);
         classBundle.diMethods = new DIMutableItemList<>(mb);
         classBundle.diCompileUnit = new DICompileUnit(mb, "llvm.dbg.cu", classBundle.diFile, classBundle.diMethods);
@@ -455,7 +455,7 @@ public class DebugInformationPlugin extends AbstractCompilerPlugin {
                     if (methodName.startsWith("[J]" + clazz.getClassName() + "."))
                         methodName = methodName.substring(clazz.getClassName().length() + 4);
                     // save method
-                    methods.add(new DebugMethodInfo(methodName,  variables.toArray(new DebugVariableInfo[variables.size()]),
+                    methods.add(new DebugMethodInfo(methodName,  variables.toArray(new DebugVariableInfo[0]),
                             methodBundle.startLine, methodBundle.finalLine));
                 }
 
@@ -463,7 +463,7 @@ public class DebugInformationPlugin extends AbstractCompilerPlugin {
                 DebugObjectFileInfo finalDebugInfo = clazz.getAttachment(DebugObjectFileInfo.class);
                 if (finalDebugInfo != null)
                     clazz.removeAttachement(finalDebugInfo);
-                finalDebugInfo = new DebugObjectFileInfo(methods.toArray(new DebugMethodInfo[methods.size()]));
+                finalDebugInfo = new DebugObjectFileInfo(getJdwpSourceFile(clazz), methods.toArray(new DebugMethodInfo[0]));
 
                 // save as attachment to class file
                 clazz.attach(finalDebugInfo);
@@ -495,20 +495,32 @@ public class DebugInformationPlugin extends AbstractCompilerPlugin {
         bcHookInstrumented.addMetadata((new DILineNumber(lineNo, 0, diSubprogram)).get());
     }
 
-    /** Simple file name resolved, for LineNumbers there is no need in absolute file location, just in name */
-    private String getSourceFile(Clazz clazz) {
+    /** Simple file name resolution to be included as Dwarf debug entry, for LineNumbers there is no need in absolute file location, just in name */
+    private String getDwarfSourceFile(Clazz clazz) {
     	String sourceFile;
+    	String ext = ".java";
         String className = clazz.getInternalName();
+        // create source file name from class internal name to preserve full path to inner classes and
+        // lambdas as it is required for dsymutils fix
+        // but also look for "SourceFileTag" to pick up proper extension in case of kotlin and others
+        SourceFileTag sourceFileTag = (SourceFileTag) clazz.getSootClass().getTag("SourceFileTag");
+        if (sourceFileTag != null) {
+            String tagSourceFile = sourceFileTag.getSourceFile();
+            int extIdx = tagSourceFile.lastIndexOf('.');
+            if (extIdx > 0)
+                ext = tagSourceFile.substring(extIdx);
+        }
+
         if (className.contains("/"))
-            sourceFile = className.substring(clazz.getInternalName().lastIndexOf("/") + 1) + ".java";
+            sourceFile = className.substring(clazz.getInternalName().lastIndexOf("/") + 1) + ext;
         else
-            sourceFile = className + ".java";
+            sourceFile = className + ext;
 
     	return sourceFile;
 	}
 
-    /** Simple file name resolved, for LineNumbers there is no need in absolute file location, just in name */
-    private String getSourceFilePath(Clazz clazz) {
+    /** Simple source file path resolution */
+    private String getDwarfSourceFilePath(Clazz clazz) {
         String sourcePath = clazz.getPath().toString();
         if (!sourcePath.endsWith("/"))
             sourcePath += "/";
@@ -521,6 +533,31 @@ public class DebugInformationPlugin extends AbstractCompilerPlugin {
         }
 
         return sourcePath;
+    }
+
+    /** picks real source file name, will be used with JDWP ReferenceType(2).SourceFile(7) command */
+    private String getJdwpSourceFile(Clazz clazz) {
+        String sourceFile;
+        // create source file name from class internal name to preserve full path to inner classes and
+        // lambdas as it is required for dsymutils fix
+        // but also look for "SourceFileTag" to pick up proper extension in case of kotlin and others
+        SourceFileTag sourceFileTag = (SourceFileTag) clazz.getSootClass().getTag("SourceFileTag");
+        if (sourceFileTag != null) {
+            sourceFile = sourceFileTag.getSourceFile();
+        } else {
+            sourceFile = clazz.getInternalName();
+            int sepIdx = sourceFile.lastIndexOf('/');
+            if (sepIdx > 0)
+                sourceFile = sourceFile.substring(sepIdx + 1);
+            sepIdx = sourceFile.indexOf('$');
+            if (sepIdx > 0)
+                sourceFile = sourceFile.substring(0, sepIdx);
+
+            // there is no name attached so guess it was compiled from java
+            sourceFile += ".java";
+        }
+
+        return sourceFile;
     }
 
     /**

--- a/compiler/compiler/src/main/java/org/robovm/compiler/plugin/debug/DebugInformationTools.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/plugin/debug/DebugInformationTools.java
@@ -37,6 +37,8 @@ public class DebugInformationTools {
     public static byte[] dumpDebugInfo(DebugObjectFileInfo debugInfo) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (DataOutputStream stream = new DataOutputStream(baos)) {
+            // put source file
+            putStringWithLen(stream, debugInfo.sourceFile());
 
             // write methods
             stream.writeInt(debugInfo.methods().length);
@@ -79,6 +81,9 @@ public class DebugInformationTools {
         // big endian, as data was written with DataOutputStream which is big endian only
         buffer.order(ByteOrder.BIG_ENDIAN);
 
+        // read source file name
+        String sourceFile = getStringWithLen(buffer);
+
         // read methods
         int methodCount = buffer.getInt();
         DebugMethodInfo[] methods = new DebugMethodInfo[methodCount];
@@ -118,10 +123,10 @@ public class DebugInformationTools {
             methods[methodIdx] = new DebugMethodInfo(methodSignature, variables, methodStartLine, methodEndLine);
         }
 
-        return new DebugObjectFileInfo(methods);
+        return new DebugObjectFileInfo(sourceFile, methods);
     }
 
-    static String getStringWithLen(ByteBuffer buffer) {
+    private static String getStringWithLen(ByteBuffer buffer) {
         int strLen = buffer.getInt();
         if (strLen == 0)
             return "";
@@ -141,7 +146,7 @@ public class DebugInformationTools {
         return str;
     }
 
-    static void putStringWithLen(DataOutputStream stream, String str) throws IOException {
+   private  static void putStringWithLen(DataOutputStream stream, String str) throws IOException {
         stream.writeInt(str.length());
         if (!str.isEmpty())
             stream.write(str.getBytes());

--- a/compiler/llvm/src/main/java/org/robovm/llvm/ObjectFile.java
+++ b/compiler/llvm/src/main/java/org/robovm/llvm/ObjectFile.java
@@ -154,10 +154,10 @@ public class ObjectFile implements AutoCloseable {
                 variables.add(new DebugVariableInfo(variableName, (flags & 1) == 1, reg, offset));
             }
 
-            methods.add(new DebugMethodInfo(methodName, variables.toArray(new DebugVariableInfo[variables.size()])));
+            methods.add(new DebugMethodInfo(methodName, variables.toArray(new DebugVariableInfo[0])));
         }
 
-        return new DebugObjectFileInfo(methods.toArray(new DebugMethodInfo[methods.size()]));
+        return new DebugObjectFileInfo(null, methods.toArray(new DebugMethodInfo[0]));
     }
 
     public synchronized void dispose() {

--- a/compiler/llvm/src/main/java/org/robovm/llvm/debuginfo/DebugObjectFileInfo.java
+++ b/compiler/llvm/src/main/java/org/robovm/llvm/debuginfo/DebugObjectFileInfo.java
@@ -8,11 +8,17 @@ import java.util.Map;
  * Object file information as extracted from ObjectFile/DWARF
  */
 public class DebugObjectFileInfo {
+    private final String sourceFile;
     private final DebugMethodInfo[] methods;
     private Map<String, DebugMethodInfo> methodBySignature;
 
-    public DebugObjectFileInfo(DebugMethodInfo[] methods) {
+    public DebugObjectFileInfo(String sourceFile, DebugMethodInfo[] methods) {
+        this.sourceFile = sourceFile;
         this.methods = methods;
+    }
+
+    public String sourceFile() {
+        return sourceFile;
     }
 
     public DebugMethodInfo[] methods() {

--- a/plugins/debugger/src/main/java/org/robovm/debugger/jdwp/handlers/referencetype/JdwpRefTypeSourceFileHandler.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/jdwp/handlers/referencetype/JdwpRefTypeSourceFileHandler.java
@@ -45,18 +45,7 @@ public class JdwpRefTypeSourceFileHandler implements IJdwpRequestHandler{
             if (!classInfo.isClass())
                 return JdwpConsts.Error.INVALID_CLASS;
 
-            // TODO: pick information from debug information
-            // as there is no way to find out the proper file location for inner classes
-            // TODO: currently making it from class name
-            String sourceFile = ((ClassInfoImpl)classInfo).className();
-            // there should be no path element just a file name, eclipse doesn't work due this 
-            int sepIdx = sourceFile.lastIndexOf('/');
-            if (sepIdx > 0)
-                sourceFile = sourceFile.substring(sepIdx + 1);
-            sepIdx = sourceFile.indexOf('$');
-            if (sepIdx > 0)
-                sourceFile = sourceFile.substring(0, sepIdx);
-            sourceFile += ".java";
+            String sourceFile = ((ClassInfoImpl)classInfo).sourceFile();
             output.writeStringWithLen(sourceFile);
         }
 

--- a/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/ClassInfoImpl.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/ClassInfoImpl.java
@@ -307,4 +307,24 @@ public class ClassInfoImpl extends ClassInfo {
     protected int convertModifiers() {
         return Converter.classModifiers(flags);
     }
+
+    public String sourceFile() {
+        String sourceFile;
+        if (debugInfo != null) {
+            sourceFile = debugInfo.sourceFile();
+        } else {
+            sourceFile = className();
+            // there should be no path element just a file name, eclipse doesn't work due this
+            int sepIdx = sourceFile.lastIndexOf('/');
+            if (sepIdx > 0)
+                sourceFile = sourceFile.substring(sepIdx + 1);
+            sepIdx = sourceFile.indexOf('$');
+            if (sepIdx > 0)
+                sourceFile = sourceFile.substring(0, sepIdx);
+            sourceFile += ".java";
+
+        }
+
+        return sourceFile;
+    }
 }


### PR DESCRIPTION
Issue was in  ReferenceType(2).SourceFile(7) as it was explicitly attached .java extension while building filename from class name. now debug information is extended source file obtained from Soot which pre-saves original extensions  