### PR TITLE
Remove compiler/vm/target on mvn clean

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,13 @@
 #!/bin/sh
+
 set -e
-mvn clean install
+#if build environment changes (e.g. xcode path) this might be needed to clear cmake-cache in /compiler/vm/target
+if [ "$1" = '--fullclean' ];
+then
+    mvn clean install -Pclean-all
+else
+    mvn clean install 
+fi
 mvn -f plugins/idea/pom.xml clean install
 mvn -f plugins/eclipse/pom.xml clean install
 ./plugins/gradle/gradlew -b plugins/gradle/build.gradle clean assemble install

--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -68,6 +68,21 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>vm/target</directory>
+              <includes>
+		  <include>**/*</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <version>2.5.1</version>
         <configuration>

--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -62,25 +62,32 @@
         <javadoc.opts>-Xdoclint:none</javadoc.opts>
       </properties>
     </profile>
+    <profile>
+      <id>clean-all</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-clean-plugin</artifactId>
+            <configuration>
+              <filesets>
+                <fileset>
+                  <directory>vm/target</directory>
+                    <includes>
+        	      <include>**/*</include>
+                    </includes>
+                    <followSymlinks>false</followSymlinks>
+                </fileset>
+              </filesets>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-clean-plugin</artifactId>
-        <configuration>
-          <filesets>
-            <fileset>
-              <directory>vm/target</directory>
-              <includes>
-		  <include>**/*</include>
-              </includes>
-              <followSymlinks>false</followSymlinks>
-            </fileset>
-          </filesets>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION
Cmake uses caching for environment variables. If this folder is not
cleaned and evironment changes, cmake might not work properely.

We noticed that after removing a XCode beta version on catalina.