### PR TITLE
Fixes to eclipse plugin pom.xml

### DIFF
--- a/plugins/eclipse/pom.xml
+++ b/plugins/eclipse/pom.xml
@@ -94,7 +94,7 @@
           <target>1.6</target>
           <debug>true</debug>
           <optimize>true</optimize>
-          <showDeprecations>true</showDeprecations>
+          <showDeprecation>true</showDeprecation>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>

--- a/plugins/eclipse/ui/pom.xml
+++ b/plugins/eclipse/ui/pom.xml
@@ -12,10 +12,6 @@
   <name>RoboVM for Eclipse Core and UI</name>
   <packaging>eclipse-plugin</packaging>
 
-  <properties>
-    <robovm.version>2.3.6-SNAPSHOT</robovm.version>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -26,19 +22,19 @@
       <dependency>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robovm-dist-compiler</artifactId>
-        <version>${robovm.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robovm-dist</artifactId>
-        <version>${robovm.version}</version>
+        <version>${project.version}</version>
         <classifier>nocompiler</classifier>
         <type>tar.gz</type>
       </dependency>
       <dependency>
       	<groupId>com.mobidevelop.robovm</groupId>
             <artifactId>robovm-debugger</artifactId>
-            <version>${robovm.version}</version>
+            <version>${project.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.mobidevelop.robovm</groupId>
@@ -49,12 +45,12 @@
       <dependency>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robovm-templater</artifactId>
-        <version>${robovm.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robovm-ibxcode</artifactId>
-        <version>${robovm.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.bcel</groupId> <!-- required for ibxcode -->


### PR DESCRIPTION
The reference to 2.3.6-SNAPSHOT in one of the Eclipse pom.xml stored in a variable has been replaced by `project.version` to avoid missing it again in the future.
