### PR TITLE
ios13_postfix#2: compiler, support for non-static @Bridge methods in ValuedEnums

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/BroMethodCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/BroMethodCompiler.java
@@ -551,9 +551,15 @@ public abstract class BroMethodCompiler extends AbstractMethodCompiler {
                 // NativeObjects are always passed by reference.
                 paramTypes.add(idx, I8_PTR);
             } else {
-                throw new IllegalArgumentException("Receiver of non static " 
-                        + anno + " method " + method 
-                        + " must either be a Struct or a NativeObject");
+                // ValueEnum supported using marshaller
+                MarshalerMethod marshalerMethod = config.getMarshalerLookup().findMarshalerMethod(new MarshalSite(method, MarshalSite.RECEIVER));
+                if (marshalerMethod instanceof ValueMarshalerMethod) {
+                    paramTypes.add(idx, ((ValueMarshalerMethod) marshalerMethod).getNativeType(config.getArch()));
+                } else {
+                    throw new IllegalArgumentException("Receiver of non static "
+                            + anno + " method " + method
+                            + " must either be a Struct, ValueEnum or a NativeObject");
+                }
             }
         }
 


### PR DESCRIPTION
non-static @Bridge methods happen for functions binding which first argument corresponds with receiver (e.g. class name it is being put). This works for Struct and NativeObject classes but doesn't for TypedEnum and failed with exception:
> Receiver of non static @Bridge method must either be a Struct or a NativeObject.

This PR adds support for TypedEnum as receiver to allow following method to be compiled: `UIImageSymbolWeight.toFontWeight`