### PR TITLE
Cocoa Bindings update: generics types 

### DIFF
--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/arkit/ARFaceAnchor.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/arkit/ARFaceAnchor.java
@@ -77,7 +77,7 @@ import org.robovm.apple.imageio.*;
     @Property(selector = "lookAtPoint")
     public native @ByVal VectorFloat3 getLookAtPoint();
     @Property(selector = "blendShapes")
-    public native NSDictionary<?, ?> getBlendShapes();
+    public native NSDictionary<NSString, NSNumber> getBlendShapes();
     @Property(selector = "isTracked")
     public native boolean isTracked();
     /*</properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/arkit/ARFaceGeometry.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/arkit/ARFaceGeometry.java
@@ -58,7 +58,7 @@ import org.robovm.apple.imageio.*;
     protected ARFaceGeometry(Handle h, long handle) { super(h, handle); }
     protected ARFaceGeometry(SkipInit skipInit) { super(skipInit); }
     @Method(selector = "initWithBlendShapes:")
-    public ARFaceGeometry(NSDictionary<?, ?> blendShapes) { super((SkipInit) null); initObject(init(blendShapes)); }
+    public ARFaceGeometry(NSDictionary<NSString, NSNumber> blendShapes) { super((SkipInit) null); initObject(init(blendShapes)); }
     @Method(selector = "initWithCoder:")
     public ARFaceGeometry(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
@@ -81,7 +81,7 @@ import org.robovm.apple.imageio.*;
     /*<members>*//*</members>*/
     /*<methods>*/
     @Method(selector = "initWithBlendShapes:")
