### PR TITLE
makes arm64 default target for launchIOSDevice

### DIFF
--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/IOSDeviceTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/IOSDeviceTask.java
@@ -33,9 +33,9 @@ public class IOSDeviceTask extends AbstractRoboVMTask {
     @Override
     public void invoke() {
         try {
-            Arch arch = Arch.thumbv7;
-            if (extension.getArch() != null && extension.getArch().equals(Arch.arm64.toString())) {
-                arch = Arch.arm64;
+            Arch arch = Arch.arm64;
+            if (extension.getArch() != null && extension.getArch().equals(Arch.thumbv7.toString())) {
+                arch = Arch.thumbv7;
             }
 
             AppCompiler compiler = build(OS.ios, arch, IOSTarget.TYPE);


### PR DESCRIPTION
thumbv7 was default, but this not an options for ios11+ and makes not sense now. to use  thumbv7 it has to specified as parameter `-Probovm.arch=thumbv7`
