### PR TITLE
fix #338 -- removing arch64e

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -171,6 +171,8 @@ public class Config {
     private String targetType;
     @Element(required = false, name = "stripArchives")
     private StripArchivesConfig stripArchivesConfig;
+    @ElementList(required = false, entry = "arch")
+    private ArrayList<String> stripArchs;
     @Element(required = false, name = "treeShaker")
     private TreeShakerMode treeShakerMode;
     @Element(required = false, name = "smartSkipRebuild")
@@ -371,6 +373,13 @@ public class Config {
     public StripArchivesConfig getStripArchivesConfig() {
        return stripArchivesConfig == null ? StripArchivesConfig.DEFAULT : stripArchivesConfig;
    }
+
+    /**
+     * @return list of architectures to be removed from embedded frameworks/app extension
+     */
+    public List<String> getStripArchs() {
+        return stripArchs == null ? Collections.<String>emptyList() : stripArchs;
+    }
 
     public DependencyGraph getDependencyGraph() {
         return dependencyGraph;
@@ -1177,6 +1186,18 @@ public class Config {
             }
             config.archs.clear();
             config.archs.addAll(archs);
+            return this;
+        }
+
+        public void stripArch(String arch) {
+            if (config.stripArchs == null) {
+                config.stripArchs = new ArrayList<>();
+            }
+            config.stripArchs.add(arch);
+        }
+
+        public Builder stripArchs(String ... archs) {
+            config.stripArchs = new ArrayList<>(Arrays.asList(archs));
             return this;
         }
 

--- a/compiler/compiler/src/main/java/org/robovm/compiler/util/ToolchainUtil.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/util/ToolchainUtil.java
@@ -305,12 +305,12 @@ public class ToolchainUtil {
         new Executor(config.getLogger(), getLipo()).args(inFiles, "-create", "-output", outFile).exec();
     }
     
-    public static void lipoRemoveArchs(Config config, File inFile, File outFile, Arch ... archs) throws IOException {
+    public static void lipoRemoveArchs(Config config, File inFile, File outFile, String ... archs) throws IOException {
         List<Object> args = new ArrayList<>();
         args.add(inFile);
-        for(Arch arch: archs) {
+        for(String arch: archs) {
             args.add("-remove");
-            args.add(arch.getClangName());
+            args.add(arch);
         }
         args.add("-output");
         args.add(outFile);

--- a/plugins/idea/src/main/java/org/robovm/idea/compilation/RoboVmCompileTask.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/compilation/RoboVmCompileTask.java
@@ -107,6 +107,10 @@ public class RoboVmCompileTask implements CompileTask {
             loadConfig(context.getProject(), builder, moduleBaseDir, false);
             builder.os(OS.ios);
             builder.archs(ipaConfig.getArchs());
+
+            // remove "arm64e" which becomes a problem starting from Xcode 10.1
+            builder.stripArch("arm64e");
+
             builder.installDir(ipaConfig.getDestinationDir());
             builder.iosSignIdentity(SigningIdentity.find(SigningIdentity.list(), ipaConfig.getSigningIdentity()));
             if (ipaConfig.getProvisioningProfile() != null) {


### PR DESCRIPTION
* added option for robovm.xml to strip extra arches, e.g. 
```xml
<stripArchs>
   <arch>zx48</arch>
</stripArchs>
```
* when building ipa arm64e is forced to be removed