### PR TITLE
* fixed #381: AVVideoSettings.setCodec not using the correct mapping

### DIFF
--- a/compiler/cocoatouch/src/main/bro-gen/avfoundation.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/avfoundation.yaml
@@ -14,7 +14,6 @@ typedefs:
     'void (^)(CMTime)': '@Block VoidBlock1<CMTime>'
     'void (^)(BOOL, NSError *)': '@Block VoidBlock2<Boolean, NSError>'
     'void (^)(CMSampleBufferRef, AVCaptureBracketedStillImageSettings *, NSError *)': '@Block VoidBlock3<CMSampleBuffer, AVCaptureBracketedStillImageSettings, NSError>'
-    AVVideoCodecType: NSString
 private_typedefs:
     CGImagePropertyOrientation: org.robovm.apple.imageio.CGImagePropertyOrientation
     # following can't be used as Enum from CoreMedia. As it defines only invalid state
@@ -106,6 +105,9 @@ typed_enums:
     AVVideoApertureMode:
         enum: AVVideoApertureMode
         prefix: AVVideoApertureMode
+        type: NSString
+    AVVideoCodecType:
+        enum: AVVideoCodecType
         type: NSString
 
 categories:
@@ -3332,8 +3334,7 @@ values:
         type: NSString
         methods:
             Codec:
-                type: CMVideoCodecType
-                annotations: ['@WeaklyLinked']
+                type: AVVideoCodecType
             Width:
                 type: long
             Height:

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVCapturePhotoOutput.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVCapturePhotoOutput.java
@@ -71,12 +71,12 @@ import org.robovm.apple.audiotoolbox.*;
      * @since Available in iOS 11.0 and later.
      */
     @Property(selector = "availablePhotoFileTypes")
-    public native NSArray<?> getAvailablePhotoFileTypes();
+    public native NSArray<NSString> getAvailablePhotoFileTypes();
     /**
      * @since Available in iOS 11.0 and later.
      */
     @Property(selector = "availableRawPhotoFileTypes")
-    public native NSArray<?> getAvailableRawPhotoFileTypes();
+    public native NSArray<NSString> getAvailableRawPhotoFileTypes();
     @Property(selector = "isStillImageStabilizationSupported")
     public native boolean isStillImageStabilizationSupported();
     @Property(selector = "isStillImageStabilizationScene")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVCapturePhotoSettings.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVCapturePhotoSettings.java
@@ -203,12 +203,12 @@ import org.robovm.apple.audiotoolbox.*;
      * @since Available in iOS 11.0 and later.
      */
     @Property(selector = "livePhotoVideoCodecType")
-    public native NSString getLivePhotoVideoCodecType();
+    public native AVVideoCodecType getLivePhotoVideoCodecType();
     /**
      * @since Available in iOS 11.0 and later.
      */
     @Property(selector = "setLivePhotoVideoCodecType:")
