### PR TITLE
maven maintenance

### DIFF
--- a/plugins/idea/src/main/java/org/robovm/idea/builder/RoboVmModuleBuilder.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/builder/RoboVmModuleBuilder.java
@@ -204,7 +204,7 @@ public class RoboVmModuleBuilder extends JavaModuleBuilder {
                     }
                 }
             } else if (buildSystem == BuildSystem.Maven) {
-                String template = IOUtils.toString(RoboVmModuleBuilder.class.getResource("/pom.xml"), "UTF-8");
+                String template = IOUtils.toString(RoboVmModuleBuilder.class.getResource("/template_pom.xml"), "UTF-8");
                 template = template.replaceAll(ROBOVM_VERSION_PLACEHOLDER, Version.getVersion());
                 template = template.replaceAll(PACKAGE_NAME_PLACEHOLDER, packageName);
                 template = template.replaceAll(APP_NAME_PLACEHOLDER, appName);

--- a/plugins/idea/src/main/java/org/robovm/idea/builder/RoboVmNewModuleEditor.form
+++ b/plugins/idea/src/main/java/org/robovm/idea/builder/RoboVmNewModuleEditor.form
@@ -72,7 +72,7 @@
           </grid>
         </constraints>
         <properties>
-          <text value="My App"/>
+          <text value="MyApp"/>
         </properties>
       </component>
       <component id="38f5a" class="javax.swing.JTextField" binding="appId">

--- a/plugins/idea/src/main/resources/template_pom.xml
+++ b/plugins/idea/src/main/resources/template_pom.xml
@@ -13,12 +13,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.robovm</groupId>
+            <groupId>com.mobidevelop.robovm</groupId>
             <artifactId>robovm-rt</artifactId>
             <version>${robovm.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.robovm</groupId>
+            <groupId>com.mobidevelop.robovm</groupId>
             <artifactId>robovm-cocoatouch</artifactId>
             <version>${robovm.version}</version>
         </dependency>
@@ -36,12 +36,12 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.robovm</groupId>
+                <groupId>com.mobidevelop.robovm</groupId>
                 <artifactId>robovm-maven-plugin</artifactId>
                 <version>${robovm.version}</version>
             </plugin>

--- a/plugins/maven/plugin/src/main/java/org/robovm/maven/plugin/AbstractRoboVMMojo.java
+++ b/plugins/maven/plugin/src/main/java/org/robovm/maven/plugin/AbstractRoboVMMojo.java
@@ -35,6 +35,8 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.archiver.UnArchiver;
@@ -56,6 +58,7 @@ import org.robovm.compiler.target.ios.SigningIdentity;
 
 /**
  */
+@Execute(goal="compile", phase = LifecyclePhase.COMPILE)
 public abstract class AbstractRoboVMMojo extends AbstractMojo {
 
     @Component

--- a/plugins/maven/plugin/src/main/java/org/robovm/maven/plugin/IOSDeviceMojo.java
+++ b/plugins/maven/plugin/src/main/java/org/robovm/maven/plugin/IOSDeviceMojo.java
@@ -39,9 +39,9 @@ public class IOSDeviceMojo extends AbstractRoboVMMojo {
 
         try {
 
-            Arch arch = Arch.thumbv7;
-            if (super.arch != null && super.arch.equals(Arch.arm64.toString())) {
-                arch = Arch.arm64;
+            Arch arch = Arch.arm64;
+            if (super.arch != null && super.arch.equals(Arch.thumbv7.toString())) {
+                arch = Arch.thumbv7;
             }
 
             AppCompiler compiler = build(OS.ios, arch, IOSTarget.TYPE);

--- a/plugins/templates/console/src/main/resources/archetype-resources/pom.xml
+++ b/plugins/templates/console/src/main/resources/archetype-resources/pom.xml
@@ -10,8 +10,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <robovm.version>1.14.0</robovm.version>
-        <robovm.maven.version>1.14.0</robovm.maven.version>
+        <robovm.version>2.3.7</robovm.version>
+        <robovm.maven.version>2.3.7</robovm.maven.version>
     </properties>
 
     <version>${version}</version>
@@ -23,12 +23,12 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.1</version>
                     <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.robovm</groupId>
+                    <groupId>com.mobidevelop.robovm</groupId>
                     <artifactId>robovm-maven-plugin</artifactId>
                     <version>${robovm.maven.version}</version>
                 </plugin>
@@ -38,7 +38,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.robovm</groupId>
+            <groupId>com.mobidevelop.robovm</groupId>
             <artifactId>robovm-rt</artifactId>
             <version>${robovm.version}</version>
         </dependency>

--- a/plugins/templates/ios-framework/src/main/resources/archetype-resources/pom.xml
+++ b/plugins/templates/ios-framework/src/main/resources/archetype-resources/pom.xml
@@ -10,8 +10,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <robovm.version>1.14.0</robovm.version>
-        <robovm.maven.version>1.14.0</robovm.maven.version>
+        <robovm.version>2.3.7</robovm.version>
+        <robovm.maven.version>2.3.7</robovm.maven.version>
     </properties>
 
     <version>${version}</version>
@@ -23,12 +23,12 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.1</version>
                     <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.robovm</groupId>
+                    <groupId>com.mobidevelop.robovm</groupId>
                     <artifactId>robovm-maven-plugin</artifactId>
                     <version>${robovm.maven.version}</version>
                 </plugin>
@@ -38,12 +38,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.robovm</groupId>
+            <groupId>com.mobidevelop.robovm</groupId>
             <artifactId>robovm-rt</artifactId>
             <version>${robovm.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.robovm</groupId>
+            <groupId>com.mobidevelop.robovm</groupId>
             <artifactId>robovm-cocoatouch</artifactId>
             <version>${robovm.version}</version>
         </dependency>

--- a/plugins/templates/ios-single-view-no-ib/src/main/resources/archetype-resources/pom.xml
+++ b/plugins/templates/ios-single-view-no-ib/src/main/resources/archetype-resources/pom.xml
@@ -10,8 +10,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <robovm.version>1.14.0</robovm.version>
-        <robovm.maven.version>1.14.0</robovm.maven.version>
+        <robovm.version>2.3.7</robovm.version>
+        <robovm.maven.version>2.3.7</robovm.maven.version>
     </properties>
 
     <version>${version}</version>
@@ -23,12 +23,12 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.1</version>
                     <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.robovm</groupId>
+                    <groupId>com.mobidevelop.robovm</groupId>
                     <artifactId>robovm-maven-plugin</artifactId>
                     <version>${robovm.maven.version}</version>
                 </plugin>
@@ -38,12 +38,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.robovm</groupId>
+            <groupId>com.mobidevelop.robovm</groupId>
             <artifactId>robovm-rt</artifactId>
             <version>${robovm.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.robovm</groupId>
+            <groupId>com.mobidevelop.robovm</groupId>
             <artifactId>robovm-cocoatouch</artifactId>
             <version>${robovm.version}</version>
         </dependency>


### PR DESCRIPTION
- `ios-device` mojo now uses `arm64` as default architecture (similar to gradle plugin) to minimize amount of error happened to new users when running on arm64 only devices
- all pojos now explicitly calls `compile` goal (similar to gradle plugin). just to eliminate `Failed to launch IOS Simulator: Main class xxx.Main not found` error for new users
- idea: mvn template fixed to use proper MobiVm dependencies (as it was still using org.robovm as result it was failing to sync)
- idea: mvn template updated to use 1.8 java, otherwise it was failing to compile 'ios app without storyboard' as it uses lambdas
- idea: default app name renamed from `My App` -> `MyApp` as space was breaking maven build (space is not allowed in artifactId).
- cosmetic: fixed pom.xml in templates to use java 1.8 and proper mobivm dependencies. cosmetic as these files are not included when building