### PR TITLE
* fixed #408 

### DIFF
--- a/compiler/rt/robovm/src/main/java/org/robovm/rt/bro/ValuedEnum.java
+++ b/compiler/rt/robovm/src/main/java/org/robovm/rt/bro/ValuedEnum.java
@@ -141,7 +141,8 @@ public interface ValuedEnum {
                     + value + " (0x" + Long.toHexString(value) + ") found in " 
                     + enumType.getName());
         }
-        
+
+        @MarshalsValue
         public static long toNative(ValuedEnum v, long flags) {
             return v.value();
         }
@@ -156,7 +157,8 @@ public interface ValuedEnum {
         public static <T extends Enum<T> & ValuedEnum> ValuedEnum toObject(Class<T> cls, @MachineSizedSInt long value, long flags) {
             return AsLongMarshaler.toObject(cls, value, flags);
         }
-        
+
+        @MarshalsValue
         public static @MachineSizedSInt long toNative(ValuedEnum v, long flags) {
             return v.value();
         }
@@ -171,7 +173,8 @@ public interface ValuedEnum {
         public static <T extends Enum<T> & ValuedEnum> ValuedEnum toObject(Class<T> cls, @MachineSizedUInt long value, long flags) {
             return AsLongMarshaler.toObject(cls, value, flags);
         }
-        
+
+        @MarshalsValue
         public static @MachineSizedUInt long toNative(ValuedEnum v, long flags) {
             return v.value();
         }


### PR DESCRIPTION
by adding missing @MarshalsValue to toNative methods. Otherwise compiler was not able to resolve to native marshaller for enum and went to parent class where it picked up default marshaller from ValuedEnum. This results in type difference in case type of enum data is not int and caused following exception:

> java.lang.IllegalArgumentException: Duplicate @StructMember(1) in @Packed structs (union in packed structs is not supported