### PR TITLE
* gradle: fixed dumpIntermediates 

### DIFF
--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMBuildTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMBuildTask.java
@@ -45,8 +45,6 @@ public abstract class AbstractRoboVMBuildTask extends AbstractRoboVMTask {
                 builder.archs(archs);
             }
             
-            builder.dumpIntermediates(extension.isDumpIntermediates());
-
             AppCompiler compiler = new AppCompiler(builder.build());
             compiler.build();
             if (shouldArchive()) {

--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMTask.java
@@ -219,6 +219,9 @@ abstract public class AbstractRoboVMTask extends DefaultTask {
             }
         }
 
+        if (extension.isDumpIntermediates())
+            builder.dumpIntermediates(true);
+
         builder.clearClasspathEntries();
 
         // configure the runtime classpath


### PR DESCRIPTION
as this configuration option was applied only for archive task. Moved to common configuration section
the problem was reported [in gitter](
https://gitter.im/MobiVM/robovm?at=5c2f0e29db5b5c688353722d)