### PR TITLE
Idea/AndroidStudio Plugin: fixed NPE  (#242) and maintenance

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/AppCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/AppCompiler.java
@@ -430,7 +430,10 @@ public class AppCompiler {
         Set<Clazz> linkClasses = new HashSet<Clazz>();
         int compiledCount = 0;
         outer: while (!compileQueue.isEmpty() && !Thread.currentThread().isInterrupted()) {
-            while (!compileQueue.isEmpty() && !Thread.currentThread().isInterrupted()) {
+            while (!compileQueue.isEmpty() ) {
+                if (Thread.currentThread().isInterrupted()) {
+                    break outer;
+                }
                 Clazz clazz = compileQueue.pollFirst();
                 if (!linkClasses.contains(clazz)) {
                     if (compile(executor, listenerWrapper, clazz, compileQueue, linkClasses)) {
@@ -463,12 +466,18 @@ public class AppCompiler {
 
         // Shutdown the executor and wait for running tasks to complete.
         if (executor instanceof ExecutorService) {
+            // save interrupted status (also Thread.interrupted() clears it)
+            // as if it stays set executorService.awaitTermination will exit with
+            // InterruptedException and clear interrupted state
+            boolean wasInterrupted = Thread.interrupted();
             ExecutorService executorService = (ExecutorService) executor;
             executorService.shutdown();
             try {
                 executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS);
-            } catch (InterruptedException e) {
+            } catch (InterruptedException ignored) {
             }
+            if (wasInterrupted)
+                Thread.currentThread().interrupt();
         }
 
         if (listenerWrapper.t != null) {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/AppCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/AppCompiler.java
@@ -494,8 +494,10 @@ public class AppCompiler {
             throw new CompilerException(listenerWrapper.t);
         }
 
-        long duration = System.currentTimeMillis() - start;
-        config.getLogger().info("Compiled %d classes in %.2f seconds", compiledCount, duration / 1000.0);
+        if (!Thread.currentThread().isInterrupted()) {
+            long duration = System.currentTimeMillis() - start;
+            config.getLogger().info("Compiled %d classes in %.2f seconds", compiledCount, duration / 1000.0);
+        }
 
         return linkClasses;
     }

--- a/dist/package/pom.xml
+++ b/dist/package/pom.xml
@@ -17,6 +17,20 @@
         <robovmdir>${basedir}/../../compiler</robovmdir>
     </properties>
 
+    <profiles>
+        <profile>
+            <id>robovm-release</id>
+            <dependencies>
+                <!-- RT sources are build during release only -->
+                <dependency>
+                    <groupId>com.mobidevelop.robovm</groupId>
+                    <artifactId>robovm-rt</artifactId>
+                    <classifier>sources</classifier>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
     <dependencies>
         <dependency>
             <groupId>com.mobidevelop.robovm</groupId>
@@ -25,11 +39,6 @@
         <dependency>
             <groupId>com.mobidevelop.robovm</groupId>
             <artifactId>robovm-rt</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.mobidevelop.robovm</groupId>
-            <artifactId>robovm-rt</artifactId>
-            <classifier>sources</classifier>
         </dependency>
         <dependency>
             <groupId>com.mobidevelop.robovm</groupId>

--- a/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmBeforeRunTaskProvider.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmBeforeRunTaskProvider.java
@@ -1,0 +1,125 @@
+package org.robovm.idea.running;
+
+import com.intellij.execution.BeforeRunTask;
+import com.intellij.execution.BeforeRunTaskProvider;
+import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.Ref;
+import com.intellij.util.concurrency.Semaphore;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.robovm.idea.RoboVmIcons;
+import org.robovm.idea.RoboVmPlugin;
+import org.robovm.idea.compilation.RoboVmCompileTask;
+
+import javax.swing.*;
+
+/**
+ * @author dkimitsa
+ * Workaround for (Unable to start RoboVM iOS in IntelliJ due to NullPointerException)
+ * https://github.com/MobiVM/robovm/issues/242
+ * Issue happened if project is gradle driven (e.g. Android one in AndroidStudio3.2 and
+ * CompilerTask is not being executed as Idea doesn't controll build process anymore.
+ * So this task is added as before run task and it checks if RoboVmCompileTask was invoked
+ * and if not -- invokes it
+ */
+public class RoboVmBeforeRunTaskProvider extends BeforeRunTaskProvider<RoboVmBeforeRunTaskProvider.Task> {
+    private static final Key<Task> TaskID = new Key<>("Buildr.BeforeRunTask");
+
+    @Override
+    public Key<Task> getId() {
+        return TaskID;
+    }
+
+    @Override
+    public String getName() {
+        return "Build RoboVm app";
+    }
+
+    @Nullable
+    @Override
+    public Icon getTaskIcon(Task task) {
+        return RoboVmIcons.ROBOVM_SMALL;
+    }
+
+    @Override
+    public String getDescription(Task task) {
+        return "Build RoboVm app";
+    }
+
+    @Nullable
+    @Override
+    public Icon getIcon() {
+        return RoboVmIcons.ROBOVM_SMALL;
+    }
+
+    @Override
+    public boolean isConfigurable() {
+        return false;
+    }
+
+    @Nullable
+    @Override
+    public Task createTask(@NotNull RunConfiguration runConfiguration) {
+        if (runConfiguration instanceof RoboVmRunConfiguration) {
+            return new Task(TaskID);
+        }
+        return null;
+    }
+
+    @Override
+    public boolean configureTask(@NotNull RunConfiguration runConfiguration, @NotNull Task task) {
+        return false;
+    }
+
+    @Override
+    public boolean canExecuteTask(@NotNull RunConfiguration configuration, @NotNull Task task) {
+        return configuration instanceof RoboVmRunConfiguration;
+    }
+
+    @Override
+    public boolean executeTask(@NotNull DataContext context, @NotNull final RunConfiguration configuration, final ExecutionEnvironment env, @NotNull Task task) {
+        final RoboVmRunConfiguration runConfig = (RoboVmRunConfiguration) configuration;
+        if (runConfig.getConfig() != null) {
+            // configuration is set when RoboVmCompilerTask is executed.
+            // in this case there is no need to run this workaround
+            return true;
+        }
+
+        final Ref<Boolean> result = new Ref<>(Boolean.FALSE);
+        final Exception[] exception = {null};
+        final Semaphore done = new Semaphore();
+        done.down();
+
+        ProgressManager.getInstance().run(new com.intellij.openapi.progress.Task.Backgroundable(env.getProject(), "Building RoboVM Project ", true) {
+            @Override
+            public void run(@NotNull ProgressIndicator progressIndicator) {
+                try {
+                    result.set(RoboVmCompileTask.compileForRunConfiguration(env.getProject(), null, progressIndicator, runConfig));
+                } catch (Exception e) {
+                    exception[0] = e;
+                } finally {
+                    done.up();
+                }
+            }
+        });
+
+        done.waitFor();
+        if (exception[0] != null) {
+            RoboVmPlugin.logErrorThrowable(env.getProject(), "Couldn't compile app", exception[0], false);
+        }
+
+        return result.get();
+    }
+
+    static class Task extends BeforeRunTask<Task> {
+        Task(@NotNull Key<Task> providerId) {
+            super(providerId);
+            setEnabled(true);
+        }
+    }
+}

--- a/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmRunConfiguration.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmRunConfiguration.java
@@ -42,7 +42,7 @@ import java.util.Collection;
 import java.util.List;
 
 public class RoboVmRunConfiguration extends ModuleBasedConfiguration<RoboVmRunConfigurationSettings, Element> implements RunConfigurationWithSuppressedDefaultDebugAction, RunConfigurationWithSuppressedDefaultRunAction, RunProfileWithCompileBeforeLaunchOption {
-    public static enum TargetType {
+    public enum TargetType {
         Simulator,
         Device,
         Console

--- a/plugins/idea/src/main/java/org/robovm/idea/sdk/RoboVmSdkType.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/sdk/RoboVmSdkType.java
@@ -21,41 +21,40 @@ import java.io.File;
 import javax.swing.*;
 
 import org.jdom.Element;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import com.intellij.pom.java.LanguageLevel;
 import org.robovm.compiler.Version;
 import org.robovm.idea.RoboVmIcons;
 import org.robovm.idea.RoboVmPlugin;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.projectRoots.*;
-import com.intellij.openapi.projectRoots.impl.JavaDependentSdkType;
 import com.intellij.openapi.roots.OrderRootType;
 import com.intellij.openapi.vfs.JarFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 
-public class RoboVmSdkType extends JavaDependentSdkType implements JavaSdkType {
-    public static final String SDK_NAME = "RoboVM SDK";
+public class RoboVmSdkType extends SdkType implements JavaSdkType {
+    private static final String SDK_NAME = "RoboVM SDK";
+    public static final LanguageLevel REQUIRED_JAVA_LANGUAGE_LEVEL = LanguageLevel.JDK_1_8;
 
     public RoboVmSdkType() {
         super(SDK_NAME);
     }
 
     @Override
-    public String getBinPath(Sdk sdk) {
-        Sdk jdk = findBestJdk();
-        return ((JavaSdk)jdk.getSdkType()).getBinPath(jdk);
+    public String getBinPath(@NotNull Sdk sdk) {
+        return null;
     }
 
     @Override
-    public String getToolsPath(Sdk sdk) {
-        Sdk jdk = findBestJdk();
-        return ((JavaSdk)jdk.getSdkType()).getToolsPath(jdk);
+    public String getToolsPath(@NotNull Sdk sdk) {
+        return null;
     }
 
     @Override
-    public String getVMExecutablePath(Sdk sdk) {
-        Sdk jdk = findBestJdk();
-        return ((JavaSdk)jdk.getSdkType()).getVMExecutablePath(jdk);
+    public String getVMExecutablePath(@NotNull Sdk sdk) {
+        return null;
     }
 
     @Nullable
@@ -69,6 +68,7 @@ public class RoboVmSdkType extends JavaDependentSdkType implements JavaSdkType {
         return RoboVmPlugin.getSdkHome().equals(new File(path));
     }
 
+    @NotNull
     @Override
     public String suggestSdkName(String currentSdkName, String sdkHome) {
         return SDK_NAME + " " + Version.getVersion();
@@ -76,10 +76,11 @@ public class RoboVmSdkType extends JavaDependentSdkType implements JavaSdkType {
 
     @Nullable
     @Override
-    public AdditionalDataConfigurable createAdditionalDataConfigurable(SdkModel sdkModel, SdkModificator sdkModificator) {
+    public AdditionalDataConfigurable createAdditionalDataConfigurable(@NotNull SdkModel sdkModel, @NotNull SdkModificator sdkModificator) {
         return null;
     }
 
+    @NotNull
     @Override
     public String getPresentableName() {
         return SDK_NAME;
@@ -90,23 +91,23 @@ public class RoboVmSdkType extends JavaDependentSdkType implements JavaSdkType {
         return RoboVmIcons.ROBOVM_SMALL;
     }
 
+    @NotNull
     @Override
     public Icon getIconForAddAction() {
         return RoboVmIcons.ROBOVM_SMALL;
     }
 
     @Override
-    public void saveAdditionalData(SdkAdditionalData additionalData, Element additional) {
+    public void saveAdditionalData(@NotNull SdkAdditionalData additionalData, @NotNull Element additional) {
     }
 
     @Override
-    public boolean setupSdkPaths(final Sdk sdk, final SdkModel sdkModel) {
-        Sdk jdk = findBestJdk();
-        setupSdkRoots(sdk, jdk);
+    public boolean setupSdkPaths(@NotNull final Sdk sdk, @NotNull final SdkModel sdkModel) {
+        setupSdkRoots(sdk);
         return true;
     }
 
-    public void setupSdkRoots(Sdk sdk, Sdk jdk) {
+    private void setupSdkRoots(Sdk sdk) {
         SdkModificator sdkModificator = sdk.getSdkModificator();
         sdkModificator.removeAllRoots();
 
@@ -115,10 +116,6 @@ public class RoboVmSdkType extends JavaDependentSdkType implements JavaSdkType {
             VirtualFile virtualFile = JarFileSystem.getInstance().findLocalVirtualFileByPath(file.getAbsolutePath());
             sdkModificator.addRoot(virtualFile, file.getName().endsWith("-sources.jar")?  OrderRootType.SOURCES: OrderRootType.CLASSES);
         }
-
-        // set the JDK version as the version string, otherwise
-        // IDEA gets angry
-        sdkModificator.setVersionString(jdk.getVersionString());
 
         // set the home path, we check this in createSdkIfNotExists
         sdkModificator.setHomePath(RoboVmPlugin.getSdkHome().getAbsolutePath());
@@ -138,7 +135,7 @@ public class RoboVmSdkType extends JavaDependentSdkType implements JavaSdkType {
             public void run() {
                 RoboVmSdkType sdkType = new RoboVmSdkType();
                 Sdk sdk = ProjectJdkTable.getInstance().createSdk(sdkType.suggestSdkName(null, null), sdkType);
-                sdkType.setupSdkRoots(sdk, findBestJdk());
+                sdkType.setupSdkRoots(sdk);
                 ProjectJdkTable.getInstance().addJdk(sdk);
                 RoboVmPlugin.logInfo(null, "Added new SDK " + sdk.getName());
             }

--- a/plugins/idea/src/main/resources/META-INF/plugin.xml
+++ b/plugins/idea/src/main/resources/META-INF/plugin.xml
@@ -4,7 +4,7 @@
     <version>${project.version}</version>
     <vendor email="robovm@mobidevelop.com" url="http://github.com/mobidevelop/robovm">mobidevelop</vendor>
 
-    <depends>org.jetbrains.idea.maven</depends>
+    <depends optional="true" config-file="">org.jetbrains.idea.maven</depends>
     <depends>org.jetbrains.plugins.gradle</depends>
 
     <idea-version since-build="141.177"/>
@@ -27,6 +27,7 @@
         <projectTemplatesFactory implementation="org.robovm.idea.builder.RoboVmTemplatesFactory"/>
         <sdkType implementation="org.robovm.idea.sdk.RoboVmSdkType"/>
         <buildProcess.parametersProvider implementation="org.robovm.idea.components.RoboVmBuildProcessParametersProvider"/>
+        <stepsBeforeRunProvider implementation="org.robovm.idea.running.RoboVmBeforeRunTaskProvider" />
         <!-- dkimitsa: removed as it is not required for open source xcode integration -->
         <!--<applicationConfigurable implementation="org.robovm.idea.config.RoboVmGlobalConfig"></applicationConfigurable>-->
     </extensions>

--- a/plugins/idea/src/main/resources/template_build.gradle
+++ b/plugins/idea/src/main/resources/template_build.gradle
@@ -32,7 +32,3 @@ dependencies {
     compile "com.mobidevelop.robovm:robovm-cocoatouch:${roboVMVersion}"
     testCompile "junit:junit:4.12"
 }
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.10'
-}

--- a/pom.xml
+++ b/pom.xml
@@ -183,13 +183,8 @@
             <dependency>
                 <groupId>org.zeroturnaround</groupId>
                 <artifactId>zt-zip</artifactId>
-                <version>1.7</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-api</artifactId>
-                    </exclusion>
-                </exclusions>
+                <version>1.13</version>
+                <type>jar</type>
             </dependency>
             <dependency>
                 <groupId>org.simpleframework</groupId>


### PR DESCRIPTION
This PR has is based on #400 so it has to be merged after it. 
- It workarounds #242 by adding task before run (and compilation happens there) 
- fixes build cancelation (build was canceled but linker was invoked)
- leaves only Gradle as build system for new projects/modules under AndroidStudio
- removes Gradle import dialog and configure gradle directly (for new projects/modules) 

Its subject for testing. 
@Tom-Ski lets merge #400 into stand alone branch and then I will update target base(now its master)

Pre-build idea plugin for testing(link updated):
https://drive.google.com/open?id=1AzGxqqF1ExoRLGqg-seLUOfXnu695b-2