### PR TITLE
reverting linker warnings

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -330,7 +330,8 @@ public class IOSTarget extends AbstractTarget {
         }
         if (isDeviceArch(arch)) {
             ccArgs.add("-miphoneos-version-min=" + minVersion);
-            if (config.isDebug()) {
+            // arm64 is always PIE, ref: https://opensource.apple.com/source/ld64/ld64-274.2/src/ld/Options.cpp.auto.html
+            if (config.isDebug() && config.getArch() != Arch.arm64) {
                 ccArgs.add("-Wl,-no_pie");
             }
         } else {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/util/ToolchainUtil.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/util/ToolchainUtil.java
@@ -388,11 +388,6 @@ public class ToolchainUtil {
             for (File objectsFile : objectsFiles) {
                 opts.add("-Wl,-filelist," + objectsFile.getAbsolutePath());
             }
-            /*
-             * See #123, ignore ld: warning: pointer not aligned at address [infostruct] message with Xcode 8.3
-             * unless we find a better solution
-             */
-            opts.add("-w");
         } else {
             opts.add(config.getArch().is32Bit() ? "-m32" : "-m64");
             for (File objectsFile : objectsFiles) {


### PR DESCRIPTION
Seems #123 is not reproduced with xcode10 anymore. 
Also removed linker's -no_pie on arm64 as it has no affect and produces warning

Warnings are important as there are useful info like: 
> [WARNING] 13:30:28.364 ld: warning: object file (Crashlytics.framework/Crashlytics(CLSBetaToken.o)) was built for newer iOS version (8.0) than being linked (7.0)