### PR TITLE
* fixed #383

### DIFF
--- a/compiler/vm/core/src/hooks.c
+++ b/compiler/vm/core/src/hooks.c
@@ -275,6 +275,11 @@ void _rvmHookThreadStarting(Env* env, Object* threadObj, Thread* thread) {
 
 void _rvmHookThreadDetaching(Env* env, Object* threadObj, Thread* thread, Object* throwable) {
     DEBUGF("Thread %p detaching, threadObj: %p, thread: %p, throwable: %p", rvmRTGetThreadId(env, threadObj), threadObj, thread, throwable);
+    // once got notified that thread is detaching -- ignore any future exceptions or instrumented breakpoints
+    // as JDWP side considers this thread as dead and will fail to lookup it
+    DebugEnv* debugEnv = (DebugEnv*)env;
+    debugEnv->ignoreExceptions = TRUE;
+    debugEnv->ignoreInstrumented = TRUE;
     rvmLockMutex(&writeMutex);
     ChannelError error = { 0 };
     writeChannelByte(clientSocket, EVT_THREAD_DETTACHED, &error);


### PR DESCRIPTION
it was crashing due following set of events:
- app get stopped at breakpoint  -- this means all threads received SUSPENDED command and has to stop on next instrumented hook;
- thread with native frames exited and VM reported it as detached to JDWP server, where it gets removed; 
- vm continue cleaning up java part and calls ThreadGroup.removeThread where instrumented hooks are injected as well, where it hit check against SUSPENDED state, and thread suspended event is reported to JDWP 
-JDWP not able to find out internal representation for this thread (as it was reported as detached) and crashes. 

Fix: suppress any further reports of any kind of events for thread once it marked as detached. 

