### PR TITLE
ios13_postfix#3: compiler, adding support for @Block struct member types

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/ClassCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/ClassCompiler.java
@@ -776,13 +776,6 @@ public class ClassCompiler {
     }
     
     private void compile(Clazz clazz, OutputStream out) throws IOException {
-        javaMethodCompiler.reset(clazz);
-        bridgeMethodCompiler.reset(clazz);
-        callbackMethodCompiler.reset(clazz);
-        nativeMethodCompiler.reset(clazz);
-        structMemberMethodCompiler.reset(clazz);
-        globalValueMethodCompiler.reset(clazz);
-        
         ClazzInfo ci = clazz.resetClazzInfo();
 
         mb = new ModuleBuilder();
@@ -794,7 +787,20 @@ public class ClassCompiler {
         for (CompilerPlugin compilerPlugin : config.getCompilerPlugins()) {
             compilerPlugin.beforeClass(config, clazz, mb);
         }
-        
+
+        // dkimitsa: intentionally moved reset section after compiler plugin beforeClass invocation.
+        // one reason for this is structMemberMethodCompiler. it tries to resolve structure type
+        // and find out all marshallers but some of them (like ObjCBlock ones) are generated only
+        // in beforeClass. so to have all marshallers and generated classes in place, reset section
+        // is moved here. it shall have no affect as these compilers are not used by plugins itself
+        javaMethodCompiler.reset(clazz);
+        bridgeMethodCompiler.reset(clazz);
+        callbackMethodCompiler.reset(clazz);
+        nativeMethodCompiler.reset(clazz);
+        structMemberMethodCompiler.reset(clazz);
+        globalValueMethodCompiler.reset(clazz);
+
+
         sootClass = clazz.getSootClass();
         trampolines = new HashMap<>();
         catches = new HashSet<String>();

--- a/compiler/compiler/src/main/java/org/robovm/compiler/plugin/objc/ObjCBlockPlugin.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/plugin/objc/ObjCBlockPlugin.java
@@ -142,7 +142,7 @@ public class ObjCBlockPlugin extends AbstractCompilerPlugin {
             Map<String, Integer> blockTypeIds = new HashMap<>();
             for (SootMethod method : sootClass.getMethods()) {
                 if (method.isNative() && (hasBridgeAnnotation(method) || hasGlobalValueAnnotation(method))
-                    || hasCallbackAnnotation(method)) {
+                    || hasCallbackAnnotation(method) || hasStructMemberAnnotation(method)) {
                     
                     int[] indexes = getBlockParameterIndexes(method);
                     if (indexes != null || hasAnnotation(method, BLOCK)) {


### PR DESCRIPTION
adds support for blocks in structures. this fixes following exception when compiling CMBufferHandlers:
>java.lang.IllegalArgumentException: No @Marshaler found for return type of @StructMember method <org.robovm.apple.coremedia.CMBufferHandlers: org.robovm.objc.block.Block1 getGetDecodeTimeStamp()>
> at org.robovm.compiler.MarshalerLookup.findMarshalerMethod(MarshalerLookup.java:169)

In details there are several moments and fixes:   
- Marshallers for `@Block` affected methods are generated by `ObjCBlockPlugin` in `ObjCBlockPlugin.Before` class run. The problem here is that `ClassCompiler` invokes it after `StructMemberMethodCompiler.reset` where this marshaller is required (and where exception is happening). The fix is to move reset section of method compilers below  invocation of plugins `Before`. This makes marshallers generated at moment `StructMemberMethodCompiler.reset` needs it.
- Second moment is that `ObjCBlockPlugin.Before` was not considering @StructMember annotated methods as subject for method transformation and the fix is trivial -- extending condition to include the case. 
