### PR TITLE
* fixed #364.

### DIFF
--- a/compiler/vm/core/src/signal.c
+++ b/compiler/vm/core/src/signal.c
@@ -230,6 +230,10 @@ void* rvmSaveSignals(Env* env) {
         rvmThrowOutOfMemoryError(env);
         return NULL;
     }
+
+    // actually save
+    sigaction(BLOCKED_THREAD_SIGNAL, NULL, &state->blockedThreadSignal);
+
     return state;
 }
 


### PR DESCRIPTION
block_thread_signal was no stored in save cycle and was reset to null in restore.