### PR TITLE
support for packed structs

### DIFF
--- a/compiler/cocoatouch/src/main/bro-gen/audiotoolbox.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/audiotoolbox.yaml
@@ -233,12 +233,15 @@ classes:
 
     # Structs
     AURecordedParameterEvent: {}
-    AUMIDIEvent: {}
+    AUMIDIEvent:
+        annotations: ['@Packed(4)']
     AUMIDIOutputCallbackStruct: {}
     AUParameterAutomationEvent: {}
-    AUParameterEvent: {}
+    AUParameterEvent:
+        annotations: ['@Packed(4)']
     AURenderEvent: {}
-    AURenderEventHeader: {}
+    AURenderEventHeader:
+        annotations: ['@Packed(4)']
     AUSamplerBankPresetData: {}
     AudioUnitParameterEvent: {}
     AudioUnitParameterEvent$InnerStruct$1:
@@ -699,6 +702,7 @@ classes:
         extends: AudioComponentInstance
 
     AudioComponentDescription: # DONE
+        annotations: ['@Packed(4)']
         componentType:
             type: AUType
         componentSubType:

--- a/compiler/cocoatouch/src/main/bro-gen/coremedia.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/coremedia.yaml
@@ -133,8 +133,10 @@ classes:
         extends: CFType
 
     # Structs
-    CMBlockBufferCustomBlockSource: {}
+    CMBlockBufferCustomBlockSource:
+        annotations: ['@Packed(4)']
     CMBufferCallbacks:
+        annotations: ['@Packed(4)']
         name: CMBufferCallbacksStruct
         refcon:
             type: '@Pointer long'
@@ -142,12 +144,17 @@ classes:
     CMBufferQueueTriggerToken: {}
     opaqueCMBufferQueueTriggerToken:
         name: CMBufferQueueTriggerToken
-    CMVideoDimensions: {}
-    CMSampleTimingInfo: {}
+    CMVideoDimensions:
+        annotations: ['@Packed(4)']
+    CMSampleTimingInfo:
+        annotations: ['@Packed(4)']
     CMTime:
+        annotations: ['@Packed(4)']
         add_ptr: true
-    CMTimeRange: {}
-    CMTimeMapping: {}
+    CMTimeRange:
+        annotations: ['@Packed(4)']
+    CMTimeMapping:
+        annotations: ['@Packed(4)']
     CMBufferHandlers: {}
 
 protocols: {}

--- a/compiler/cocoatouch/src/main/bro-gen/coremidi.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/coremidi.yaml
@@ -145,10 +145,12 @@ classes:
 
         # Structs
     MIDIPacketList:
+        annotations: ['@Packed(4)']
         skip_def_constructor: true
     MIDISysexSendRequest: {}
     MIDINotification: {}
-    MIDIPacket: {}
+    MIDIPacket:
+        annotations: ['@Packed(4)']
     MIDIObjectAddRemoveNotification: {}
     MIDIObjectPropertyChangeNotification: {}
     MIDIIOErrorNotification: {}

--- a/compiler/cocoatouch/src/main/bro-gen/coreservices.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/coreservices.yaml
@@ -39,6 +39,7 @@ classes:
         name: CFHost
         extends: CFType
     CFHostClientContext:
+        annotations: ['@Packed(2)']
         visibility: ''
         info:
             type: '@Pointer long'
@@ -55,6 +56,7 @@ classes:
         name: CFNetService
         extends: CFType
     CFNetServiceClientContext:
+        annotations: ['@Packed(2)']
         visibility: ''
         info:
             type: '@Pointer long'

--- a/compiler/cocoatouch/src/main/bro-gen/gamecontroller.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/gamecontroller.yaml
@@ -18,9 +18,12 @@ classes:
     GCEulerAngles: {}
     GCRotationRate: {}
     GCQuaternion: {}
-    GCMicroGamepadSnapShotDataV100: {}
-    GCExtendedGamepadSnapshotData: {}
-    GCMicroGamepadSnapshotData: {}
+    GCMicroGamepadSnapShotDataV100:
+        annotations: ['@Packed(1)']
+    GCExtendedGamepadSnapshotData:
+        annotations: ['@Packed(1)']
+    GCMicroGamepadSnapshotData:
+        annotations: ['@Packed(1)']
 
     GCController: # DONE
         methods:
@@ -61,7 +64,8 @@ classes:
         methods:
             '-init.*':
                 name: init
-    GCGamepadSnapShotDataV100: {} # DONE
+    GCGamepadSnapShotDataV100:
+        annotations: ['@Packed(1)']
     GCMotion: # DONE
         properties:
             'valueChangedHandler':

--- a/compiler/cocoatouch/src/main/bro-gen/mediatoolbox.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/mediatoolbox.yaml
@@ -23,6 +23,7 @@ classes:
 
     # Structs
     MTAudioProcessingTapCallbacks:
+        annotations: ['@Packed(4)']
         name: MTAudioProcessingTapCallbacksStruct
         visibility: ''
         finalize:

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/audiotoolbox/AUMIDIEvent.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/audiotoolbox/AUMIDIEvent.java
@@ -38,7 +38,7 @@ import org.robovm.apple.uikit.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*//*</annotations>*/
+/*<annotations>*/@Packed(4)/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/AUMIDIEvent/*</name>*/ 
     extends /*<extends>*/Struct<AUMIDIEvent>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/audiotoolbox/AUParameterEvent.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/audiotoolbox/AUParameterEvent.java
@@ -38,7 +38,7 @@ import org.robovm.apple.uikit.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*//*</annotations>*/
+/*<annotations>*/@Packed(4)/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/AUParameterEvent/*</name>*/ 
     extends /*<extends>*/Struct<AUParameterEvent>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/audiotoolbox/AURenderEventHeader.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/audiotoolbox/AURenderEventHeader.java
@@ -38,7 +38,7 @@ import org.robovm.apple.uikit.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*//*</annotations>*/
+/*<annotations>*/@Packed(4)/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/AURenderEventHeader/*</name>*/ 
     extends /*<extends>*/Struct<AURenderEventHeader>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/audiotoolbox/AudioComponentDescription.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/audiotoolbox/AudioComponentDescription.java
@@ -38,7 +38,7 @@ import org.robovm.apple.uikit.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*//*</annotations>*/
+/*<annotations>*/@Packed(4)/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/AudioComponentDescription/*</name>*/ 
     extends /*<extends>*/Struct<AudioComponentDescription>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMBlockBufferCustomBlockSource.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMBlockBufferCustomBlockSource.java
