### PR TITLE
fixed #373: wrong marshaller

### DIFF
--- a/compiler/cocoatouch/src/main/bro-gen/coremidi.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/coremidi.yaml
@@ -28,12 +28,12 @@ private_typedefs:
     CFPropertyListRef: CFPropertyList
     
 enums:
-    MIDINetworkConnectionPolicy: { first: MIDINetworkConnectionPolicy_NoOne, marshaler: ValuedEnum.AsMachineSizedUIntMarshaler }
+    MIDINetworkConnectionPolicy: { marshaler: ValuedEnum.AsMachineSizedUIntMarshaler }
     MIDIError: { first: kMIDIInvalidClient }
-    MIDIObjectType: { first: kMIDIObjectType_Other, marshaler: ValuedEnum.AsMachineSizedSIntMarshaler, ignore: ExternalMask }
-    MIDINotificationMessageID: { first: kMIDIMsgSetupChanged, marshaler: ValuedEnum.AsMachineSizedSIntMarshaler }
-    MIDITransformType: { first: kMIDITransform_None, marshaler: ValuedEnum.AsMachineSizedUIntMarshaler }
-    MIDITransformControlType: { first: kMIDIControlType_7Bit, marshaler: ValuedEnum.AsMachineSizedUIntMarshaler }
+    MIDIObjectType: { marshaler: ValuedEnum.AsSignedIntMarshaler }
+    MIDINotificationMessageID: { marshaler: ValuedEnum.AsSignedIntMarshaler }
+    MIDITransformType: { marshaler: ValuedEnum.AsUnsignedShortMarshaler }
+    MIDITransformControlType: { marshaler: ValuedEnum.AsUnsignedByteMarshaler }
         
 classes:
     MIDINetworkConnection: # DONE

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDINotificationMessageID.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDINotificationMessageID.java
@@ -34,7 +34,7 @@ import org.robovm.apple.corefoundation.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
+/*<annotations>*/@Marshaler(ValuedEnum.AsSignedIntMarshaler.class)/*</annotations>*/
 public enum /*<name>*/MIDINotificationMessageID/*</name>*/ implements ValuedEnum {
     /*<values>*/
     SetupChanged(1L),

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDIObjectType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDIObjectType.java
@@ -34,7 +34,7 @@ import org.robovm.apple.corefoundation.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
+/*<annotations>*/@Marshaler(ValuedEnum.AsSignedIntMarshaler.class)/*</annotations>*/
 public enum /*<name>*/MIDIObjectType/*</name>*/ implements ValuedEnum {
     /*<values>*/
     Other(-1L),

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDITransformControlType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDITransformControlType.java
@@ -34,7 +34,7 @@ import org.robovm.apple.corefoundation.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedUIntMarshaler.class)/*</annotations>*/
+/*<annotations>*/@Marshaler(ValuedEnum.AsUnsignedByteMarshaler.class)/*</annotations>*/
 public enum /*<name>*/MIDITransformControlType/*</name>*/ implements ValuedEnum {
     /*<values>*/
     _7Bit(0L),

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDITransformType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDITransformType.java
@@ -34,7 +34,7 @@ import org.robovm.apple.corefoundation.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedUIntMarshaler.class)/*</annotations>*/
+/*<annotations>*/@Marshaler(ValuedEnum.AsUnsignedShortMarshaler.class)/*</annotations>*/
 public enum /*<name>*/MIDITransformType/*</name>*/ implements ValuedEnum {
     /*<values>*/
     None(0L),


### PR DESCRIPTION
issue happened as enum value was assigned wrong marshalers for sint32 types. `ValuedEnum.AsMachineSizedSIntMarshaler` corresponds to NSInteger data type which is 32bit wide on 32 bit system, but 64 on 64 bit one. 
But  sint32 is defined as:
```
#if __LP64__
typedef signed int                      SInt32;
#else
typedef signed long                     SInt32;
#endif
```

And it is typedef to int (32 bit wide) on `LP64`( 64 bit macos/ios), and long (32 bit wide) on `ILP32`(32 bit iOS) . here [are details]

Proper marshaller is `AsSignedIntMarshaler` in this case. 