-    protected native @Pointer long init(NSDictionary<?, ?> blendShapes);
+    protected native @Pointer long init(NSDictionary<NSString, NSNumber> blendShapes);
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder coder);
     @Method(selector = "initWithCoder:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreml/MLModelDescription.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreml/MLModelDescription.java
@@ -59,7 +59,7 @@ import org.robovm.apple.corevideo.*;
     @Property(selector = "predictedProbabilitiesName")
     public native String getPredictedProbabilitiesName();
     @Property(selector = "metadata")
-    public native NSDictionary<?, ?> getMetadata();
+    public native NSDictionary<NSString, ?> getMetadata();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSLinguisticTagger.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSLinguisticTagger.java
@@ -165,7 +165,7 @@ import org.robovm.apple.dispatch.*;
      * @since Available in iOS 11.0 and later.
      */
     @Method(selector = "tagsInRange:unit:scheme:options:tokenRanges:")
-    public native NSArray<?> tagsInRange(@ByVal NSRange range, NSLinguisticTaggerUnit unit, String scheme, NSLinguisticTaggerOptions options, NSArray.NSArrayPtr<?> tokenRanges);
+    public native NSArray<NSString> tagsInRange(@ByVal NSRange range, NSLinguisticTaggerUnit unit, String scheme, NSLinguisticTaggerOptions options, NSArray.NSArrayPtr<?> tokenRanges);
     /**
      * @since Available in iOS 5.0 and later.
      */
@@ -190,7 +190,7 @@ import org.robovm.apple.dispatch.*;
      * @since Available in iOS 11.0 and later.
      */
     @Method(selector = "availableTagSchemesForUnit:language:")
-    public static native NSArray<?> availableTagSchemesForUnit(NSLinguisticTaggerUnit unit, String language);
+    public static native NSArray<NSString> availableTagSchemesForUnit(NSLinguisticTaggerUnit unit, String language);
     /**
      * @since Available in iOS 5.0 and later.
      */
@@ -210,7 +210,7 @@ import org.robovm.apple.dispatch.*;
      * @since Available in iOS 11.0 and later.
      */
     @Method(selector = "tagsForString:range:unit:scheme:options:orthography:tokenRanges:")
-    public static native NSArray<?> tagsForString(String string, @ByVal NSRange range, NSLinguisticTaggerUnit unit, String scheme, NSLinguisticTaggerOptions options, NSOrthography orthography, NSArray.NSArrayPtr<?> tokenRanges);
+    public static native NSArray<NSString> tagsForString(String string, @ByVal NSRange range, NSLinguisticTaggerUnit unit, String scheme, NSLinguisticTaggerOptions options, NSOrthography orthography, NSArray.NSArrayPtr<?> tokenRanges);
     /**
      * @since Available in iOS 11.0 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSObject.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSObject.java
@@ -431,7 +431,7 @@ import org.robovm.apple.dispatch.*;
     @Method(selector = "mutableCopy")
     public native NSObject mutableCopy();
     @Method(selector = "performSelector:withObject:afterDelay:inModes:")
-    public final native void performSelector(Selector aSelector, NSObject anArgument, double delay, NSArray<?> modes);
+    public final native void performSelector(Selector aSelector, NSObject anArgument, double delay, NSArray<NSString> modes);
     @Method(selector = "performSelector:withObject:afterDelay:")
     public final native void performSelector(Selector aSelector, NSObject anArgument, double delay);
     @Method(selector = "addObserver:forKeyPath:options:context:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/naturallanguage/NLLanguageRecognizer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/naturallanguage/NLLanguageRecognizer.java
@@ -59,22 +59,22 @@ import org.robovm.apple.coreml.*;
      * @since Available in iOS 12.0 and later.
      */
     @Property(selector = "languageHints")
-    public native NSDictionary<?, ?> getLanguageHints();
+    public native NSDictionary<NSString, NSNumber> getLanguageHints();
     /**
      * @since Available in iOS 12.0 and later.
      */
     @Property(selector = "setLanguageHints:")
-    public native void setLanguageHints(NSDictionary<?, ?> v);
+    public native void setLanguageHints(NSDictionary<NSString, NSNumber> v);
     /**
      * @since Available in iOS 12.0 and later.
      */
     @Property(selector = "languageConstraints")
-    public native NSArray<?> getLanguageConstraints();
+    public native NSArray<NSString> getLanguageConstraints();
     /**
      * @since Available in iOS 12.0 and later.
      */
     @Property(selector = "setLanguageConstraints:")
-    public native void setLanguageConstraints(NSArray<?> v);
+    public native void setLanguageConstraints(NSArray<NSString> v);
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
@@ -92,7 +92,7 @@ import org.robovm.apple.coreml.*;
      * @since Available in iOS 12.0 and later.
      */
     @Method(selector = "languageHypothesesWithMaximum:")
-    public native NSDictionary<?, ?> create(@MachineSizedUInt long maxHypotheses);
+    public native NSDictionary<NSString, NSNumber> create(@MachineSizedUInt long maxHypotheses);
     /**
      * @since Available in iOS 12.0 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/naturallanguage/NLTagger.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/naturallanguage/NLTagger.java
@@ -52,14 +52,14 @@ import org.robovm.apple.coreml.*;
      * @since Available in iOS 12.0 and later.
      */
     @Method(selector = "initWithTagSchemes:")
-    public NLTagger(NSArray<?> tagSchemes) { super((SkipInit) null); initObject(init(tagSchemes)); }
+    public NLTagger(NSArray<NSString> tagSchemes) { super((SkipInit) null); initObject(init(tagSchemes)); }
     /*</constructors>*/
     /*<properties>*/
     /**
      * @since Available in iOS 12.0 and later.
      */
     @Property(selector = "tagSchemes")
-    public native NSArray<?> getTagSchemes();
+    public native NSArray<NSString> getTagSchemes();
     /**
      * @since Available in iOS 12.0 and later.
      */
@@ -82,7 +82,7 @@ import org.robovm.apple.coreml.*;
      * @since Available in iOS 12.0 and later.
      */
     @Method(selector = "initWithTagSchemes:")
-    protected native @Pointer long init(NSArray<?> tagSchemes);
+    protected native @Pointer long init(NSArray<NSString> tagSchemes);
     /**
      * @since Available in iOS 12.0 and later.
      */
@@ -102,7 +102,7 @@ import org.robovm.apple.coreml.*;
      * @since Available in iOS 12.0 and later.
      */
     @Method(selector = "tagsInRange:unit:scheme:options:tokenRanges:")
-    public native NSArray<?> getTags(@ByVal NSRange range, NLTokenUnit unit, NLTagScheme scheme, NLTaggerOptions options, NSArray.NSArrayPtr<?> tokenRanges);
+    public native NSArray<NSString> getTags(@ByVal NSRange range, NLTokenUnit unit, NLTagScheme scheme, NLTaggerOptions options, NSArray.NSArrayPtr<?> tokenRanges);
     /**
      * @since Available in iOS 12.0 and later.
      */
@@ -121,6 +121,6 @@ import org.robovm.apple.coreml.*;
      * @since Available in iOS 12.0 and later.
      */
     @Method(selector = "availableTagSchemesForUnit:language:")
-    public static native NSArray<?> getAvailableTagSchemes(NLTokenUnit unit, NLLanguage language);
+    public static native NSArray<NSString> getAvailableTagSchemes(NLTokenUnit unit, NLLanguage language);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/passkit/PKPaymentAuthorizationController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/passkit/PKPaymentAuthorizationController.java
@@ -70,8 +70,8 @@ import org.robovm.apple.contacts.*;
     @Method(selector = "canMakePayments")
     public static native boolean canMakePayments();
     @Method(selector = "canMakePaymentsUsingNetworks:")
-    public static native boolean canMakePaymentsUsingNetworks(NSArray<?> supportedNetworks);
+    public static native boolean canMakePaymentsUsingNetworks(NSArray<NSString> supportedNetworks);
     @Method(selector = "canMakePaymentsUsingNetworks:capabilities:")
-    public static native boolean canMakePayments(NSArray<?> supportedNetworks, PKMerchantCapability capabilties);
+    public static native boolean canMakePayments(NSArray<NSString> supportedNetworks, PKMerchantCapability capabilties);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/passkit/PKPaymentRequest.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/passkit/PKPaymentRequest.java
@@ -80,12 +80,12 @@ import org.robovm.apple.contacts.*;
      * @since Available in iOS 11.0 and later.
      */
     @Property(selector = "requiredBillingContactFields")
-    public native NSSet<?> getRequiredBillingContactFields();
+    public native NSSet<NSString> getRequiredBillingContactFields();
     /**
      * @since Available in iOS 11.0 and later.
      */
     @Property(selector = "setRequiredBillingContactFields:")
-    public native void setRequiredBillingContactFields(NSSet<?> v);
+    public native void setRequiredBillingContactFields(NSSet<NSString> v);
     /**
      * @since Available in iOS 8.0 and later.
      * @deprecated Deprecated in iOS 11.0.
@@ -114,12 +114,12 @@ import org.robovm.apple.contacts.*;
      * @since Available in iOS 11.0 and later.
      */
     @Property(selector = "requiredShippingContactFields")
-    public native NSSet<?> getRequiredShippingContactFields();
+    public native NSSet<NSString> getRequiredShippingContactFields();
     /**
      * @since Available in iOS 11.0 and later.
      */
     @Property(selector = "setRequiredShippingContactFields:")
-    public native void setRequiredShippingContactFields(NSSet<?> v);
+    public native void setRequiredShippingContactFields(NSSet<NSString> v);
     /**
      * @since Available in iOS 8.0 and later.
      * @deprecated Deprecated in iOS 11.0.
@@ -207,7 +207,7 @@ import org.robovm.apple.contacts.*;
      * @since Available in iOS 10.0 and later.
      */
     @Method(selector = "availableNetworks")
-    public static native NSArray<?> availableNetworks();
+    public static native NSArray<NSString> availableNetworks();
     /**
      * @since Available in iOS 11.0 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/vision/VNDetectBarcodesRequest.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/vision/VNDetectBarcodesRequest.java
@@ -58,11 +58,11 @@ import org.robovm.apple.imageio.*;
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "supportedSymbologies")
-    public static native NSArray<?> getSupportedSymbologies();
+    public static native NSArray<NSString> getSupportedSymbologies();
     @Property(selector = "symbologies")
-    public native NSArray<?> getSymbologies();
+    public native NSArray<NSString> getSymbologies();
     @Property(selector = "setSymbologies:")
-    public native void setSymbologies(NSArray<?> v);
+    public native void setSymbologies(NSArray<NSString> v);
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/


### PR DESCRIPTION
Mostly cosmetic (but might break code where collections without genetic type were used). -- but these changes will be used with next iOS version anyway.

Recent fix to bro gen ([commit](https://github.com/dkimitsa/robovm-bro-gen/commit/626e5a5f7f14fb0a23e27b61ddb7fa0f9f8c8ffb)) allowed to extract additional information about generic types. 