### PR TITLE
restoring mach exception handlers after initializing analytics (Crashlytics today)

### DIFF
--- a/compiler/vm/core/include/robovm/signal.h
+++ b/compiler/vm/core/include/robovm/signal.h
@@ -22,5 +22,7 @@ extern jboolean rvmRestoreThreadSignalMask(Env* env);
 extern jboolean rvmInstallChainingSignals(Env* env);
 extern jboolean rvmReinstallSavedSignals(Env* env, void* state);
 extern void* rvmSaveSignals(Env* env);
+extern jboolean rvmReinstallSavedMachPorts(Env* env, void* state);
+extern void* rvmSaveMachPorts(Env* env);
 
 #endif

--- a/compiler/vm/core/src/signal.c
+++ b/compiler/vm/core/src/signal.c
@@ -20,6 +20,8 @@
 #if defined(DARWIN)
 #   include <mach/mach.h>
 #   include <mach/semaphore.h>
+#   include <mach/task.h>
+#   include <mach/mach_init.h>
 #else
 #   include <semaphore.h>
 #endif
@@ -53,6 +55,14 @@ static inline int sem_post(sem_t* sem) {
 typedef struct {
     struct sigaction blockedThreadSignal;
 } SavedSignals;
+
+#if defined(DARWIN)
+typedef struct {
+    mach_port_t ports[EXC_TYPES_COUNT];
+    exception_behavior_t behaviors[EXC_TYPES_COUNT];
+    thread_state_flavor_t flavors[EXC_TYPES_COUNT];
+} SavedMachPorts;
+#endif
 
 /*
  * The common way to implement stack overflow detection is to catch SIGSEGV and see if the
@@ -221,6 +231,89 @@ void* rvmSaveSignals(Env* env) {
         return NULL;
     }
     return state;
+}
+
+#if defined(DARWIN)
+static kern_return_t buildMachPortList(SavedMachPorts *state) {
+    // prepares converts port list into array where each cell corresponds exception
+    mach_msg_type_number_t count;
+    exception_mask_t masks[EXC_TYPES_COUNT];
+    mach_port_t ports[EXC_TYPES_COUNT];
+    exception_behavior_t behaviors[EXC_TYPES_COUNT];
+    thread_state_flavor_t flavors[EXC_TYPES_COUNT];
+
+    kern_return_t result = task_get_exception_ports(mach_task_self(), EXC_MASK_ALL, masks, &count, ports, behaviors, flavors);
+    if (result == KERN_SUCCESS) {
+        memset(state, 0, sizeof(SavedMachPorts));
+        for (int j = 0; j < count; j++) {
+            exception_mask_t mask = masks[j];
+            mach_port_t port = ports[j];
+            exception_behavior_t behavior = behaviors[j];
+            thread_state_flavor_t flavor = flavors[j];
+            for (int i = FIRST_EXCEPTION; i < EXC_TYPES_COUNT; i++) {
+                if (mask & (1 << i)) {
+                    state->ports[i] = port;
+                    state->behaviors[i] = behavior;
+                    state->flavors[i] = flavor;
+                }
+            }
+        }
+    }
+    
+    return result;
+}
+#endif
+
+void* rvmSaveMachPorts(Env* env) {
+#if defined(DARWIN)
+    SavedMachPorts* state = malloc(sizeof(SavedMachPorts));
+    kern_return_t result = buildMachPortList(state);
+    assert(result == KERN_SUCCESS);
+    if (result != KERN_SUCCESS) {
+        // failed
+        free(state);
+        return NULL;
+    }
+    
+    return state;
+#else
+    return NULL;
+#endif
+}
+
+jboolean rvmReinstallSavedMachPorts(Env* env, void* p) {
+#if defined(DARWIN)
+    SavedMachPorts* savedPorts = (SavedMachPorts*) p;
+    SavedMachPorts state;
+    kern_return_t result = buildMachPortList(&state);
+    assert(result == KERN_SUCCESS);
+    if (result != KERN_SUCCESS) {
+        free(p);
+        return false;
+    }
+    
+    // compare current state and revert back to saved
+    for (int i = FIRST_EXCEPTION; i < EXC_TYPES_COUNT; i++) {
+        if (savedPorts->ports[i] != state.ports[i]) {
+            mach_port_t port = savedPorts->ports[i];
+            exception_behavior_t behavior = savedPorts->behaviors[i];
+            thread_state_flavor_t flavor = savedPorts->flavors[i];
+            if (!MACH_PORT_VALID(port)) {
+                port = MACH_PORT_NULL;
+                behavior = EXCEPTION_DEFAULT;
+                flavor = MACHINE_THREAD_STATE;
+            }
+
+            assert(task_set_exception_ports(mach_task_self(), 1 << i, port, behavior, flavor) == KERN_SUCCESS);
+        }
+    }
+    
+    free(p);
+    return true;
+
+#else
+    return false;
+#endif
 }
 
 void dumpThreadStackTrace(Env* env, Thread* thread, CallStack* callStack) {

--- a/compiler/vm/rt/robovm/org_robovm_rt_Signals.c
+++ b/compiler/vm/rt/robovm/org_robovm_rt_Signals.c
@@ -26,3 +26,11 @@ void Java_org_robovm_rt_Signals_reinstallSavedSignals(Env* env, Class* c, jlong 
 jlong Java_org_robovm_rt_Signals_saveSignals(Env* env, Class* c) {
     return PTR_TO_LONG(rvmSaveSignals(env));
 }
+
+void Java_org_robovm_rt_Signals_reinstallSavedMachPorts(Env* env, Class* c, jlong state) {
+    rvmReinstallSavedMachPorts(env, LONG_TO_PTR(state));
+}
+
+jlong Java_org_robovm_rt_Signals_saveMachPorts(Env* env, Class* c) {
+    return PTR_TO_LONG(rvmSaveMachPorts(env));
+}


### PR DESCRIPTION
this PR adds preservePorts option to Sygnals.installSignals. When set to true it will save mach exception handlers before invoking callback and restore after it. It is required to pre-serve mach handlers from modification by  third party analytics such as Crashlytics.

RoboVM uses signals handlers to process null-pointer exceptions. Crash reporters often uses same signals to handle crashed and some of them terminates app. Which causes NPE even in try-catch block to crash app. More details [in old post](https://dkimitsa.github.io/2018/02/16/crash-reporters-and-java-exceptions/) 

Crashlytics additionally install task mach exception handler end intercepts javas NPE as EXC_BAD_ACCESS and reports these as crashes. 
The workaround for this is same as with signals -- restore mach port handlers to state it was before calling Sygnals.installSignals.

This PR adds additional API to Signal with preservePorts parameter, when set to true -- will preserve handler and restore after processing callback call:
```
        Signals.installSignals(() -> {
            // initialize crash reporters here
            Fabric.with(Crashlytics.class);
        }, true);
```