### PR TITLE
Fix for `Invalid Swift Support` issue

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -171,8 +171,6 @@ public class Config {
     private String targetType;
     @Element(required = false, name = "stripArchives")
     private StripArchivesConfig stripArchivesConfig;
-    @ElementList(required = false, entry = "arch")
-    private ArrayList<String> stripArchs;
     @Element(required = false, name = "treeShaker")
     private TreeShakerMode treeShakerMode;
     @Element(required = false, name = "smartSkipRebuild")
@@ -372,13 +370,6 @@ public class Config {
     
     public StripArchivesConfig getStripArchivesConfig() {
        return stripArchivesConfig == null ? StripArchivesConfig.DEFAULT : stripArchivesConfig;
-   }
-
-    /**
-     * @return list of architectures to be removed from embedded frameworks/app extension
-     */
-    public List<String> getStripArchs() {
-        return stripArchs == null ? Collections.<String>emptyList() : stripArchs;
     }
 
     public DependencyGraph getDependencyGraph() {
@@ -1186,18 +1177,6 @@ public class Config {
             }
             config.archs.clear();
             config.archs.addAll(archs);
-            return this;
-        }
-
-        public void stripArch(String arch) {
-            if (config.stripArchs == null) {
-                config.stripArchs = new ArrayList<>();
-            }
-            config.stripArchs.add(arch);
-        }
-
-        public Builder stripArchs(String ... archs) {
-            config.stripArchs = new ArrayList<>(Arrays.asList(archs));
             return this;
         }
 

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
@@ -359,10 +359,11 @@ public abstract class AbstractTarget implements Target {
                                 copyFile(resource, file, destDir);
 
                                 if (isDynamicLibrary(file)) {
-                                    // remove simulator archs for device builds
+                                    // leave only archs we compile against and remove all other, also strip bitcode if any
                                     if (config.getOs() == OS.ios && config.getArch().isArm()) {
                                         File libFile = new File(destDir, file.getName());
                                         stripExtraArches(libFile);
+                                        stripBitcode(libFile);
                                     }
 
                                     // check if this dylib depends on Swift
@@ -386,7 +387,7 @@ public abstract class AbstractTarget implements Target {
 
         // copy Swift libraries if required
         if (!swiftLibraries.isEmpty()) {
-            copySwiftLibs(swiftLibraries, frameworksDir);
+            copySwiftLibs(swiftLibraries, frameworksDir, true);
         }
     }
 
@@ -419,10 +420,11 @@ public abstract class AbstractTarget implements Target {
                     copyFile(resource, file, destDir);
 
                     if (config.getOs() == OS.ios && config.getArch().isArm()) {
-                        // remove simulator archs for device builds
+                        // leave only archs we compile against and remove all other, also strip bitcode if any
                         if (isAppExtension(file)) {
                             File libFile = new File(destDir, file.getName());
                             stripExtraArches(libFile);
+                            stripBitcode(libFile);
                         }
                     }
                 }
@@ -444,7 +446,7 @@ public abstract class AbstractTarget implements Target {
         }
     }
 
-	protected void copySwiftLibs(Collection<String> swiftLibraries, File targetDir) throws IOException {
+	protected void copySwiftLibs(Collection<String> swiftLibraries, File targetDir, boolean strip) throws IOException {
 		String system = null;
 		if (config.getOs() == OS.ios) {
 			if (config.getArch().isArm()) {
@@ -486,38 +488,53 @@ public abstract class AbstractTarget implements Target {
 			File swiftLibrary = new File(swiftDir, library);
 			FileUtils.copyFileToDirectory(swiftLibrary, targetDir);
 
-            // remove simulator archs for device builds
-            if (config.getOs() == OS.ios && config.getArch().isArm()) {
-                File libFile = new File(targetDir, swiftLibrary.getName());
-                stripExtraArches(libFile);
+			// don't strip if libraries goes to SwiftSupport folder
+			if (strip) {
+                // leave only archs we compile against and remove all other, also strip bitcode if any
+                if (config.getOs() == OS.ios && config.getArch().isArm()) {
+                    File libFile = new File(targetDir, swiftLibrary.getName());
+                    stripExtraArches(libFile);
+                    stripBitcode(libFile);
+                }
             }
         }
 	}
 
     /**
-     * strips simulator and extra architecture from mach-o binary (framework, lib, appext)
+     * removes all architectures extra architectures other than binary is build for from mach-o binary (framework, lib, appext)
      */
 	protected void stripExtraArches(File libFile) throws IOException {
-        String archs = ToolchainUtil.lipoInfo(config, libFile);
-        List<String> archesToRemove = new ArrayList<>();
-        if(archs.contains(Arch.x86.getClangName())) {
-            archesToRemove.add(Arch.x86.getClangName());
-        }
-        if(archs.contains(Arch.x86_64.getClangName())) {
-            archesToRemove.add(Arch.x86_64.getClangName());
-        }
-        // also remove configured ones
-        for (String arch : config.getStripArchs()) {
-            if(archs.contains(arch)) {
-                archesToRemove.add(arch);
+        String info = ToolchainUtil.lipoInfo(config, libFile);
+        Matcher pattern = Pattern.compile("^(Non-|Architectures in the )fat file: .+( is architecture| are): (.*)$").matcher(info);
+        if (pattern.find() && pattern.groupCount() == 3) {
+            String[] archs = pattern.group(3).split(" ");
+            List<String> archesToRemove = new ArrayList<>(Arrays.asList(archs));
+
+            // leave only arches we are building against
+            for (Arch a : config.getArchs()) {
+                archesToRemove.remove(a.getClangName());
+            }
+
+            if (archs.length - archesToRemove.size() != config.getArchs().size()) {
+                // drop warning if there if required arch is missing
+                config.getLogger().warn("%s doesn't contain required architectures: %s", libFile.getAbsoluteFile(), config.getArchs().toString());
+            }
+
+            if (!archesToRemove.isEmpty()) {
+                File tmpFile = new File(libFile.getAbsolutePath() + ".tmp");
+                ToolchainUtil.lipoRemoveArchs(config, libFile, tmpFile, archesToRemove.toArray(new String[0]));
+                FileUtils.copyFile(tmpFile, libFile);
+                tmpFile.delete();
             }
         }
-        if (!archesToRemove.isEmpty()) {
-            File tmpFile = new File(libFile.getAbsolutePath() + ".tmp");
-            ToolchainUtil.lipoRemoveArchs(config, libFile, tmpFile, archesToRemove.toArray(new String[0]));
-            FileUtils.copyFile(tmpFile, libFile);
-            tmpFile.delete();
-        }
+    }
+
+    /** removes bitcode from frameworks/libraries to minimize size */
+    protected void stripBitcode(File libFile) throws IOException {
+        File tmpFile = new File(libFile.getAbsolutePath() + ".tmp");
+        ToolchainUtil.bitcodeStrip(config, libFile, tmpFile);
+        FileUtils.copyFile(tmpFile, libFile);
+        tmpFile.delete();
     }
 
     protected boolean isDynamicLibrary(File file) throws IOException {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
@@ -507,17 +507,21 @@ public abstract class AbstractTarget implements Target {
         String info = ToolchainUtil.lipoInfo(config, libFile);
         Matcher pattern = Pattern.compile("^(Non-|Architectures in the )fat file: .+( is architecture| are): (.*)$").matcher(info);
         if (pattern.find() && pattern.groupCount() == 3) {
-            String[] archs = pattern.group(3).split(" ");
-            List<String> archesToRemove = new ArrayList<>(Arrays.asList(archs));
+            String[] libArchs = pattern.group(3).split(" ");
+            List<String> archesToRemove = new ArrayList<>(Arrays.asList(libArchs));
 
             // leave only arches we are building against
-            for (Arch a : config.getArchs()) {
+            List<Arch> archs = config.getArchs();
+            if (archs.isEmpty()) {
+                archs = config.getTarget().getDefaultArchs();
+            }
+            for (Arch a : archs) {
                 archesToRemove.remove(a.getClangName());
             }
 
-            if (archs.length - archesToRemove.size() != config.getArchs().size()) {
+            if (libArchs.length - archesToRemove.size() != archs.size()) {
                 // drop warning if there if required arch is missing
-                config.getLogger().warn("%s doesn't contain required architectures: %s", libFile.getAbsoluteFile(), config.getArchs().toString());
+                config.getLogger().warn("%s doesn't contain required architectures: %s", libFile.getAbsoluteFile(), archs.toString());
             }
 
             if (!archesToRemove.isEmpty()) {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -706,8 +706,18 @@ public class IOSTarget extends AbstractTarget {
 
             if (swiftLibs != null && swiftLibs.length > 0){
                 File swiftSupportDir = new File(tmpDir, "SwiftSupport");
-                swiftSupportDir.mkdir();
-                copySwiftLibs(Arrays.asList(swiftLibs), swiftSupportDir);
+
+                // append OS name subfolder same as XCode does
+                if (config.getOs() == OS.ios) {
+                    if (config.getArch().isArm()) {
+                        swiftSupportDir = new File(swiftSupportDir, "iphoneos");
+                    }
+                } else {
+                    swiftSupportDir = new File(swiftSupportDir, "mac");
+                }
+
+                swiftSupportDir.mkdirs();
+                copySwiftLibs(Arrays.asList(swiftLibs), swiftSupportDir, false);
             }
         }
 

--- a/compiler/compiler/src/main/java/org/robovm/compiler/util/ToolchainUtil.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/util/ToolchainUtil.java
@@ -43,6 +43,7 @@ public class ToolchainUtil {
     private static String PNGCRUSH;
     private static String PLUTIL;
     private static String LIPO;
+    private static String BITCODE_STRIP;
     private static String PACKAGE_APPLICATION;
     private static String TEXTUREATLAS;
     private static String ACTOOL;
@@ -105,6 +106,13 @@ public class ToolchainUtil {
             LIPO = findXcodeCommand("lipo", "iphoneos");
         }
         return LIPO;
+    }
+
+    private static String getBitcodeStrip() throws IOException {
+        if (BITCODE_STRIP == null) {
+            BITCODE_STRIP = findXcodeCommand("bitcode_strip", "iphoneos");
+        }
+        return BITCODE_STRIP;
     }
 
     private static String getNm() throws IOException {
@@ -316,7 +324,12 @@ public class ToolchainUtil {
         args.add(outFile);
         new Executor(Logger.NULL_LOGGER, getLipo()).args(args).exec();
     }
-    
+
+
+    public static void bitcodeStrip(Config config, File inFile, File outFile) throws IOException {
+        new Executor(config.getLogger(), getBitcodeStrip()).args(inFile, "-r", "-o", outFile).exec();
+    }
+
     public static String lipoInfo(Config config, File inFile) throws IOException {
         List<Object> args = new ArrayList<>();
         args.add("-info");

--- a/plugins/idea/src/main/java/org/robovm/idea/compilation/RoboVmCompileTask.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/compilation/RoboVmCompileTask.java
@@ -108,9 +108,6 @@ public class RoboVmCompileTask implements CompileTask {
             builder.os(OS.ios);
             builder.archs(ipaConfig.getArchs());
 
-            // remove "arm64e" which becomes a problem starting from Xcode 10.1
-            builder.stripArch("arm64e");
-
             builder.installDir(ipaConfig.getDestinationDir());
             builder.iosSignIdentity(SigningIdentity.find(SigningIdentity.list(), ipaConfig.getSigningIdentity()));
             if (ipaConfig.getProvisioningProfile() != null) {


### PR DESCRIPTION
Update: works for me, works for topic starter (Eric Nondahl).  

This shell fix `Invalid Swift Support` issue when uploading to AppleStore.

root case assumed: during #340 there was introduced defect that swift libs copy in 'SwiftSupport' also get stripped of ARM64E arch as result copy of these files were modified. As part of fix this commit does:
* fixed issue with modifying of swift libs in 'SwiftSupport'
* ~now all dynamic frameworks/libs/appext are being stripped to keep only archs same as in app (similar fix done in [rules_apple] (https://github.com/bazelbuild/rules_apple/commit/b238ee53afd6c70eed5a9346dbd834f09f96b89f)). This also reduce final IPA size~ UPDATE: reverted to strip only ARM64E
* ~as all extra arches are being stripped introduced in #340 `stripArchs` option is not required anymore and was removed`~ UPDATE: this option was removed as well as it is enough only to strip ARM64E
* added functionality to strip bitcode from frameworks/libs/appext similar how XCode does, it also saves final IPA size