### PR TITLE
* Xcode project generator: adding argument type to IBAction 

### DIFF
--- a/plugins/ibxcode/src/main/java/org/robovm/ibxcode/export/IBActionExportMemberItem.java
+++ b/plugins/ibxcode/src/main/java/org/robovm/ibxcode/export/IBActionExportMemberItem.java
@@ -40,7 +40,15 @@ public class IBActionExportMemberItem implements  IClassExportMemberItem {
         ps.println("*/");
         ps.print("-(IBAction) ");
         ps.print(this.selector != null ? this.selector : this.name);
-        ps.println(this.argType != null ? ":(id) sender;": ";");
+        String args = null;
+        if (this.argType != null) {
+            // use native or custom class name to allow IBActions with UIStoryboardSegue
+            if (this.argType.isNative() || this.argType.isCustom())
+                args = this.argType.getExportClassName() + "*";
+            else
+                args = "id";
+        }
+        ps.println(args != null ? ":(" + args + ") sender;": ";");
         ps.println("");
     }
 

--- a/plugins/ibxcode/src/main/java/org/robovm/ibxcode/parser/IBClassHierarchyData.java
+++ b/plugins/ibxcode/src/main/java/org/robovm/ibxcode/parser/IBClassHierarchyData.java
@@ -116,6 +116,10 @@ public class IBClassHierarchyData {
         return hasAnyFlag(FLAG_NATIVE_CLASS | FLAG_INHERITS_NATIVE);
     }
 
+    public boolean isCustom() {
+        return hasAnyFlag(FLAG_CUSTOM_CLASS);
+    }
+
     public boolean isUIKit() {
         return hasAnyFlag(FLAG_UIKIT_CLASS| FLAG_INHERITS_UIKIT);
     }


### PR DESCRIPTION
this fixes an issue described by [Alex @avazquezdev](
https://gitter.im/MobiVM/robovm?at=5b90d82660f9ee7aa4e5c1eb)

In general it adds type specifier for IBActions in generated Xcode project. It has no affect on generated robovm code itself. 

generated Xcode header, before:
```
-(IBAction) unwindToNameList:(id) sender;
```

now:
```
-(IBAction) unwindToNameList:(UIStoryboardSegue*) sender;
```