@@ -39,7 +39,7 @@ import org.robovm.apple.audiotoolbox.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*//*</annotations>*/
+/*<annotations>*/@Packed(4)/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CMBlockBufferCustomBlockSource/*</name>*/ 
     extends /*<extends>*/Struct<CMBlockBufferCustomBlockSource>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMBufferCallbacksStruct.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMBufferCallbacksStruct.java
@@ -39,7 +39,7 @@ import org.robovm.apple.audiotoolbox.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*//*</annotations>*/
+/*<annotations>*/@Packed(4)/*</annotations>*/
 /*<visibility>*//*</visibility>*/ class /*<name>*/CMBufferCallbacksStruct/*</name>*/ 
     extends /*<extends>*/Struct<CMBufferCallbacksStruct>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMSampleTimingInfo.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMSampleTimingInfo.java
@@ -39,7 +39,7 @@ import org.robovm.apple.audiotoolbox.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*/@Library("CoreMedia")/*</annotations>*/
+/*<annotations>*/@Packed(4) @Library("CoreMedia")/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CMSampleTimingInfo/*</name>*/ 
     extends /*<extends>*/Struct<CMSampleTimingInfo>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMTime.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMTime.java
@@ -39,7 +39,7 @@ import org.robovm.apple.audiotoolbox.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*/@Library("CoreMedia")/*</annotations>*/
+/*<annotations>*/@Packed(4) @Library("CoreMedia")/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CMTime/*</name>*/ 
     extends /*<extends>*/Struct<CMTime>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMTimeMapping.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMTimeMapping.java
@@ -39,7 +39,7 @@ import org.robovm.apple.audiotoolbox.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*//*</annotations>*/
+/*<annotations>*/@Packed(4)/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CMTimeMapping/*</name>*/ 
     extends /*<extends>*/Struct<CMTimeMapping>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMTimeRange.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMTimeRange.java
@@ -39,7 +39,7 @@ import org.robovm.apple.audiotoolbox.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*/@Library("CoreMedia")/*</annotations>*/
+/*<annotations>*/@Packed(4) @Library("CoreMedia")/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CMTimeRange/*</name>*/ 
     extends /*<extends>*/Struct<CMTimeRange>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMVideoDimensions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMVideoDimensions.java
@@ -39,7 +39,7 @@ import org.robovm.apple.audiotoolbox.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*//*</annotations>*/
+/*<annotations>*/@Packed(4)/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CMVideoDimensions/*</name>*/ 
     extends /*<extends>*/Struct<CMVideoDimensions>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDIPacket.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDIPacket.java
@@ -34,7 +34,7 @@ import org.robovm.apple.corefoundation.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*//*</annotations>*/
+/*<annotations>*/@Packed(4)/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/MIDIPacket/*</name>*/ 
     extends /*<extends>*/Struct<MIDIPacket>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDIPacketList.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDIPacketList.java
@@ -34,7 +34,7 @@ import org.robovm.apple.corefoundation.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*/@Library("CoreMIDI")/*</annotations>*/
+/*<annotations>*/@Packed(4) @Library("CoreMIDI")/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/MIDIPacketList/*</name>*/ 
     extends /*<extends>*/Struct<MIDIPacketList>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreservices/CFHostClientContext.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreservices/CFHostClientContext.java
@@ -34,7 +34,7 @@ import org.robovm.apple.corefoundation.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*//*</annotations>*/
+/*<annotations>*/@Packed(2)/*</annotations>*/
 /*<visibility>*//*</visibility>*/ class /*<name>*/CFHostClientContext/*</name>*/ 
     extends /*<extends>*/Struct<CFHostClientContext>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreservices/CFNetServiceClientContext.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreservices/CFNetServiceClientContext.java
@@ -34,7 +34,7 @@ import org.robovm.apple.corefoundation.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*//*</annotations>*/
+/*<annotations>*/@Packed(2)/*</annotations>*/
 /*<visibility>*//*</visibility>*/ class /*<name>*/CFNetServiceClientContext/*</name>*/ 
     extends /*<extends>*/Struct<CFNetServiceClientContext>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/gamecontroller/GCExtendedGamepadSnapshotData.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/gamecontroller/GCExtendedGamepadSnapshotData.java
@@ -35,7 +35,7 @@ import org.robovm.apple.uikit.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*//*</annotations>*/
+/*<annotations>*/@Packed(1)/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/GCExtendedGamepadSnapshotData/*</name>*/ 
     extends /*<extends>*/Struct<GCExtendedGamepadSnapshotData>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/gamecontroller/GCGamepadSnapShotDataV100.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/gamecontroller/GCGamepadSnapShotDataV100.java
@@ -35,7 +35,7 @@ import org.robovm.apple.uikit.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*/@Library("GameController")/*</annotations>*/
+/*<annotations>*/@Packed(1) @Library("GameController")/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/GCGamepadSnapShotDataV100/*</name>*/ 
     extends /*<extends>*/Struct<GCGamepadSnapShotDataV100>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/gamecontroller/GCMicroGamepadSnapShotDataV100.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/gamecontroller/GCMicroGamepadSnapShotDataV100.java
@@ -35,7 +35,7 @@ import org.robovm.apple.uikit.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*/@Library("GameController")/*</annotations>*/
+/*<annotations>*/@Packed(1) @Library("GameController")/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/GCMicroGamepadSnapShotDataV100/*</name>*/ 
     extends /*<extends>*/Struct<GCMicroGamepadSnapShotDataV100>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/gamecontroller/GCMicroGamepadSnapshotData.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/gamecontroller/GCMicroGamepadSnapshotData.java
@@ -35,7 +35,7 @@ import org.robovm.apple.uikit.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*//*</annotations>*/
+/*<annotations>*/@Packed(1)/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/GCMicroGamepadSnapshotData/*</name>*/ 
     extends /*<extends>*/Struct<GCMicroGamepadSnapshotData>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/mediatoolbox/MTAudioProcessingTapCallbacksStruct.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/mediatoolbox/MTAudioProcessingTapCallbacksStruct.java
@@ -37,7 +37,7 @@ import org.robovm.apple.audiotoolbox.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*//*</annotations>*/
+/*<annotations>*/@Packed(4)/*</annotations>*/
 /*<visibility>*//*</visibility>*/ class /*<name>*/MTAudioProcessingTapCallbacksStruct/*</name>*/ 
     extends /*<extends>*/Struct<MTAudioProcessingTapCallbacksStruct>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/Annotations.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/Annotations.java
