### PR TITLE
Add class paths for JVM languages other than Java.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/sh
 set -e
 mvn clean install
 mvn -f plugins/idea/pom.xml clean install


### PR DESCRIPTION
Replicates behaviour of Robovm gradle plugin. Without this patch, Kotlin classes either do not compile during build (e.g. for application class) or are not found at run time.