### PR TITLE
* fix for "WARNING ITMS-90725: "SDK Version Issue"

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -329,7 +329,13 @@ public class IOSTarget extends AbstractTarget {
         }
         ccArgs.add("-isysroot");
         ccArgs.add(sdk.getRoot().getAbsolutePath());
-        
+
+        // specify sdk version for linker
+        libArgs.add("-Xlinker");
+        libArgs.add("-sdk_version");
+        libArgs.add("-Xlinker");
+        libArgs.add(sdk.getVersion());
+
         // specify dynamic library loading path
         libArgs.add("-Xlinker");
         libArgs.add("-rpath");

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/SDK.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/SDK.java
@@ -110,12 +110,7 @@ public class SDK implements Comparable<SDK> {
     }
 
     private static List<SDK> listSDKs(String platform) {
-        List<SDK> allSdks = new ArrayList<>();
-
-        allSdks.addAll(listBundledFileFormatSdks(platform));
-
-        allSdks.addAll(listAdditionalFileFormatSdks());
-
+        List<SDK> allSdks = new ArrayList<>(listBundledFileFormatSdks(platform));
         return allSdks;
     }
 
@@ -192,7 +187,9 @@ public class SDK implements Comparable<SDK> {
     }
 
     public static List<SDK> listSimulatorSDKs() {
-        return listSDKs("iPhoneSimulator");
+        List<SDK> sdks = listSDKs("iPhoneSimulator");
+        sdks.addAll(listAdditionalFileFormatSdks());
+        return sdks;
     }
 
     public String getDisplayName() {
@@ -266,6 +263,12 @@ public class SDK implements Comparable<SDK> {
             c = minor < o.minor ? -1 : (minor > o.minor ? 1 : 0);
             if (c == 0) {
                 c = revision < o.revision ? -1 : (revision > o.revision ? 1 : 0);
+                if (c == 0) {
+                    // exactly same
+                    // special sorting case: but if the path contains iPhoneOS.sdk without version make version lower
+                    c = getRoot().getAbsolutePath().contains("iPhoneOS.sdk") ? 0 : 1;
+                    c -= o.getRoot().getAbsolutePath().contains("iPhoneOS.sdk") ? 0 : 1;
+                }
             }
         }
         return c;


### PR DESCRIPTION
Root case is SDK field is not being set in LC_VERSION_MIN_IPHONEOS MACHO command. 
Commit fixes following:
* adds `sdk_version VERSION` linker command to explicitly specify version. this is only required fix
* also changes soring logic when compares iPhone.sdk with latest iPhone11.4.sdk (symb link to iPhone.sdk) to give iPhone.sdk one lower priority. So it will not go as sysroot.