@@ -48,6 +48,7 @@ public class Annotations {
     public static final String CALLBACK = "Lorg/robovm/rt/bro/annotation/Callback;";
     public static final String STRUCT_MEMBER = "Lorg/robovm/rt/bro/annotation/StructMember;";
     public static final String VECTORISED = "Lorg/robovm/rt/bro/annotation/Vectorised;";
+    public static final String STRUCT_PACKED = "Lorg/robovm/rt/bro/annotation/Packed;";
     public static final String GLOBAL_VALUE = "Lorg/robovm/rt/bro/annotation/GlobalValue;";
     public static final String ARRAY = "Lorg/robovm/rt/bro/annotation/Array;";
     public static final String BASE_TYPE = "Lorg/robovm/rt/bro/annotation/BaseType;";
@@ -306,6 +307,10 @@ public class Annotations {
 
     public static AnnotationTag getStructVectorisedAnnotation(SootClass clazz) {
         return getAnnotation(clazz, VECTORISED);
+    }
+
+    public static AnnotationTag getStructPackedAnnotation(SootClass clazz) {
+        return getAnnotation(clazz, STRUCT_PACKED);
     }
     
     public static AnnotationTag getArrayAnnotation(SootMethod method) {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/BridgeMethodCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/BridgeMethodCompiler.java
@@ -153,7 +153,7 @@ public class BridgeMethodCompiler extends BroMethodCompiler {
         // We order structs by name in reverse order. The names are constructed
         // such that nested structs get names which are naturally ordered after
         // their parent struct.
-        Map<String, String> structs = new TreeMap<String, String>(Collections.reverseOrder());
+        Map<String, String> typedefs = new TreeMap<String, String>(Collections.reverseOrder());
         
         String hiReturnType = returnType instanceof StructureType 
                 ? "void" : getHiType(returnType);
@@ -169,7 +169,7 @@ public class BridgeMethodCompiler extends BroMethodCompiler {
         }
 
         StringBuilder loSignature = new StringBuilder();
-        String loReturnType = getLoType(returnType, name, 0, structs);
+        String loReturnType = getLoType(returnType, name, 0, typedefs);
         loSignature
             .append(loReturnType)
             .append(' ')
@@ -189,7 +189,7 @@ public class BridgeMethodCompiler extends BroMethodCompiler {
             hiSignature.append(hiParamType).append(' ').append(arg);
 
             if (i < loParameterTypes.length) {
-                String loParamType = getLoType(hiParameterTypes[i], name, i + 1, structs);
+                String loParamType = getLoType(hiParameterTypes[i], name, i + 1, typedefs);
                 if (i > 0) {
                     loSignature.append(", ");
                 }
@@ -211,9 +211,9 @@ public class BridgeMethodCompiler extends BroMethodCompiler {
             loSignature.append(", ...");
         }
         loSignature.append(')');
-        
-        for (Entry<String, String> struct : structs.entrySet()) {
-            body.append("    typedef " + struct.getValue() + " " + struct.getKey() + ";\n");
+
+        for (String typedef : typedefs.values()) {
+            body.append(typedef + "\n");
         }
         
         if (returnType instanceof StructureType) {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/BroMethodCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/BroMethodCompiler.java
@@ -677,7 +677,7 @@ public abstract class BroMethodCompiler extends AbstractMethodCompiler {
                 int index = offset + ownMembersOffset;
                 if (result[index] == null) {
                     result[index] = type;
-                } else if (type != result[index]) {
+                } else if (!type.equals(result[index])) {
                     // Two members mapped to the same offset (union). Pick
                     // the type with the largest alignment and pad with bytes
                     // up to the largest size.

--- a/compiler/compiler/src/main/java/org/robovm/compiler/BroMethodCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/BroMethodCompiler.java
@@ -48,6 +48,7 @@ import org.robovm.compiler.llvm.IntegerConstant;
 import org.robovm.compiler.llvm.IntegerType;
 import org.robovm.compiler.llvm.Inttoptr;
 import org.robovm.compiler.llvm.Load;
+import org.robovm.compiler.llvm.PackedStructureType;
 import org.robovm.compiler.llvm.PointerType;
 import org.robovm.compiler.llvm.PrimitiveType;
 import org.robovm.compiler.llvm.Ptrtoint;
@@ -58,6 +59,7 @@ import org.robovm.compiler.llvm.Trunc;
 import org.robovm.compiler.llvm.Type;
 import org.robovm.compiler.llvm.Value;
 import org.robovm.compiler.llvm.Variable;
+import org.robovm.compiler.llvm.VectorStructureType;
 import org.robovm.compiler.llvm.Zext;
 import org.robovm.compiler.trampoline.Invokestatic;
 import org.robovm.compiler.trampoline.LdcClass;
@@ -71,6 +73,7 @@ import soot.RefType;
 import soot.SootClass;
 import soot.SootMethod;
 import soot.VoidType;
+import soot.tagkit.AnnotationIntElem;
 import soot.tagkit.AnnotationTag;
 
 
@@ -570,7 +573,7 @@ public abstract class BroMethodCompiler extends AbstractMethodCompiler {
         for (SootMethod method : clazz.getMethods()) {
             n = Math.max(getStructMemberOffset(method) + 1, n);
         }
-        
+
 
         StructureType superType = null;
         if (clazz.hasSuperclass()) {
@@ -583,7 +586,7 @@ public abstract class BroMethodCompiler extends AbstractMethodCompiler {
         Type[] result;
         int ownMembersOffset = 0;
         if (superType != null) {
-            // if structure inherits another stuct add it as member zero
+            // if structure inherits another struct add it as member zero
             ownMembersOffset = 1;
             result = new Type[n + 1];
             result[0] = superType;
@@ -592,6 +595,28 @@ public abstract class BroMethodCompiler extends AbstractMethodCompiler {
             // added anymore
             result = new Type[n];
         }
+
+        // check for vector/packed annotations
+        AnnotationTag vectorisedAnnotation = getStructVectorisedAnnotation(clazz);
+        AnnotationTag packedAnnotation = getStructPackedAnnotation(clazz);
+        if (vectorisedAnnotation != null && packedAnnotation != null) {
+            throw new IllegalArgumentException("Struct class " + clazz + " cannot have both @Packed and @Vectorized same time");
+        }
+
+        // initial vector validation
+        if (vectorisedAnnotation != null && ownMembersOffset != 0) {
+            throw new IllegalArgumentException("Struct class " + clazz + " cannot inherit struct when annotated @Vectorised");
+        }
+
+        // initial packed struct validation
+        int packedAllign = 0;
+        if (packedAnnotation != null) {
+            packedAllign = ((AnnotationIntElem) packedAnnotation.getElemAt(0)).getValue();
+            if (packedAllign != 1 && packedAllign != 2 && packedAllign != 4) {
+                throw new IllegalArgumentException("Struct class " + clazz + " has wrong @Packed annotation. Only 1,2,4 are allowed");
+            }
+        }
+
 
         for (SootMethod method : clazz.getMethods()) {
             int offset = getStructMemberOffset(method);
@@ -656,6 +681,13 @@ public abstract class BroMethodCompiler extends AbstractMethodCompiler {
                     // Two members mapped to the same offset (union). Pick
                     // the type with the largest alignment and pad with bytes
                     // up to the largest size.
+
+                    // unions are not allowed in vectors and packed structs
+                    if (vectorisedAnnotation != null)
+                        throw new IllegalArgumentException("Duplicate @StructMember(" + index + ") in @Vectorised structs (union in vector is not supported");
+                    if (packedAnnotation != null)
+                        throw new IllegalArgumentException("Duplicate @StructMember(" + index + ") in @Packed structs (union in packed structs is not supported");
+
                     result[index] = mergeStructMemberTypes(config.getDataLayout(), type, result[index]);
                 }
             }
@@ -668,21 +700,33 @@ public abstract class BroMethodCompiler extends AbstractMethodCompiler {
             }
         }
 
+        // fix alignment in packed struct
+        if (packedAnnotation != null && packedAllign != 1 && result.length > 1) {
+            // packed struct, obey alignment parameter and add padding if required
+            int packedStructOffset = 0;
+            for (int i = ownMembersOffset; i < result.length; i++) {
+                Type next = i + 1 < result.length ? result[i + 1] : result[0];
+                result[i] = packStructMemberTypes(config.getDataLayout(), packedAllign, packedStructOffset, result[i], next);
+                packedStructOffset += config.getDataLayout().getStoreSize(result[i]);
+            }
+        }
+
         if (!clazz.isAbstract() && checkEmpty && n == 0 && superType == null) {
             throw new IllegalArgumentException("Struct class " + clazz + " has no @StructMember annotated methods");
         }
 
-        // convert to vector if required
-        AnnotationTag vectorised = getStructVectorisedAnnotation(clazz);
-        if (vectorised != null) {
-            if (ownMembersOffset != 0) {
-                // just stuck to simple case for noe
-                throw new IllegalArgumentException("Struct class " + clazz + " cannot inherit struct when annotated @Vectorised");
-            }
+        if (vectorisedAnnotation != null) {
+            // validate vector
             validateVectorStruct(clazz, result);
         }
 
-        return new StructureType(ownMembersOffset, vectorised != null, result);
+        // create corresponding version of struct
+        if (vectorisedAnnotation != null)
+            return new VectorStructureType(ownMembersOffset, result);
+        else if (packedAnnotation != null && result.length > 1)
+            return new PackedStructureType(ownMembersOffset, packedAllign, result);
+        else
+            return new StructureType(ownMembersOffset, result);
     }
 
     /**
@@ -735,7 +779,28 @@ public abstract class BroMethodCompiler extends AbstractMethodCompiler {
             return result;
         }
     }
-    
+
+    /**
+     * finds out if for given member we have to add padding as another packed struct make provide
+     * proper alignment of next field
+     * @param memberStructOffs -- offset from start of structure, member will start at
+     */
+    static Type packStructMemberTypes(DataLayout dataLayout, int packAlign, int memberStructOffs, Type memberType, Type nextMemberType) {
+        int memberSize = dataLayout.getStoreSize(memberType);
+
+        // if packed structure member is aligned by own align or pack pragma align, what is smaller
+        int nextMemberAlign = Math.min(packAlign, dataLayout.getAlignment(nextMemberType));
+
+        // check if next member gets proper alignment, otherwise add padding
+        int pad = (nextMemberAlign - (memberStructOffs + memberSize) % nextMemberAlign) % nextMemberAlign;
+        if (pad > 0) {
+            // add padding for alignment
+            return new PackedStructureType(memberType, pad == 1 ? I8 : new ArrayType(pad, I8));
+        } else {
+            return memberType;
+        }
+    }
+
     protected static String getHiType(Type type) {
         if (type == Type.VOID) {
             return "void";
@@ -761,32 +826,39 @@ public abstract class BroMethodCompiler extends AbstractMethodCompiler {
         throw new IllegalArgumentException("Cannot convert type " + type + " to C type");
     }
 
-    protected static String getLoType(final Type type, String base, int index, Map<String, String> structs) {
-        if (type instanceof StructureType && ((StructureType)type).isVector()) {
+    protected static String getLoType(final Type type, String base, int index, Map<String, String> typedefs) {
+        final String intend = "    ";
+        if (type instanceof VectorStructureType) {
             String name = String.format("%s_%04d", base, index);
             StringBuilder sb = new StringBuilder();
-            StructureType st = (StructureType) type;
+            VectorStructureType st = (VectorStructureType) type;
             Type t = st.getTypeAt(0);
             if (st.isVectorArray()) {
                 // vector of structs, such as MatrixFloat2x2
-                sb.append("struct { ")
-                        .append(getLoType(t, name, 0, structs))
+                sb.append(intend + "typedef struct { ")
+                        .append(getLoType(t, name, 0, typedefs))
                         .append(" m[").append(st.getTypeCount()).append("];}");
             } else {
                 // vector of primitives such as VectorFloat3
-                sb.append("__attribute__((__ext_vector_type__(")
+                sb.append(intend + "typedef __attribute__((__ext_vector_type__(")
                         .append(st.getTypeCount())
                         .append("))) ")
-                        .append(getLoType(t, name, 0, structs));
+                        .append(getLoType(t, name, 0, typedefs));
             }
 
-            structs.put(name, sb.toString());
+            sb.append(" "  + name + ";");
+            typedefs.put(name, sb.toString());
             return name;
         } else if (type instanceof StructureType) {
             String name = String.format("%s_%04d", base, index);
             StringBuilder sb = new StringBuilder();
             StructureType st = (StructureType) type;
-            sb.append("struct {");
+            if (type instanceof PackedStructureType) {
+                // adding packed pragma
+                String packPragma = String.format(intend +"#pragma pack(push, %d)\n", ((PackedStructureType)st).getAlign());
+                sb.append(packPragma);
+            }
+            sb.append(intend + "typedef struct {");
             for (int i = 0; i < st.getTypeCount(); i++) {
                 Type t = st.getTypeAt(i);
                 // Only support arrays embedded in structs
@@ -796,10 +868,14 @@ public abstract class BroMethodCompiler extends AbstractMethodCompiler {
                     dims.append('[').append(at.getSize()).append(']');
                     t = ((ArrayType) t).getElementType();
                 }
-                sb.append(getLoType(t, name, i, structs)).append(" m" + i).append(dims).append(";");
+                sb.append(getLoType(t, name, i, typedefs)).append(" m" + i).append(dims).append(";");
             }
-            sb.append("}");
-            structs.put(name, sb.toString());
+            sb.append("} " + name + ";");
+            if (type instanceof PackedStructureType) {
+                // adding packed pragma
+                sb.append("\n" + intend + "#pragma pack(pop)");
+            }
+            typedefs.put(name, sb.toString());
             return name;
         } else {
             return getHiType(type);

--- a/compiler/compiler/src/main/java/org/robovm/compiler/CallbackMethodCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/CallbackMethodCompiler.java
@@ -77,7 +77,7 @@ public class CallbackMethodCompiler extends BroMethodCompiler {
         // We order structs by name in reverse order. The names are constructed
         // such that nested structs get names which are naturally ordered after
         // their parent struct.
-        Map<String, String> structs = new TreeMap<String, String>(Collections.reverseOrder());
+        Map<String, String> typedefs = new TreeMap<String, String>(Collections.reverseOrder());
         
         StringBuilder hiSignature = new StringBuilder();
         hiSignature
@@ -87,7 +87,7 @@ public class CallbackMethodCompiler extends BroMethodCompiler {
             .append('(');
 
         StringBuilder loSignature = new StringBuilder();
-        String loReturnType = getLoType(functionType.getReturnType(), name, 0, structs);
+        String loReturnType = getLoType(functionType.getReturnType(), name, 0, typedefs);
         loSignature
             .append(loReturnType)
             .append(' ')
@@ -108,7 +108,7 @@ public class CallbackMethodCompiler extends BroMethodCompiler {
             String hiParamType = getHiType(functionType.getParameterTypes()[i]);
             hiSignature.append(hiParamType);
 
-            String loParamType = getLoType(functionType.getParameterTypes()[i], name, i + 1, structs);
+            String loParamType = getLoType(functionType.getParameterTypes()[i], name, i + 1, typedefs);
             loSignature.append(loParamType).append(' ').append(arg);
 
             if (functionType.getParameterTypes()[i] instanceof StructureType) {
@@ -125,8 +125,8 @@ public class CallbackMethodCompiler extends BroMethodCompiler {
         loSignature.append(')');
         
         StringBuilder header = new StringBuilder();
-        for (Entry<String, String> struct : structs.entrySet()) {
-            header.append("typedef " + struct.getValue() + " " + struct.getKey()  +";\n");
+        for (String typedef : typedefs.values()) {
+            header.append(typedef + "\n");
         }
         header.append(hiSignature + ";\n");
         

--- a/compiler/compiler/src/main/java/org/robovm/compiler/ClassCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/ClassCompiler.java
@@ -132,6 +132,7 @@ import java.util.regex.Pattern;
 
 import static org.robovm.compiler.Annotations.*;
 import static org.robovm.compiler.Functions.*;
+import static org.robovm.compiler.StructMemberMethodCompiler.STRUCT_ATTRIBUTES_METHOD;
 import static org.robovm.compiler.Types.*;
 import static org.robovm.compiler.llvm.Type.*;
 
@@ -825,6 +826,10 @@ public class ClassCompiler {
             sootClass.addMethod(_sizeOf);
             SootMethod sizeOf = new SootMethod("sizeOf", Collections.EMPTY_LIST, IntType.v(), Modifier.PUBLIC | Modifier.STATIC | Modifier.NATIVE);
             sootClass.addMethod(sizeOf);
+
+            // method that will provide meta flags for runtime to help finding out if stret is required
+            SootMethod stretMeta = new SootMethod(STRUCT_ATTRIBUTES_METHOD, Collections.EMPTY_LIST, IntType.v(), Modifier.PUBLIC | Modifier.STATIC | Modifier.NATIVE);
+            sootClass.addMethod(stretMeta);
         }
         
         mb.addInclude(getClass().getClassLoader().getResource(String.format("header-%s-%s.ll", config.getOs().getFamily(), config.getArch())));
@@ -865,7 +870,7 @@ public class ClassCompiler {
             } else if (hasGlobalValueAnnotation(method)) {
                 function = globalValueMethod(method);
             } else if (isStruct(sootClass) && ("_sizeOf".equals(name) 
-                        || "sizeOf".equals(name) || hasStructMemberAnnotation(method))) {
+                        || "sizeOf".equals(name) || STRUCT_ATTRIBUTES_METHOD.equals(name) || hasStructMemberAnnotation(method))) {
                 function = structMember(method);
             } else if (method.isNative()) {
                 function = nativeMethod(method);

--- a/compiler/compiler/src/main/java/org/robovm/compiler/StructMemberMethodCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/StructMemberMethodCompiler.java
@@ -106,7 +106,7 @@ public class StructMemberMethodCompiler extends BroMethodCompiler {
                 if (packedMember.getTypeCount() != 2 || !packedMember.getTypeAt(0).equals(memberType)) {
                     throw new IllegalArgumentException("Internal error: method and struct member type missmatch. " + method);
                 }
-                function.add(new Getelementptr(tmp, handlePtr.ref(), 0, 0, offset));
+                function.add(new Getelementptr(tmp, handlePtr.ref(), 0, offset));
             } else if (structType instanceof VectorStructureType && ((VectorStructureType) structType).isVectorArray()) {
                 // vector array struct represent following IR object
                 // MatrixFloat2x2 for example { [2 x <2 x float>] }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/StructMemberMethodCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/StructMemberMethodCompiler.java
@@ -27,6 +27,7 @@ import org.robovm.compiler.config.Config;
 import org.robovm.compiler.llvm.Bitcast;
 import org.robovm.compiler.llvm.Function;
 import org.robovm.compiler.llvm.Getelementptr;
+import org.robovm.compiler.llvm.IntegerConstant;
 import org.robovm.compiler.llvm.Inttoptr;
 import org.robovm.compiler.llvm.Load;
 import org.robovm.compiler.llvm.PackedStructureType;
@@ -47,7 +48,7 @@ import soot.VoidType;
  *
  */
 public class StructMemberMethodCompiler extends BroMethodCompiler {
-
+    public static final String STRUCT_ATTRIBUTES_METHOD = "$attr$stretMetadata";
     private StructureType structType;
 
     public StructMemberMethodCompiler(Config config) {
@@ -67,15 +68,24 @@ public class StructMemberMethodCompiler extends BroMethodCompiler {
     protected Function doCompile(ModuleBuilder moduleBuilder, SootMethod method) {
         if ("_sizeOf".equals(method.getName()) || "sizeOf".equals(method.getName())) {
             return structSizeOf(moduleBuilder, method);
+        } else if (STRUCT_ATTRIBUTES_METHOD.equals(method.getName())) {
+            return stretMeta(moduleBuilder, method);
         } else {
             return structMember(moduleBuilder, method);
         }
     }
-    
+
     private Function structSizeOf(ModuleBuilder moduleBuilder, SootMethod method) {
         Function fn = createMethodFunction(method);
         moduleBuilder.addFunction(fn);
         fn.add(new Ret(sizeof(structType)));
+        return fn;
+    }
+
+    private Function stretMeta(ModuleBuilder moduleBuilder, SootMethod method) {
+        Function fn = createMethodFunction(method);
+        moduleBuilder.addFunction(fn);
+        fn.add(new Ret(new IntegerConstant(structType.getAttributes())));
         return fn;
     }
 

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/DataLayout.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/DataLayout.java
@@ -43,17 +43,19 @@ public class DataLayout {
             String definition;
             if (type instanceof PrimitiveType) {
                 definition = "{" + ((PrimitiveType) type).getName() + "}";
-            } else if (type instanceof StructureType) {
+            } else if (type instanceof VectorStructureType) {
                 // if it is vector of primitive (E.g. VectorFloat2) it will return
                 // <2 x float> like definition  and it will not go to
                 // LLVM types that will cause a crash later, so wrap it into struct
                 // And if it is vector of another structs (E.g. MatrixFloat2x2) it
                 // will be wrapped into struct and nothing to be done
-                StructureType st = (StructureType) type;
-                if (st.isVector() && !st.isVectorArray())
+                VectorStructureType st = (VectorStructureType) type;
+                if (!st.isVectorArray())
                     definition = "{" + ((StructureType) type).getDefinition() + "}";
                 else
                     definition = ((StructureType) type).getDefinition();
+            } else if (type instanceof StructureType) {
+                definition = ((StructureType) type).getDefinition();
             } else {
                 definition = "{" + ((UserType) type).getDefinition() + "}";
             }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/PackedStructureType.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/PackedStructureType.java
@@ -25,13 +25,14 @@ package org.robovm.compiler.llvm;
 public class PackedStructureType extends StructureType {
     private final int align;
 
-    public PackedStructureType(int ownMembersOffset, int align, Type... types) {
-        super(ownMembersOffset, types);
+    public PackedStructureType(int ownMembersOffset, int attributes, int align, Type... types) {
+        super(ownMembersOffset, attributes, types);
         this.align = align;
     }
 
     public PackedStructureType(Type ... types) {
-        this(0, 1, types);
+        super(types);
+        align = 1;
     }
 
 

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/PackedStructureType.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/PackedStructureType.java
@@ -23,17 +23,29 @@ package org.robovm.compiler.llvm;
  * @version $Id$
  */
 public class PackedStructureType extends StructureType {
-    
-    public PackedStructureType(Type ... types) {
-        super(types);
+    private final int align;
+
+    public PackedStructureType(int ownMembersOffset, int align, Type... types) {
+        super(ownMembersOffset, types);
+        this.align = align;
     }
-    
+
+    public PackedStructureType(Type ... types) {
+        this(0, 1, types);
+    }
+
+
     public PackedStructureType(String alias, Type ... types) {
         super(alias, types);
+        align = 1;
     }
 
     @Override
     public String getDefinition() {
         return "<" + super.getDefinition() + ">";
+    }
+
+    public int getAlign() {
+        return align;
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/StructureType.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/StructureType.java
@@ -27,20 +27,30 @@ public class StructureType extends AggregateType {
     protected final Type[] types;
     private final int ownMembersOffset; // 1 if inherit another struct, zero otherwise
 
-    public StructureType(int ownMembersOffset, Type ... types) {
+    // attributes, to help runtime solving stret case
+    private final int attributes; // bitmask
+    public final static int ATTR_UNALIGNED             = 1 << 0; // contains at least one field that is not aligned to its nature alignment
+    public final static int ATTR_NOT_SINGLE_INT_STRUCT = 1 << 1; // indicates that structure is not one integer field wrap (up to 32 bit one)
+
+    public StructureType(int ownMembersOffset, int flags, Type ... types) {
         this.types = types.clone();
         this.ownMembersOffset = ownMembersOffset;
+        this.attributes = flags;
+    }
+
+    public StructureType(int ownMembersOffset, int flags, String alias, Type ... types) {
+        super(alias);
+        this.types = types.clone();
+        this.ownMembersOffset = ownMembersOffset;
+        this.attributes = flags;
     }
 
     public StructureType(Type ... types) {
-        this.types = types.clone();
-        ownMembersOffset = 0;
+        this(0, 0, types);
     }
     
     public StructureType(String alias, Type ... types) {
-        super(alias);
-        this.types = types.clone();
-        ownMembersOffset = 0;
+        this(0, 0, alias, types);
     }
 
     @Override
@@ -98,5 +108,9 @@ public class StructureType extends AggregateType {
             return false;
         }
         return true;
+    }
+
+    public int getAttributes() {
+        return attributes;
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/StructureType.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/StructureType.java
@@ -24,33 +24,23 @@ import java.util.Arrays;
  * @version $Id$
  */
 public class StructureType extends AggregateType {
-    private final Type[] types;
+    protected final Type[] types;
     private final int ownMembersOffset; // 1 if inherit another struct, zero otherwise
-    private final boolean isVector;
 
     public StructureType(int ownMembersOffset, Type ... types) {
         this.types = types.clone();
         this.ownMembersOffset = ownMembersOffset;
-        isVector = false;
-    }
-
-    public StructureType(int ownMembersOffset, boolean vector, Type ... types) {
-        this.types = types.clone();
-        this.ownMembersOffset = ownMembersOffset;
-        isVector = vector;
     }
 
     public StructureType(Type ... types) {
         this.types = types.clone();
         ownMembersOffset = 0;
-        isVector = false;
     }
     
     public StructureType(String alias, Type ... types) {
         super(alias);
         this.types = types.clone();
         ownMembersOffset = 0;
-        isVector = false;
     }
 
     @Override
@@ -71,40 +61,17 @@ public class StructureType extends AggregateType {
         return ownMembersOffset;
     }
 
-    public boolean isVector() {
-        return isVector;
-    }
-
-    /**
-     * @return true if vector consists of another vector structs (not primitives)\
-     * and will be translated into stuct of array of primitive vector
-     * example is MatrixFloat2x2
-     */
-    public boolean isVectorArray() {
-        return isVector && types[0] instanceof StructureType;
-    }
-
     @Override
     public String getDefinition() {
-        if (isVector && types.length > 0) {
-            if (types[0] instanceof StructureType) {
-                // return as struct that contains array
-                StructureType st = (StructureType) types[0];
-                return "{ [" + types.length + " x " + st.getDefinition() + "] }";
-            } else {
-                return "<" + types.length + " x " + types[0].toString() + ">";
+        StringBuilder sb = new StringBuilder("{");
+        for (int i = 0; i < types.length; i++) {
+            if (i > 0) {
+                sb.append(", ");
             }
-        } else {
-            StringBuilder sb = new StringBuilder("{");
-            for (int i = 0; i < types.length; i++) {
-                if (i > 0) {
-                    sb.append(", ");
-                }
-                sb.append(types[i].toString());
-            }
-            sb.append("}");
-            return sb.toString();
+            sb.append(types[i].toString());
         }
+        sb.append("}");
+        return sb.toString();
     }
 
     @Override
@@ -127,7 +94,7 @@ public class StructureType extends AggregateType {
             return false;
         }
         StructureType other = (StructureType) obj;
-        if (!Arrays.equals(types, other.types) || isVector != other.isVector) {
+        if (!Arrays.equals(types, other.types)) {
             return false;
         }
         return true;

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/VectorStructureType.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/VectorStructureType.java
@@ -25,7 +25,7 @@ package org.robovm.compiler.llvm;
 public class VectorStructureType extends StructureType {
 
     public VectorStructureType(int ownMembersOffset, Type ... types) {
-        super(ownMembersOffset, types);
+        super(ownMembersOffset, 0, types);
     }
 
     public VectorStructureType(Type ... types) {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/VectorStructureType.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/VectorStructureType.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2012 RoboVM AB
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/gpl-2.0.html>.
+ */
+package org.robovm.compiler.llvm;
+
+
+
+/**
+ *
+ * @version $Id$
+ */
+public class VectorStructureType extends StructureType {
+
+    public VectorStructureType(int ownMembersOffset, Type ... types) {
+        super(ownMembersOffset, types);
+    }
+
+    public VectorStructureType(Type ... types) {
+        super(types);
+    }
+
+    public VectorStructureType(String alias, Type ... types) {
+        super(alias, types);
+    }
+
+    /**
+     * @return true if vector consists of another vector structs (not primitives)\
+     * and will be translated into stuct of array of primitive vector
+     * example is MatrixFloat2x2
+     */
+    public boolean isVectorArray() {
+        return types[0] instanceof StructureType;
+    }
+
+
+    @Override
+    public String getDefinition() {
+        if (types[0] instanceof StructureType) {
+            // return as struct that contains array
+            StructureType st = (StructureType) types[0];
+            return "{ [" + types.length + " x " + st.getDefinition() + "] }";
+        } else {
+            return "<" + types.length + " x " + types[0].toString() + ">";
+        }
+    }
+}

--- a/compiler/compiler/src/test/java/org/robovm/compiler/BridgeMethodCompilerTest.java
+++ b/compiler/compiler/src/test/java/org/robovm/compiler/BridgeMethodCompilerTest.java
@@ -239,7 +239,7 @@ public class BridgeMethodCompilerTest {
     @Test
     public void testCreateBridgeCWrapperPackedStructByVal() {
         FunctionType functionType = new FunctionType(
-                VOID, new PackedStructureType(0, 1, I32));
+                VOID, new PackedStructureType(0, 0, 1, I32));
         assertEquals(
                 "void f(void* target, void* p0) {\n" +
                         "    #pragma pack(push, 1)\n" +

--- a/compiler/compiler/src/test/java/org/robovm/compiler/BridgeMethodCompilerTest.java
+++ b/compiler/compiler/src/test/java/org/robovm/compiler/BridgeMethodCompilerTest.java
@@ -210,7 +210,7 @@ public class BridgeMethodCompilerTest {
     @Test
     public void testCreateBridgeCWrapperVectorStructByValReturn() {
         // test for VectorFloat2
-        FunctionType functionType = new FunctionType(new StructureType(0, true, Type.FLOAT, Type.FLOAT));
+        FunctionType functionType = new FunctionType(new VectorStructureType(0, Type.FLOAT, Type.FLOAT));
         assertEquals(
                 "void f(void* target, void* ret) {\n" +
                         "    typedef __attribute__((__ext_vector_type__(2))) float f_0000;\n" +
@@ -223,14 +223,29 @@ public class BridgeMethodCompilerTest {
     public void testCreateBridgeCWrapperVectorArrayStructByValReturn() {
         // test for MatrixFloat2x2
         FunctionType functionType = new FunctionType(
-                new StructureType(0, true,
-                        new StructureType(0, true, Type.FLOAT, Type.FLOAT),
-                        new StructureType(0, true, Type.FLOAT, Type.FLOAT)));
+                new VectorStructureType(0,
+                        new VectorStructureType(0, Type.FLOAT, Type.FLOAT),
+                        new VectorStructureType(0, Type.FLOAT, Type.FLOAT)));
         assertEquals(
                 "void f(void* target, void* ret) {\n" +
                         "    typedef __attribute__((__ext_vector_type__(2))) float f_0000_0000;\n" +
                         "    typedef struct { f_0000_0000 m[2];} f_0000;\n" +
                         "    *((f_0000*)ret) = ((f_0000 (*)(void)) target)();\n" +
+                        "}\n",
+                BridgeMethodCompiler.createBridgeCWrapper(functionType.getReturnType(),
+                        functionType.getParameterTypes(), functionType.getParameterTypes(), "f"));
+    }
+
+    @Test
+    public void testCreateBridgeCWrapperPackedStructByVal() {
+        FunctionType functionType = new FunctionType(
+                VOID, new PackedStructureType(0, 1, I32));
+        assertEquals(
+                "void f(void* target, void* p0) {\n" +
+                        "    #pragma pack(push, 1)\n" +
+                        "    typedef struct {int m0;} f_0001;\n" +
+                        "    #pragma pack(pop)\n" +
+                        "    ((void (*)(f_0001)) target)(*((f_0001*)p0));\n" +
                         "}\n",
                 BridgeMethodCompiler.createBridgeCWrapper(functionType.getReturnType(),
                         functionType.getParameterTypes(), functionType.getParameterTypes(), "f"));

--- a/compiler/compiler/src/test/java/org/robovm/compiler/StructMemberMethodCompilerTest.java
+++ b/compiler/compiler/src/test/java/org/robovm/compiler/StructMemberMethodCompilerTest.java
@@ -1,0 +1,168 @@
+
+package org.robovm.compiler;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.robovm.compiler.clazz.Clazz;
+import org.robovm.compiler.config.Arch;
+import org.robovm.compiler.config.Config;
+import org.robovm.compiler.config.Config.Home;
+import org.robovm.compiler.llvm.StructureType;
+import org.robovm.compiler.log.Logger;
+import org.robovm.rt.bro.Struct;
+import org.robovm.rt.bro.annotation.ByVal;
+import org.robovm.rt.bro.annotation.Packed;
+import org.robovm.rt.bro.annotation.StructMember;
+import org.robovm.rt.bro.annotation.Vectorised;
+import soot.Scene;
+import soot.SootClass;
+import soot.options.Options;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests {@link StructMemberMethodCompiler}.
+ */
+public class StructMemberMethodCompilerTest {
+
+    private static Config config;
+    
+    @BeforeClass
+    public static void initializeSoot() throws IOException {
+        soot.G.reset();
+        Options.v().set_output_format(Options.output_format_jimple);
+        Options.v().set_include_all(true);
+        Options.v().set_print_tags_in_output(true);
+        Options.v().set_allow_phantom_refs(true);
+        Options.v().set_soot_classpath(System.getProperty("sun.boot.class.path") + 
+                ":" + System.getProperty("java.class.path"));
+        Scene.v().loadNecessaryClasses();
+        
+        Config.Builder configBuilder = new Config.Builder();
+        for (String p : System.getProperty("sun.boot.class.path").split(File.pathSeparator)) {
+            configBuilder.addBootClasspathEntry(new File(p));
+        }
+        for (String p : System.getProperty("java.class.path").split(File.pathSeparator)) {
+            configBuilder.addClasspathEntry(new File(p));
+        }
+        configBuilder.skipInstall(true);
+        configBuilder.skipLinking(true);
+        configBuilder.home(new MockHome(new File(System.getProperty("java.io.tmpdir"))));
+        configBuilder.logger(new Logger() {
+            public void warn(String format, Object... args) {
+                System.out.format("WARN: " + format, args);
+                System.out.println();
+            }
+            public void info(String format, Object... args) {
+                System.out.format("INFO: " + format, args);
+                System.out.println();
+            }
+            public void error(String format, Object... args) {
+                System.out.format("ERROR: " + format, args);
+                System.out.println();
+            }
+            public void debug(String format, Object... args) {
+                System.out.format("DEBUG: " + format, args);
+                System.out.println();
+            }
+        });
+        configBuilder.arch(Arch.arm64);
+        config = configBuilder.build();
+    }
+    
+    private Clazz toClazz(Class<?> cls) {
+        return config.getClazzes().load(cls.getName().replace('.', '/'));
+    }
+
+    private SootClass toSootClass(Class<?> cls) {
+        return toClazz(cls).getSootClass();
+    }
+
+    @Test
+    public void testVectoredStructures() {
+        StructMemberMethodCompiler compiler = new StructMemberMethodCompiler(config);
+
+        StructureType vectorized = compiler.getStructType(toSootClass(VectorFloat2.class));
+        assertEquals("<2 x float>", vectorized.getDefinition());
+
+        vectorized = compiler.getStructType(toSootClass(MatrixFloat2x2.class));
+        assertEquals("{<2 x float>, <2 x float>}", vectorized.getDefinition());
+    }
+
+    @Test
+    public void testPackedStructures() {
+        StructMemberMethodCompiler compiler = new StructMemberMethodCompiler(config);
+
+        StructureType packed = compiler.getStructType(toSootClass(PackedLongByte1.class));
+        assertEquals("<{i64, i8}>", packed.getDefinition());
+        assertEquals(config.getDataLayout().getStoreSize(packed), 9);
+
+        packed = compiler.getStructType(toSootClass(PackedLongByte2.class));
+        assertEquals("<{i64, <{i8, i8}>}>", packed.getDefinition());
+        assertEquals(config.getDataLayout().getStoreSize(packed), 10);
+
+        packed = compiler.getStructType(toSootClass(PackedLongByte4.class));
+        assertEquals("<{i64, <{i8, [3 x i8]}>}>", packed.getDefinition());
+        assertEquals(config.getDataLayout().getStoreSize(packed), 12);
+    }
+
+
+
+    @Vectorised
+    public static class VectorFloat2 extends Struct<VectorFloat2> {
+        VectorFloat2() {}
+
+        @StructMember(0) public native float getX();
+        @StructMember(0) public native VectorFloat2 setX(float x);
+
+        @StructMember(1) public native float getY();
+        @StructMember(1) public native VectorFloat2 setY(float y);
+    }
+
+
+    public static class MatrixFloat2x2 extends Struct<MatrixFloat2x2> {
+        MatrixFloat2x2() {}
+
+        @StructMember(0) public native @ByVal
+        VectorFloat2 getC1();
+        @StructMember(0) public native MatrixFloat2x2 setC1(@ByVal VectorFloat2 column1);
+        @StructMember(1) public native @ByVal VectorFloat2 getC2();
+        @StructMember(1) public native MatrixFloat2x2 setC2(@ByVal VectorFloat2 column2);
+    }
+
+    @Packed(1)
+    public static class PackedLongByte1 extends Struct<PackedLongByte1> {
+        @StructMember(0) public native long getA();
+        @StructMember(0) public native PackedLongByte1 setA(long a);
+
+        @StructMember(1) public native byte getC();
+        @StructMember(1) public native PackedLongByte1 setC(byte c);
+    }
+
+    @Packed(2)
+    public static class PackedLongByte2 extends Struct<PackedLongByte2> {
+        @StructMember(0) public native long getA();
+        @StructMember(0) public native PackedLongByte2 setA(long a);
+
+        @StructMember(1) public native byte getC();
+        @StructMember(1) public native PackedLongByte2 setC(byte c);
+    }
+
+    @Packed(4)
+    public static class PackedLongByte4 extends Struct<PackedLongByte4> {
+        @StructMember(0) public native long getA();
+        @StructMember(0) public native PackedLongByte4 setA(long a);
+
+        @StructMember(1) public native byte getC();
+        @StructMember(1) public native PackedLongByte4 setC(byte c);
+    }
+
+    public static class MockHome extends Home {
+        public MockHome(File homeDir) {
+            super(homeDir, false);
+        }
+    }
+}

--- a/compiler/rt/robovm/src/main/java/org/robovm/rt/bro/annotation/Packed.java
+++ b/compiler/rt/robovm/src/main/java/org/robovm/rt/bro/annotation/Packed.java
@@ -1,0 +1,17 @@
+package org.robovm.rt.bro.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies that annotated struct has to be packed
+ * @author dkimitsa
+ * @version $Id$
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface Packed {
+    int value();
+}


### PR DESCRIPTION
it adds for packed structures, which is required for bro to handle C structures defined with #pragma pack. (check this issue for details https://github.com/MobiVM/robovm/issues/374).

* To mark structure as packed annotation `@Packed(align)` was introduced. 
* cocoa touch bindings were revised and regenerated with annotation added.
* also to support runtime in finding proper bridge (`objc_msgSend_stret` or `objc_msgSend`) to be used, compiler now generates synthetic `$attr$stretMetadata` method for struct classes that returns attributes(flags): if struct has unaligned members, if struct is `int like struct`
