### PR TITLE
Vector structs

### DIFF
--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/MatrixDouble4x4.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/MatrixDouble4x4.java
@@ -20,12 +20,14 @@ package org.robovm.apple.foundation;
 import org.robovm.rt.bro.Struct;
 import org.robovm.rt.bro.annotation.ByVal;
 import org.robovm.rt.bro.annotation.StructMember;
+import org.robovm.rt.bro.annotation.Vectorised;
 import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
+@Vectorised
 /*<visibility>*/public/*</visibility>*/ class MatrixDouble4x4 
     extends /*<extends>*/Struct<MatrixDouble4x4>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/MatrixFloat2x2.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/MatrixFloat2x2.java
@@ -20,12 +20,14 @@ package org.robovm.apple.foundation;
 import org.robovm.rt.bro.Struct;
 import org.robovm.rt.bro.annotation.ByVal;
 import org.robovm.rt.bro.annotation.StructMember;
+import org.robovm.rt.bro.annotation.Vectorised;
 import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
+@Vectorised
 /*<visibility>*/public/*</visibility>*/ class MatrixFloat2x2
     extends /*<extends>*/Struct<MatrixFloat2x2>/*</extends>*/
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/MatrixFloat2x3.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/MatrixFloat2x3.java
@@ -20,12 +20,14 @@ package org.robovm.apple.foundation;
 import org.robovm.rt.bro.Struct;
 import org.robovm.rt.bro.annotation.ByVal;
 import org.robovm.rt.bro.annotation.StructMember;
+import org.robovm.rt.bro.annotation.Vectorised;
 import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
+@Vectorised
 /*<visibility>*/public/*</visibility>*/ class MatrixFloat2x3
     extends /*<extends>*/Struct<MatrixFloat2x3>/*</extends>*/
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/MatrixFloat2x4.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/MatrixFloat2x4.java
@@ -20,12 +20,14 @@ package org.robovm.apple.foundation;
 import org.robovm.rt.bro.Struct;
 import org.robovm.rt.bro.annotation.ByVal;
 import org.robovm.rt.bro.annotation.StructMember;
+import org.robovm.rt.bro.annotation.Vectorised;
 import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
+@Vectorised
 /*<visibility>*/public/*</visibility>*/ class MatrixFloat2x4
     extends /*<extends>*/Struct<MatrixFloat2x4>/*</extends>*/
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/MatrixFloat3x2.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/MatrixFloat3x2.java
@@ -20,12 +20,14 @@ package org.robovm.apple.foundation;
 import org.robovm.rt.bro.Struct;
 import org.robovm.rt.bro.annotation.ByVal;
 import org.robovm.rt.bro.annotation.StructMember;
+import org.robovm.rt.bro.annotation.Vectorised;
 import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
+@Vectorised
 /*<visibility>*/public/*</visibility>*/ class MatrixFloat3x2
     extends /*<extends>*/Struct<MatrixFloat3x2>/*</extends>*/
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/MatrixFloat3x3.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/MatrixFloat3x3.java
@@ -20,12 +20,14 @@ package org.robovm.apple.foundation;
 import org.robovm.rt.bro.Struct;
 import org.robovm.rt.bro.annotation.ByVal;
 import org.robovm.rt.bro.annotation.StructMember;
+import org.robovm.rt.bro.annotation.Vectorised;
 import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
+@Vectorised
 /*<visibility>*/public/*</visibility>*/ class MatrixFloat3x3
     extends /*<extends>*/Struct<MatrixFloat3x3>/*</extends>*/
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/MatrixFloat3x4.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/MatrixFloat3x4.java
@@ -20,12 +20,14 @@ package org.robovm.apple.foundation;
 import org.robovm.rt.bro.Struct;
 import org.robovm.rt.bro.annotation.ByVal;
 import org.robovm.rt.bro.annotation.StructMember;
+import org.robovm.rt.bro.annotation.Vectorised;
 import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
+@Vectorised
 /*<visibility>*/public/*</visibility>*/ class MatrixFloat3x4
     extends /*<extends>*/Struct<MatrixFloat3x4>/*</extends>*/
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/MatrixFloat4x2.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/MatrixFloat4x2.java
@@ -20,12 +20,14 @@ package org.robovm.apple.foundation;
 import org.robovm.rt.bro.Struct;
 import org.robovm.rt.bro.annotation.ByVal;
 import org.robovm.rt.bro.annotation.StructMember;
