### PR TITLE
ios13_postfix#3: compiler, fix for exception on JVM bridged methods with @Bridge annotation

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/ClassCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/ClassCompiler.java
@@ -862,7 +862,13 @@ public class ClassCompiler {
             String name = method.getName();
             Function function = null;
             if (hasBridgeAnnotation(method)) {
-                function = bridgeMethod(method);
+                // javac generates JVM synthetic bridge methods for covariant return
+                // and copies @Bridge annotations as well. Don't try to compile bridge methods
+                // as these are not a subject for RoboVM bridge compiler and it will fail on them
+                if (!isJvmSyntheticBridgeMethod(method))
+                    function = bridgeMethod(method);
+                else
+                    function = method(method);
             } else if (hasGlobalValueAnnotation(method)) {
                 function = globalValueMethod(method);
             } else if (isStruct(sootClass) && ("_sizeOf".equals(name) 
@@ -1032,6 +1038,16 @@ public class ClassCompiler {
             }
         }
         clazz.saveClazzInfo();
+    }
+
+    private boolean isJvmSyntheticBridgeMethod(SootMethod method) {
+        final int BRIDGE = 0x00000040;
+        final int SYNTHETIC = 0x00001000;
+
+        return !method.isAbstract() &&
+                !method.isNative() &&
+                (method.getModifiers() & BRIDGE) == BRIDGE &&
+                (method.getModifiers() & SYNTHETIC) == SYNTHETIC;
     }
 
     private static void addClassDependencyIfNeeded(Clazz clazz, soot.Type type, boolean weak) {
@@ -1489,7 +1505,7 @@ public class ClassCompiler {
                     body.add(linetableGlobal.ref());
                 }
             }
-            if (hasBridgeAnnotation(m)) {
+            if (hasBridgeAnnotation(m) && !isJvmSyntheticBridgeMethod(m)) {
                 if (!readBooleanElem(getAnnotation(m, BRIDGE), "dynamic", false)) {
                     body.add(new GlobalRef(Symbols.bridgePtrSymbol(m), I8_PTR));
                 } else {


### PR DESCRIPTION
this PR adds logic to skip bridged synthetic JVM methods added by compiler to handle overridden covariant return type methods. This fixes compiler exception while compiling `NWTxtRecord` class:

```
java.lang.IllegalArgumentException: @Bridge annotated method <org.robovm.apple.network.NWTxtRecord: org.robovm.apple.foundation.NSObject copy()> must be native
	at org.robovm.compiler.BridgeMethodCompiler.validateBridgeMethod(BridgeMethodCompiler.java:87)
	at org.robovm.compiler.BridgeMethodCompiler.doCompile(BridgeMethodCompiler.java:233)
```