### PR TITLE
fixed "no simulators" problem simctrl returns version as com.apple.CoreSimulator.SimRuntime.iOS-X-Y

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/DeviceType.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/DeviceType.java
@@ -39,6 +39,7 @@ import org.robovm.compiler.util.Executor;
  */
 public class DeviceType implements Comparable<DeviceType> {
     public static final String PREFIX = "com.apple.CoreSimulator.SimDeviceType.";
+    public static final String IOS_VERSION_PREFIX = "com.apple.CoreSimulator.SimRuntime.iOS-";
     public static final String PREFERRED_IPHONE_SIM_NAME = "iPhone 6";
     public static final String PREFERRED_IPAD_SIM_NAME = "iPad Air";
     
@@ -120,7 +121,16 @@ public class DeviceType implements Comparable<DeviceType> {
             Iterator iter=deviceList.entrySet().iterator();
             while(iter.hasNext()){
     			Map.Entry entry=(Map.Entry)iter.next();
-    			String sdkMapKey = entry.getKey().toString().replace("iOS ","");
+    			String sdkMapKey = entry.getKey().toString();
+    			if (sdkMapKey.startsWith(IOS_VERSION_PREFIX)) {
+    			    // com.apple.CoreSimulator.SimRuntime.iOS-
+                    sdkMapKey = sdkMapKey.replace(IOS_VERSION_PREFIX, "").replace('-', '.');
+                } else if (sdkMapKey.startsWith("iOS ")) {
+                    sdkMapKey = sdkMapKey.replace("iOS ","");
+                } else {
+    			    // not iOS
+    			    continue;
+                }
     			JSONArray devices = (JSONArray) entry.getValue();
     			for (Object obj : devices) {
     				JSONObject device = (JSONObject) obj;

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/DeviceType.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/DeviceType.java
@@ -135,9 +135,17 @@ public class DeviceType implements Comparable<DeviceType> {
     			for (Object obj : devices) {
     				JSONObject device = (JSONObject) obj;
     				SDK sdk = sdkMap.get(sdkMapKey);
-    				final String deviceName = device.get("name").toString();
-    				
-    				if (!device.get("availability").toString().contains("unavailable") && sdk != null) {
+    				boolean isAvailable = false;
+    				if (sdk != null) {
+    				    if (device.containsKey("isAvailable")) {
+    				        Object o = device.get("isAvailable");
+                            isAvailable = o instanceof Boolean ? (Boolean) o : "true".equals(o.toString());
+                        } else if (device.containsKey("availability"))
+                            isAvailable = !device.get("availability").toString().contains("unavailable");
+                    }
+
+    				if (isAvailable) {
+                        final String deviceName = device.get("name").toString();
     					Set<Arch> archs = new HashSet<>();
     					archs.add(Arch.x86);
     					if (!Arrays.asList(ONLY_32BIT_DEVICES).contains(deviceName)) {


### PR DESCRIPTION
added handling of case when `xcrun simctl list devices -j` returns simulator version in form of `com.apple.CoreSimulator.SimRuntime.iOS-12-2` instead of expected `iOS 12.2`. This happen when two xcode is installed same time. also skips not iOS targets

this hit me when I had both XCode10.1 and XCode10.2beta3 installed