### PR TITLE
ios13_postfix#1: compiler, fixed resolving of block argument in generic type

### DIFF
--- a/compiler/compiler/src/test/java/org/robovm/compiler/plugin/objc/ObjCBlockPluginTest.java
+++ b/compiler/compiler/src/test/java/org/robovm/compiler/plugin/objc/ObjCBlockPluginTest.java
@@ -212,20 +212,18 @@ public class ObjCBlockPluginTest {
                 BOOLEAN);
     }
 
-    @Test(expected = CompilerException.class)
+    @Test
     public void testResolveTargetMethodSignatureGenericWithUnresolvedIndirectTypeVariable() throws Exception {
-        SootMethod target = toSootClass(F.class).getMethodByName("run");
-        SootMethod m = toSootClass(Runners.class).getMethodByName("runner7");
-        SootMethodType mType = new SootMethodType(m);
-        ObjCBlockPlugin.resolveTargetMethodSignature(m, target, mType.getGenericParameterTypes()[0]);
+        testResolveTargetMethodSignature("runner7",
+                classNameToType("java.lang.Object"), classNameToType("java.lang.Integer"),
+                classNameToType("java.lang.Integer"), BOOLEAN);
     }
 
-    @Test(expected = CompilerException.class)
+    @Test
     public void testResolveTargetMethodSignatureGenericWithUnresolvedDirectTypeVariable() throws Exception {
-        SootMethod target = toSootClass(F.class).getMethodByName("run");
-        SootMethod m = toSootClass(Runners.class).getMethodByName("runner8");
-        SootMethodType mType = new SootMethodType(m);
-        ObjCBlockPlugin.resolveTargetMethodSignature(m, target, mType.getGenericParameterTypes()[0]);
+        testResolveTargetMethodSignature("runner8",
+                classNameToType("java.lang.Object"), classNameToType("java.lang.Integer"),
+                classNameToType("java.lang.Number"), BOOLEAN);
     }
 
     @Test


### PR DESCRIPTION
Compiler fails when compiling `NSOrderedCollectionDifference` with exception:  
> org.robovm.compiler.CompilerException: Unresolved type variable T in parameter 1 of @Block method

This PR fixes block method parameter resolution by resolving arguments to Java classes level eliminating TypeVariable ones from it.