### PR TITLE
Intents fix: binding for NSUserActivity and CLPlacemark categories

### DIFF
--- a/compiler/cocoatouch/src/main/bro-gen/intents.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/intents.yaml
@@ -6,7 +6,8 @@ clang_args: ['-x', 'objective-c']
 headers:
     - /System/Library/Frameworks/Intents.framework/Headers/Intents.h
 typedefs: {}
-
+private_typedefs:
+    'CNPostalAddress *': org.robovm.apple.contacts.CNPostalAddress
 enums:
     INIntentErrorCode: { nserror: true, prefix: INIntentError} #since 10.0
     INCallCapabilityOptions: {prefix: INCallCapabilityOption} #since 10.0
@@ -113,6 +114,12 @@ enums:
     INDailyRoutineSituation: {} #since 12.0
     INRelevantShortcutRole: {} #since 12.0
 
+categories:
+    NSUserActivity: {}
+    CLPlacemark:
+        methods:
+            '+placemarkWithLocation:name:postalAddress:':
+                name: getPlacemark
 classes:
     INAccountTypeResolutionResult: {} #since 11.0
     INActivateCarSignalIntent: #since 10.3

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/intents/CLPlacemarkExtensions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/intents/CLPlacemarkExtensions.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.intents;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.eventkit.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/*</javadoc>*/
+/*<annotations>*/@Library("Intents")/*</annotations>*/
+/*<visibility>*/public final/*</visibility>*/ class /*<name>*/CLPlacemarkExtensions/*</name>*/ 
+    extends /*<extends>*/NSExtensions/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(CLPlacemarkExtensions.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    private CLPlacemarkExtensions() {}
+    /*</constructors>*/
+    /*<properties>*/
+    
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "placemarkWithLocation:name:postalAddress:")
+    protected static native CLPlacemark getPlacemark(ObjCClass clazz, CLLocation location, String name, org.robovm.apple.contacts.CNPostalAddress postalAddress);
+    public static CLPlacemark getPlacemark(CLLocation location, String name, org.robovm.apple.contacts.CNPostalAddress postalAddress) { return getPlacemark(ObjCClass.getByType(CLPlacemark.class), location, name, postalAddress); }
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/intents/NSUserActivityExtensions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/intents/NSUserActivityExtensions.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.intents;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.eventkit.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/*</javadoc>*/
+/*<annotations>*/@Library("Intents")/*</annotations>*/
+/*<visibility>*/public final/*</visibility>*/ class /*<name>*/NSUserActivityExtensions/*</name>*/ 
+    extends /*<extends>*/NSExtensions/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(NSUserActivityExtensions.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    private NSUserActivityExtensions() {}
+    /*</constructors>*/
+    /*<properties>*/
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "interaction")
+    public static native INInteraction getInteraction(NSUserActivity thiz);
+    /**
+     * @since Available in iOS 12.0 and later.
+     */
+    @Property(selector = "suggestedInvocationPhrase")
+    public static native String getSuggestedInvocationPhrase(NSUserActivity thiz);
+    /**
+     * @since Available in iOS 12.0 and later.
+     */
+    @Property(selector = "setSuggestedInvocationPhrase:")
+    public static native void setSuggestedInvocationPhrase(NSUserActivity thiz, String v);
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    
+    /*</methods>*/
+}


### PR DESCRIPTION
this PR added bindings for NSUserActivity and CLPlacemark categories which were skipped. 
it was required by used as [in this post](
https://gitter.im/MobiVM/robovm?at=5c34b94d1d1c2c3f9cdf749a)