+import org.robovm.rt.bro.annotation.Vectorised;
 import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
+@Vectorised
 /*<visibility>*/public/*</visibility>*/ class MatrixFloat4x2
     extends /*<extends>*/Struct<MatrixFloat4x2>/*</extends>*/
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/MatrixFloat4x3.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/MatrixFloat4x3.java
@@ -20,12 +20,14 @@ package org.robovm.apple.foundation;
 import org.robovm.rt.bro.Struct;
 import org.robovm.rt.bro.annotation.ByVal;
 import org.robovm.rt.bro.annotation.StructMember;
+import org.robovm.rt.bro.annotation.Vectorised;
 import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
+@Vectorised
 /*<visibility>*/public/*</visibility>*/ class MatrixFloat4x3
     extends /*<extends>*/Struct<MatrixFloat4x3>/*</extends>*/
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/MatrixFloat4x4.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/MatrixFloat4x4.java
@@ -24,7 +24,8 @@ import org.robovm.rt.bro.ptr.*;
 /*<javadoc>*/
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ class MatrixFloat4x4 
+@Vectorised
+/*<visibility>*/public/*</visibility>*/ class MatrixFloat4x4
     extends /*<extends>*/Struct<MatrixFloat4x4>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {
 

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/VectorDouble4.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/VectorDouble4.java
@@ -19,13 +19,15 @@ package org.robovm.apple.foundation;
 
 import org.robovm.rt.bro.Struct;
 import org.robovm.rt.bro.annotation.StructMember;
+import org.robovm.rt.bro.annotation.Vectorised;
 import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ class VectorDouble4 
+@Vectorised
+/*<visibility>*/public/*</visibility>*/ class VectorDouble4
     extends /*<extends>*/Struct<VectorDouble4>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {
 

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/VectorFloat2.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/VectorFloat2.java
@@ -24,7 +24,8 @@ import org.robovm.rt.bro.ptr.*;
 /*<javadoc>*/
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ class VectorFloat2 
+@Vectorised
+/*<visibility>*/public/*</visibility>*/ class VectorFloat2
     extends /*<extends>*/Struct<VectorFloat2>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {
 

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/VectorFloat3.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/VectorFloat3.java
@@ -24,7 +24,8 @@ import org.robovm.rt.bro.ptr.*;
 /*<javadoc>*/
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ class VectorFloat3 
+@Vectorised
+/*<visibility>*/public/*</visibility>*/ class VectorFloat3
     extends /*<extends>*/Struct<VectorFloat3>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {
 

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/VectorFloat4.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/VectorFloat4.java
@@ -24,7 +24,8 @@ import org.robovm.rt.bro.ptr.*;
 /*<javadoc>*/
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ class VectorFloat4 
+@Vectorised
+/*<visibility>*/public/*</visibility>*/ class VectorFloat4
     extends /*<extends>*/Struct<VectorFloat4>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {
 

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/VectorInt2.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/VectorInt2.java
@@ -24,7 +24,8 @@ import org.robovm.rt.bro.ptr.*;
 /*<javadoc>*/
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ class VectorInt2 
+@Vectorised
+/*<visibility>*/public/*</visibility>*/ class VectorInt2
     extends /*<extends>*/Struct<VectorInt2>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {
 

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/VectorInt3.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/VectorInt3.java
@@ -24,7 +24,8 @@ import org.robovm.rt.bro.ptr.*;
 /*<javadoc>*/
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ class VectorInt3 
+@Vectorised
+/*<visibility>*/public/*</visibility>*/ class VectorInt3
     extends /*<extends>*/Struct<VectorInt3>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {
 

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/VectorInt4.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/VectorInt4.java
@@ -24,7 +24,8 @@ import org.robovm.rt.bro.ptr.*;
 /*<javadoc>*/
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ class VectorInt4 
+@Vectorised
+/*<visibility>*/public/*</visibility>*/ class VectorInt4
     extends /*<extends>*/Struct<VectorInt4>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {
 

--- a/compiler/compiler/src/main/java/org/robovm/compiler/Annotations.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/Annotations.java
@@ -47,6 +47,7 @@ public class Annotations {
     public static final String BRIDGE = "Lorg/robovm/rt/bro/annotation/Bridge;";
     public static final String CALLBACK = "Lorg/robovm/rt/bro/annotation/Callback;";
     public static final String STRUCT_MEMBER = "Lorg/robovm/rt/bro/annotation/StructMember;";
+    public static final String VECTORISED = "Lorg/robovm/rt/bro/annotation/Vectorised;";
     public static final String GLOBAL_VALUE = "Lorg/robovm/rt/bro/annotation/GlobalValue;";
     public static final String ARRAY = "Lorg/robovm/rt/bro/annotation/Array;";
     public static final String BASE_TYPE = "Lorg/robovm/rt/bro/annotation/BaseType;";
@@ -301,6 +302,10 @@ public class Annotations {
 
     public static AnnotationTag getStructMemberAnnotation(SootMethod method) {
         return getAnnotation(method, STRUCT_MEMBER);
+    }
+
+    public static AnnotationTag getStructVectorisedAnnotation(SootClass clazz) {
+        return getAnnotation(clazz, VECTORISED);
     }
     
     public static AnnotationTag getArrayAnnotation(SootMethod method) {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/BridgeMethodCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/BridgeMethodCompiler.java
@@ -213,7 +213,7 @@ public class BridgeMethodCompiler extends BroMethodCompiler {
         loSignature.append(')');
         
         for (Entry<String, String> struct : structs.entrySet()) {
-            body.append("    struct " + struct.getKey() + " " + struct.getValue() + ";\n");
+            body.append("    typedef " + struct.getValue() + " " + struct.getKey() + ";\n");
         }
         
         if (returnType instanceof StructureType) {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/CallbackMethodCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/CallbackMethodCompiler.java
@@ -126,7 +126,7 @@ public class CallbackMethodCompiler extends BroMethodCompiler {
         
         StringBuilder header = new StringBuilder();
         for (Entry<String, String> struct : structs.entrySet()) {
-            header.append("struct " + struct.getKey() + " " + struct.getValue() + ";\n");
+            header.append("typedef " + struct.getValue() + " " + struct.getKey()  +";\n");
         }
         header.append(hiSignature + ";\n");
         

--- a/compiler/compiler/src/test/java/org/robovm/compiler/BridgeMethodCompilerTest.java
+++ b/compiler/compiler/src/test/java/org/robovm/compiler/BridgeMethodCompilerTest.java
@@ -19,10 +19,7 @@ package org.robovm.compiler;
 import static org.junit.Assert.*;
 
 import org.junit.Test;
-import org.robovm.compiler.llvm.ArrayType;
-import org.robovm.compiler.llvm.FunctionType;
-import org.robovm.compiler.llvm.PointerType;
-import org.robovm.compiler.llvm.StructureType;
+import org.robovm.compiler.llvm.*;
 
 import static org.robovm.compiler.llvm.Type.*;
 
@@ -81,26 +78,28 @@ public class BridgeMethodCompilerTest {
                 BridgeMethodCompiler.createBridgeCWrapper(functionType.getReturnType(),
                         functionType.getParameterTypes(), functionType.getParameterTypes(), "f"));
     }
-    @Test
-    public void testCreateBridgeCWrapperIgnoresEmptyStructAsFirstMember() {
-        FunctionType functionType = new FunctionType(VOID, 
-                new StructureType(new StructureType(), I32));
-        assertEquals(
-                "void f(void* target, void* p0) {\n" +
-                "    struct f_0001 {int m1;};\n" +
-                "    ((void (*)(struct f_0001)) target)(*((struct f_0001*)p0));\n" +
-                "}\n", 
-                BridgeMethodCompiler.createBridgeCWrapper(functionType.getReturnType(),
-                        functionType.getParameterTypes(), functionType.getParameterTypes(), "f"));
-    }
+
+//    dkimitsa: test removed as there is no empty struct passed if there is no super struct
+//    @Test
+//    public void testCreateBridgeCWrapperIgnoresEmptyStructAsFirstMember() {
+//        FunctionType functionType = new FunctionType(VOID,
+//                new StructureType(new StructureType(), I32));
+//        assertEquals(
+//                "void f(void* target, void* p0) {\n" +
+//                "    typedef struct {int m1;} f_0001;\n" +
+//                "    ((void (*)(f_0001)) target)(*((f_0001*)p0));\n" +
+//                "}\n",
+//                BridgeMethodCompiler.createBridgeCWrapper(functionType.getReturnType(),
+//                        functionType.getParameterTypes(), functionType.getParameterTypes(), "f"));
+//    }
     @Test
     public void testCreateBridgeCWrapperSmallStructByValParameter() {
         FunctionType functionType = new FunctionType(VOID, 
                 new StructureType(I32));
         assertEquals(
                 "void f(void* target, void* p0) {\n" +
-                "    struct f_0001 {int m0;};\n" +
-                "    ((void (*)(struct f_0001)) target)(*((struct f_0001*)p0));\n" +
+                "    typedef struct {int m0;} f_0001;\n" +
+                "    ((void (*)(f_0001)) target)(*((f_0001*)p0));\n" +
                 "}\n", 
                 BridgeMethodCompiler.createBridgeCWrapper(functionType.getReturnType(),
                         functionType.getParameterTypes(), functionType.getParameterTypes(), "f"));
@@ -113,10 +112,10 @@ public class BridgeMethodCompilerTest {
                         new StructureType(I32)));
         assertEquals(
                 "void f(void* target, void* p0) {\n" +
-                "    struct f_0001_0001 {int m0;};\n" +
-                "    struct f_0001_0000 {int m0;};\n" +
-                "    struct f_0001 {struct f_0001_0000 m0;struct f_0001_0001 m1;};\n" +
-                "    ((void (*)(struct f_0001)) target)(*((struct f_0001*)p0));\n" +
+                "    typedef struct {int m0;} f_0001_0001;\n" +
+                "    typedef struct {int m0;} f_0001_0000;\n" +
+                "    typedef struct {f_0001_0000 m0;f_0001_0001 m1;} f_0001;\n" +
+                "    ((void (*)(f_0001)) target)(*((f_0001*)p0));\n" +
                 "}\n",
                 BridgeMethodCompiler.createBridgeCWrapper(functionType.getReturnType(),
                         functionType.getParameterTypes(), functionType.getParameterTypes(), "f"));
@@ -132,12 +131,12 @@ public class BridgeMethodCompilerTest {
                                 new PointerType(new StructureType(I32)))));
         assertEquals(
                 "void f(void* target, void* p0) {\n" +
-                "    struct f_0001_0003 {void* m0;void* m1;};\n" +
-                "    struct f_0001_0002 {float m0;double m1;};\n" +
-                "    struct f_0001_0001 {int m0;long long m1;};\n" +
-                "    struct f_0001_0000 {char m0;short m1;};\n" +
-                "    struct f_0001 {struct f_0001_0000 m0;struct f_0001_0001 m1;struct f_0001_0002 m2;struct f_0001_0003 m3;};\n" +
-                "    ((void (*)(struct f_0001)) target)(*((struct f_0001*)p0));\n" +
+                "    typedef struct {void* m0;void* m1;} f_0001_0003;\n" +
+                "    typedef struct {float m0;double m1;} f_0001_0002;\n" +
+                "    typedef struct {int m0;long long m1;} f_0001_0001;\n" +
+                "    typedef struct {char m0;short m1;} f_0001_0000;\n" +
+                "    typedef struct {f_0001_0000 m0;f_0001_0001 m1;f_0001_0002 m2;f_0001_0003 m3;} f_0001;\n" +
+                "    ((void (*)(f_0001)) target)(*((f_0001*)p0));\n" +
                 "}\n", 
                 BridgeMethodCompiler.createBridgeCWrapper(functionType.getReturnType(),
                         functionType.getParameterTypes(), functionType.getParameterTypes(), "f"));
@@ -147,8 +146,8 @@ public class BridgeMethodCompilerTest {
         FunctionType functionType = new FunctionType(new StructureType(I32));
         assertEquals(
                 "void f(void* target, void* ret) {\n" +
-                "    struct f_0000 {int m0;};\n" +
-                "    *((struct f_0000*)ret) = ((struct f_0000 (*)(void)) target)();\n" +
+                "    typedef struct {int m0;} f_0000;\n" +
+                "    *((f_0000*)ret) = ((f_0000 (*)(void)) target)();\n" +
                 "}\n", 
                 BridgeMethodCompiler.createBridgeCWrapper(functionType.getReturnType(),
                         functionType.getParameterTypes(), functionType.getParameterTypes(), "f"));
@@ -158,10 +157,10 @@ public class BridgeMethodCompilerTest {
         FunctionType functionType = new FunctionType(new StructureType(new StructureType(I32), new StructureType(I32)));
         assertEquals(
                 "void f(void* target, void* ret) {\n" +
-                "    struct f_0000_0001 {int m0;};\n" +
-                "    struct f_0000_0000 {int m0;};\n" +
-                "    struct f_0000 {struct f_0000_0000 m0;struct f_0000_0001 m1;};\n" +
-                "    *((struct f_0000*)ret) = ((struct f_0000 (*)(void)) target)();\n" +
+                "    typedef struct {int m0;} f_0000_0001;\n" +
+                "    typedef struct {int m0;} f_0000_0000;\n" +
+                "    typedef struct {f_0000_0000 m0;f_0000_0001 m1;} f_0000;\n" +
+                "    *((f_0000*)ret) = ((f_0000 (*)(void)) target)();\n" +
                 "}\n", 
                 BridgeMethodCompiler.createBridgeCWrapper(functionType.getReturnType(),
                         functionType.getParameterTypes(), functionType.getParameterTypes(), "f"));
@@ -180,19 +179,19 @@ public class BridgeMethodCompilerTest {
         FunctionType functionType = new FunctionType(structType, structType);
         assertEquals(
                 "void f(void* target, void* ret, void* p0) {\n" +
-                "    struct f_0001_0006 {void* m0;void* m1;};\n" +
-                "    struct f_0001_0004 {float m0;float m1;};\n" +
-                "    struct f_0001_0002 {float m0;double m1;};\n" +
-                "    struct f_0001_0001 {int m0;long long m1;};\n" +
-                "    struct f_0001_0000 {char m0;short m1;};\n" +
-                "    struct f_0001 {struct f_0001_0000 m0;struct f_0001_0001 m1;struct f_0001_0002 m2;int m3[100];struct f_0001_0004 m4[10];int m5[5][10];struct f_0001_0006 m6;};\n" +
-                "    struct f_0000_0006 {void* m0;void* m1;};\n" +
-                "    struct f_0000_0004 {float m0;float m1;};\n" +
-                "    struct f_0000_0002 {float m0;double m1;};\n" +
-                "    struct f_0000_0001 {int m0;long long m1;};\n" +
-                "    struct f_0000_0000 {char m0;short m1;};\n" +
-                "    struct f_0000 {struct f_0000_0000 m0;struct f_0000_0001 m1;struct f_0000_0002 m2;int m3[100];struct f_0000_0004 m4[10];int m5[5][10];struct f_0000_0006 m6;};\n" +
-                "    *((struct f_0000*)ret) = ((struct f_0000 (*)(struct f_0001)) target)(*((struct f_0001*)p0));\n" +
+                "    typedef struct {void* m0;void* m1;} f_0001_0006;\n" +
+                "    typedef struct {float m0;float m1;} f_0001_0004;\n" +
+                "    typedef struct {float m0;double m1;} f_0001_0002;\n" +
+                "    typedef struct {int m0;long long m1;} f_0001_0001;\n" +
+                "    typedef struct {char m0;short m1;} f_0001_0000;\n" +
+                "    typedef struct {f_0001_0000 m0;f_0001_0001 m1;f_0001_0002 m2;int m3[100];f_0001_0004 m4[10];int m5[5][10];f_0001_0006 m6;} f_0001;\n" +
+                "    typedef struct {void* m0;void* m1;} f_0000_0006;\n" +
+                "    typedef struct {float m0;float m1;} f_0000_0004;\n" +
+                "    typedef struct {float m0;double m1;} f_0000_0002;\n" +
+                "    typedef struct {int m0;long long m1;} f_0000_0001;\n" +
+                "    typedef struct {char m0;short m1;} f_0000_0000;\n" +
+                "    typedef struct {f_0000_0000 m0;f_0000_0001 m1;f_0000_0002 m2;int m3[100];f_0000_0004 m4[10];int m5[5][10];f_0000_0006 m6;} f_0000;\n" +
+                "    *((f_0000*)ret) = ((f_0000 (*)(f_0001)) target)(*((f_0001*)p0));\n" +
                 "}\n", 
                 BridgeMethodCompiler.createBridgeCWrapper(functionType.getReturnType(),
                         functionType.getParameterTypes(), functionType.getParameterTypes(), "f"));
@@ -207,5 +206,33 @@ public class BridgeMethodCompilerTest {
                 "}\n", 
                 BridgeMethodCompiler.createBridgeCWrapper(hiType.getReturnType(),
                         hiType.getParameterTypes(), loType.getParameterTypes(), "f"));
+    }
+    @Test
+    public void testCreateBridgeCWrapperVectorStructByValReturn() {
+        // test for VectorFloat2
+        FunctionType functionType = new FunctionType(new StructureType(0, true, Type.FLOAT, Type.FLOAT));
+        assertEquals(
+                "void f(void* target, void* ret) {\n" +
+                        "    typedef __attribute__((__ext_vector_type__(2))) float f_0000;\n" +
+                        "    *((f_0000*)ret) = ((f_0000 (*)(void)) target)();\n" +
+                        "}\n",
+                BridgeMethodCompiler.createBridgeCWrapper(functionType.getReturnType(),
+                        functionType.getParameterTypes(), functionType.getParameterTypes(), "f"));
+    }
+    @Test
+    public void testCreateBridgeCWrapperVectorArrayStructByValReturn() {
+        // test for MatrixFloat2x2
+        FunctionType functionType = new FunctionType(
+                new StructureType(0, true,
+                        new StructureType(0, true, Type.FLOAT, Type.FLOAT),
+                        new StructureType(0, true, Type.FLOAT, Type.FLOAT)));
+        assertEquals(
+                "void f(void* target, void* ret) {\n" +
+                        "    typedef __attribute__((__ext_vector_type__(2))) float f_0000_0000;\n" +
+                        "    typedef struct { f_0000_0000 m[2];} f_0000;\n" +
+                        "    *((f_0000*)ret) = ((f_0000 (*)(void)) target)();\n" +
+                        "}\n",
+                BridgeMethodCompiler.createBridgeCWrapper(functionType.getReturnType(),
+                        functionType.getParameterTypes(), functionType.getParameterTypes(), "f"));
     }
 }

--- a/compiler/compiler/src/test/java/org/robovm/compiler/CallbackMethodCompilerTest.java
+++ b/compiler/compiler/src/test/java/org/robovm/compiler/CallbackMethodCompilerTest.java
@@ -80,24 +80,25 @@ public class CallbackMethodCompilerTest {
                 CallbackMethodCompiler.createCallbackCWrapper(
                         new FunctionType(I8_PTR), "f", "f_inner"));
     }
-    @Test
-    public void testCreateCallbackCWrapperIgnoresEmptyStructAsFirstMember() {
-        assertEquals(
-                "struct f_0001 {int m1;};\n" +
-                "void f_inner(void*);\n" +
-                "void f(struct f_0001 p0) {\n" +
-                "    f_inner((void*) &p0);\n" +
-                "}\n", 
-                CallbackMethodCompiler.createCallbackCWrapper(
-                        new FunctionType(VOID, 
-                                new StructureType(new StructureType(), I32)), "f", "f_inner"));
-    }
+//    dkimitsa: empty struct is now not passed if there is no super struct, this test is not required
+//    @Test
+//    public void testCreateCallbackCWrapperIgnoresEmptyStructAsFirstMember() {
+//        assertEquals(
+//                "typedef struct {int m1;} f_0001;\n" +
+//                "void f_inner(void*);\n" +
+//                "void f(f_0001 p0) {\n" +
+//                "    f_inner((void*) &p0);\n" +
+//                "}\n",
+//                CallbackMethodCompiler.createCallbackCWrapper(
+//                        new FunctionType(VOID,
+//                                new StructureType(new StructureType(), I32)), "f", "f_inner"));
+//    }
     @Test
     public void testCreateCallbackCWrapperSmallStructByValParameter() {
         assertEquals(
-                "struct f_0001 {int m0;};\n" +
+                "typedef struct {int m0;} f_0001;\n" +
                 "void f_inner(void*);\n" +
-                "void f(struct f_0001 p0) {\n" +
+                "void f(f_0001 p0) {\n" +
                 "    f_inner((void*) &p0);\n" +
                 "}\n", 
                 CallbackMethodCompiler.createCallbackCWrapper(
@@ -107,11 +108,11 @@ public class CallbackMethodCompilerTest {
     @Test
     public void testCreateCallbackCWrapperNestedStructByValParameter() {
         assertEquals(
-                "struct f_0001_0001 {int m0;};\n" +
-                "struct f_0001_0000 {int m0;};\n" +
-                "struct f_0001 {struct f_0001_0000 m0;struct f_0001_0001 m1;};\n" +
+                "typedef struct {int m0;} f_0001_0001;\n" +
+                "typedef struct {int m0;} f_0001_0000;\n" +
+                "typedef struct {f_0001_0000 m0;f_0001_0001 m1;} f_0001;\n" +
                 "void f_inner(void*);\n" +
-                "void f(struct f_0001 p0) {\n" +
+                "void f(f_0001 p0) {\n" +
                 "    f_inner((void*) &p0);\n" +
                 "}\n",
                 CallbackMethodCompiler.createCallbackCWrapper(
@@ -123,13 +124,13 @@ public class CallbackMethodCompilerTest {
     @Test
     public void testCreateCallbackCWrapperComplexNestedStructByValParameter() {
         assertEquals(
-                "struct f_0001_0003 {void* m0;void* m1;};\n" +
-                "struct f_0001_0002 {float m0;double m1;};\n" +
-                "struct f_0001_0001 {int m0;long long m1;};\n" +
-                "struct f_0001_0000 {char m0;short m1;};\n" +
-                "struct f_0001 {struct f_0001_0000 m0;struct f_0001_0001 m1;struct f_0001_0002 m2;struct f_0001_0003 m3;};\n" +
+                "typedef struct {void* m0;void* m1;} f_0001_0003;\n" +
+                "typedef struct {float m0;double m1;} f_0001_0002;\n" +
+                "typedef struct {int m0;long long m1;} f_0001_0001;\n" +
+                "typedef struct {char m0;short m1;} f_0001_0000;\n" +
+                "typedef struct {f_0001_0000 m0;f_0001_0001 m1;f_0001_0002 m2;f_0001_0003 m3;} f_0001;\n" +
                 "void f_inner(void*);\n" +
-                "void f(struct f_0001 p0) {\n" +
+                "void f(f_0001 p0) {\n" +
                 "    f_inner((void*) &p0);\n" +
                 "}\n", 
                 CallbackMethodCompiler.createCallbackCWrapper(
@@ -144,10 +145,10 @@ public class CallbackMethodCompilerTest {
     @Test
     public void testCreateCallbackCWrapperSmallStructByValReturn() {
         assertEquals(
-                "struct f_0000 {int m0;};\n" +
+                "typedef struct {int m0;} f_0000;\n" +
                 "void* f_inner(void);\n" +
-                "struct f_0000 f(void) {\n" +
-                "    return *((struct f_0000*) f_inner());\n" +
+                "f_0000 f(void) {\n" +
+                "    return *((f_0000*) f_inner());\n" +
                 "}\n", 
                 CallbackMethodCompiler.createCallbackCWrapper(
                         new FunctionType(new StructureType(I32)), "f", "f_inner"));
@@ -155,12 +156,12 @@ public class CallbackMethodCompilerTest {
     @Test
     public void testCreateCallbackCWrapperNestedStructByValReturn() {
         assertEquals(
-                "struct f_0000_0001 {int m0;};\n" +
-                "struct f_0000_0000 {int m0;};\n" +
-                "struct f_0000 {struct f_0000_0000 m0;struct f_0000_0001 m1;};\n" +
+                "typedef struct {int m0;} f_0000_0001;\n" +
+                "typedef struct {int m0;} f_0000_0000;\n" +
+                "typedef struct {f_0000_0000 m0;f_0000_0001 m1;} f_0000;\n" +
                 "void* f_inner(void);\n" +
-                "struct f_0000 f(void) {\n" +
-                "    return *((struct f_0000*) f_inner());\n" +
+                "f_0000 f(void) {\n" +
+                "    return *((f_0000*) f_inner());\n" +
                 "}\n", 
                 CallbackMethodCompiler.createCallbackCWrapper(
                         new FunctionType(new StructureType(new StructureType(I32), new StructureType(I32))), "f", "f_inner"));
@@ -177,21 +178,21 @@ public class CallbackMethodCompilerTest {
                 new StructureType(I8_PTR, 
                         new PointerType(new StructureType(I32))));
         assertEquals(
-                "struct f_0001_0006 {void* m0;void* m1;};\n" +
-                "struct f_0001_0004 {float m0;float m1;};\n" +
-                "struct f_0001_0002 {float m0;double m1;};\n" +
-                "struct f_0001_0001 {int m0;long long m1;};\n" +
-                "struct f_0001_0000 {char m0;short m1;};\n" +
-                "struct f_0001 {struct f_0001_0000 m0;struct f_0001_0001 m1;struct f_0001_0002 m2;int m3[100];struct f_0001_0004 m4[10];int m5[5][10];struct f_0001_0006 m6;};\n" +
-                "struct f_0000_0006 {void* m0;void* m1;};\n" +
-                "struct f_0000_0004 {float m0;float m1;};\n" +
-                "struct f_0000_0002 {float m0;double m1;};\n" +
-                "struct f_0000_0001 {int m0;long long m1;};\n" +
-                "struct f_0000_0000 {char m0;short m1;};\n" +
-                "struct f_0000 {struct f_0000_0000 m0;struct f_0000_0001 m1;struct f_0000_0002 m2;int m3[100];struct f_0000_0004 m4[10];int m5[5][10];struct f_0000_0006 m6;};\n" +
+                "typedef struct {void* m0;void* m1;} f_0001_0006;\n" +
+                "typedef struct {float m0;float m1;} f_0001_0004;\n" +
+                "typedef struct {float m0;double m1;} f_0001_0002;\n" +
+                "typedef struct {int m0;long long m1;} f_0001_0001;\n" +
+                "typedef struct {char m0;short m1;} f_0001_0000;\n" +
+                "typedef struct {f_0001_0000 m0;f_0001_0001 m1;f_0001_0002 m2;int m3[100];f_0001_0004 m4[10];int m5[5][10];f_0001_0006 m6;} f_0001;\n" +
+                "typedef struct {void* m0;void* m1;} f_0000_0006;\n" +
+                "typedef struct {float m0;float m1;} f_0000_0004;\n" +
+                "typedef struct {float m0;double m1;} f_0000_0002;\n" +
+                "typedef struct {int m0;long long m1;} f_0000_0001;\n" +
+                "typedef struct {char m0;short m1;} f_0000_0000;\n" +
+                "typedef struct {f_0000_0000 m0;f_0000_0001 m1;f_0000_0002 m2;int m3[100];f_0000_0004 m4[10];int m5[5][10];f_0000_0006 m6;} f_0000;\n" +
                 "void* f_inner(void*);\n" +
-                "struct f_0000 f(struct f_0001 p0) {\n" +
-                "    return *((struct f_0000*) f_inner((void*) &p0));\n" +
+                "f_0000 f(f_0001 p0) {\n" +
+                "    return *((f_0000*) f_inner((void*) &p0));\n" +
                 "}\n", 
                 CallbackMethodCompiler.createCallbackCWrapper(
                         new FunctionType(structType, structType), "f", "f_inner"));

--- a/compiler/rt/robovm/src/main/java/org/robovm/rt/bro/annotation/Vectorised.java
+++ b/compiler/rt/robovm/src/main/java/org/robovm/rt/bro/annotation/Vectorised.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2012 RoboVM AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.rt.bro.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies that annotated struct has to be optimized as SIMD Vector
+ * @author dkimitsa
+ * @version $Id$
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface Vectorised {
+}


### PR DESCRIPTION
This PR adds support to vector data types that is widely used in ARKit. 
In general it adds: 
- special annotation to mark structures to be vectorized 
- compiler code is modified to generate corresponding bridge code for annotated structs
- general struct handling code was modified to remove empty super-related empty struct member and to generate proper vector IR data type for vector structs 