-    public native void setLivePhotoVideoCodecType(NSString v);
+    public native void setLivePhotoVideoCodecType(AVVideoCodecType v);
     @Property(selector = "livePhotoMovieMetadata")
     public native NSArray<AVMetadataItem> getLivePhotoMovieMetadata();
     @Property(selector = "setLivePhotoMovieMetadata:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVCaptureVideoDataOutput.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVCaptureVideoDataOutput.java
@@ -130,7 +130,7 @@ import org.robovm.apple.audiotoolbox.*;
      * @since Available in iOS 11.0 and later.
      */
     @Method(selector = "recommendedVideoSettingsForVideoCodecType:assetWriterOutputFileType:")
-    public native NSDictionary<?, ?> getRecommendedVideoSettings(NSString videoCodecType, String outputFileType);
+    public native NSDictionary<?, ?> getRecommendedVideoSettings(AVVideoCodecType videoCodecType, String outputFileType);
     @Method(selector = "new")
     protected static native @Pointer long create();
     /*</methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVVideoCodecType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVVideoCodecType.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.avfoundation;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.corefoundation.*;
+import org.robovm.apple.dispatch.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coreaudio.*;
+import org.robovm.apple.coremedia.*;
+import org.robovm.apple.corevideo.*;
+import org.robovm.apple.mediatoolbox.*;
+import org.robovm.apple.audiotoolbox.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/*</javadoc>*/
+/*<annotations>*/@Library("AVFoundation") @StronglyLinked/*</annotations>*/
+@Marshaler(/*<name>*/AVVideoCodecType/*</name>*/.Marshaler.class)
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/AVVideoCodecType/*</name>*/ 
+    extends /*<extends>*/GlobalValueEnumeration<NSString>/*</extends>*/
+    /*<implements>*//*</implements>*/ {
+
+    static { Bro.bind(/*<name>*/AVVideoCodecType/*</name>*/.class); }
+
+    /*<marshalers>*/
+    public static class Marshaler {
+        @MarshalsPointer
+        public static AVVideoCodecType toObject(Class<AVVideoCodecType> cls, long handle, long flags) {
+            NSString o = (NSString) NSObject.Marshaler.toObject(NSString.class, handle, flags);
+            if (o == null) {
+                return null;
+            }
+            return AVVideoCodecType.valueOf(o);
+        }
+        @MarshalsPointer
+        public static long toNative(AVVideoCodecType o, long flags) {
+            if (o == null) {
+                return 0L;
+            }
+            return NSObject.Marshaler.toNative(o.value(), flags);
+        }
+    }
+    public static class AsListMarshaler {
+        @SuppressWarnings("unchecked")
+        @MarshalsPointer
+        public static List<AVVideoCodecType> toObject(Class<? extends NSObject> cls, long handle, long flags) {
+            NSArray<NSString> o = (NSArray<NSString>) NSObject.Marshaler.toObject(NSArray.class, handle, flags);
+            if (o == null) {
+                return null;
+            }
+            List<AVVideoCodecType> list = new ArrayList<>();
+            for (int i = 0; i < o.size(); i++) {
+                list.add(AVVideoCodecType.valueOf(o.get(i)));
+            }
+            return list;
+        }
+        @MarshalsPointer
+        public static long toNative(List<AVVideoCodecType> l, long flags) {
+            if (l == null) {
+                return 0L;
+            }
+            NSArray<NSString> array = new NSMutableArray<>();
+            for (AVVideoCodecType o : l) {
+                array.add(o.value());
+            }
+            return NSObject.Marshaler.toNative(array, flags);
+        }
+    }
+    /*</marshalers>*/
+
+    /*<constants>*/
+    /**
+     * @since Available in iOS 11.0 and later.
+     */
+    public static final AVVideoCodecType AVVideoCodecTypeHEVC = new AVVideoCodecType("AVVideoCodecTypeHEVC");
+    /**
+     * @since Available in iOS 11.0 and later.
+     */
+    public static final AVVideoCodecType AVVideoCodecTypeH264 = new AVVideoCodecType("AVVideoCodecTypeH264");
+    /**
+     * @since Available in iOS 11.0 and later.
+     */
+    public static final AVVideoCodecType AVVideoCodecTypeJPEG = new AVVideoCodecType("AVVideoCodecTypeJPEG");
+    /**
+     * @since Available in iOS 11.0 and later.
+     */
+    public static final AVVideoCodecType AVVideoCodecTypeAppleProRes4444 = new AVVideoCodecType("AVVideoCodecTypeAppleProRes4444");
+    /**
+     * @since Available in iOS 11.0 and later.
+     */
+    public static final AVVideoCodecType AVVideoCodecTypeAppleProRes422 = new AVVideoCodecType("AVVideoCodecTypeAppleProRes422");
+    /*</constants>*/
+    
+    private static /*<name>*/AVVideoCodecType/*</name>*/[] values = new /*<name>*/AVVideoCodecType/*</name>*/[] {/*<value_list>*/AVVideoCodecTypeHEVC, AVVideoCodecTypeH264, AVVideoCodecTypeJPEG, AVVideoCodecTypeAppleProRes4444, AVVideoCodecTypeAppleProRes422/*</value_list>*/};
+    
+    /*<name>*/AVVideoCodecType/*</name>*/ (String getterName) {
+        super(Values.class, getterName);
+    }
+    
+    public static /*<name>*/AVVideoCodecType/*</name>*/ valueOf(/*<type>*/NSString/*</type>*/ value) {
+        for (/*<name>*/AVVideoCodecType/*</name>*/ v : values) {
+            if (v.value().equals(value)) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + value + " found in " 
+            + /*<name>*/AVVideoCodecType/*</name>*/.class.getName());
+    }
+    
+    /*<methods>*//*</methods>*/
+    
+    /*<annotations>*/@Library("AVFoundation") @StronglyLinked/*</annotations>*/
+    public static class Values {
+    	static { Bro.bind(Values.class); }
+
+        /*<values>*/
+        /**
+         * @since Available in iOS 11.0 and later.
+         */
+        @GlobalValue(symbol="AVVideoCodecTypeHEVC", optional=true)
+        public static native NSString AVVideoCodecTypeHEVC();
+        /**
+         * @since Available in iOS 11.0 and later.
+         */
+        @GlobalValue(symbol="AVVideoCodecTypeH264", optional=true)
+        public static native NSString AVVideoCodecTypeH264();
+        /**
+         * @since Available in iOS 11.0 and later.
+         */
+        @GlobalValue(symbol="AVVideoCodecTypeJPEG", optional=true)
+        public static native NSString AVVideoCodecTypeJPEG();
+        /**
+         * @since Available in iOS 11.0 and later.
+         */
+        @GlobalValue(symbol="AVVideoCodecTypeAppleProRes4444", optional=true)
+        public static native NSString AVVideoCodecTypeAppleProRes4444();
+        /**
+         * @since Available in iOS 11.0 and later.
+         */
+        @GlobalValue(symbol="AVVideoCodecTypeAppleProRes422", optional=true)
+        public static native NSString AVVideoCodecTypeAppleProRes422();
+        /*</values>*/
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVVideoSettings.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVVideoSettings.java
@@ -119,20 +119,18 @@ import org.robovm.apple.audiotoolbox.*;
     /**
      * @since Available in iOS 4.0 and later.
      */
-    @WeaklyLinked
-    public CMVideoCodecType getCodec() {
+    public AVVideoCodecType getCodec() {
         if (has(Keys.Codec())) {
-            NSNumber val = (NSNumber) get(Keys.Codec());
-            return CMVideoCodecType.valueOf(val.longValue());
+            NSString val = (NSString) get(Keys.Codec());
+            return AVVideoCodecType.valueOf(val);
         }
         return null;
     }
     /**
      * @since Available in iOS 4.0 and later.
      */
-    @WeaklyLinked
-    public AVVideoSettings setCodec(CMVideoCodecType codec) {
-        set(Keys.Codec(), NSNumber.valueOf(codec.value()));
+    public AVVideoSettings setCodec(AVVideoCodecType codec) {
+        set(Keys.Codec(), codec.value());
         return this;
     }
     /**

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMVideoCodecType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMVideoCodecType.java
@@ -115,11 +115,14 @@ public enum /*<name>*/CMVideoCodecType/*</name>*/ implements ValuedEnum {
     
     public String asFourCharCode() {
         byte[] b = new byte[8];
+        int write_idx = 8;
         long value = value();
-        for (int i = 0; i < 8; ++i) {
-            b[i] = (byte)(value >> (8 - i - 1 << 3));
+        while (value != 0) {
+            write_idx -= 1;
+            b[write_idx] = (byte) (value & 0xFF);
+            value >>= 8;
         }
-        return new String(b);
+        return new String(b, write_idx, 8 - write_idx);
     }
     
     public static /*<name>*/CMVideoCodecType/*</name>*/ valueOf(long n) {


### PR DESCRIPTION
added AVVideoCodecType as it declared in apple source.
asFourCharCode fixed -- as it was returning 8 char string (with four zero chars)