### PR TITLE
release script: fixed bugs

### DIFF
--- a/plugins/eclipse/pom.xml
+++ b/plugins/eclipse/pom.xml
@@ -2,17 +2,8 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <prerequisites>
-        <maven>3.0</maven>
-    </prerequisites>
-
-    <parent>
-        <groupId>com.mobidevelop.robovm</groupId>
-        <artifactId>robovm-parent</artifactId>
-        <version>2.3.8-SNAPSHOT</version>
-        <relativePath>../../</relativePath>
-    </parent>
-
+    <groupId>com.mobidevelop.robovm</groupId>
+    <version>2.3.8-SNAPSHOT</version>
     <artifactId>org.robovm.eclipse.parent</artifactId>
     <name>RoboVM for Eclipse</name>
     <packaging>pom</packaging>
@@ -37,7 +28,8 @@
     </licenses>
 
     <properties>
-        <tycho.version>1.5.0-SNAPSHOT</tycho.version>
+        <robovm.version>2.3.8-SNAPSHOT</robovm.version>
+        <tycho.version>1.5.1</tycho.version>
         <eclipse-site>https://download.eclipse.org/releases/photon</eclipse-site>
     </properties>
 
@@ -47,27 +39,50 @@
             <url>${eclipse-site}</url>
             <layout>p2</layout>
         </repository>
-    </repositories>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>tycho-snapshots</id>
-            <url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</url>
+        <repository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
-        </pluginRepository>
-    </pluginRepositories>
+        </repository>
+    </repositories>
 
     <build>
         <plugins>
+            <!-- compiler: produce Java8 code everywhere by default -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>8</release>
+                    <debug>true</debug>
+                    <optimize>true</optimize>
+                    <encoding>UTF-8</encoding>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <!-- need to keep it this way, as MobiVM uses build number Z (from X.Y.Z) as release version -->
+                            <Specification-Version>${project.version}</Specification-Version>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.eclipse.tycho</groupId>
@@ -78,6 +93,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.0.0-M1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/plugins/eclipse/ui/pom.xml
+++ b/plugins/eclipse/ui/pom.xml
@@ -12,6 +12,19 @@
     <name>RoboVM for Eclipse Core and UI</name>
     <packaging>eclipse-plugin</packaging>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- include parent pom as bill of material to pick up dependency definitions from it -->
+            <dependency>
+                <groupId>com.mobidevelop.robovm</groupId>
+                <artifactId>robovm-parent</artifactId>
+                <version>${robovm.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <resources>
             <resource>

--- a/plugins/idea/build.gradle
+++ b/plugins/idea/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id "org.jetbrains.intellij" version "0.4.9"
+    id "org.jetbrains.intellij" version "0.4.12"
 }
 
 ext {

--- a/plugins/idea/pom.xml
+++ b/plugins/idea/pom.xml
@@ -1,13 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>com.mobidevelop.robovm</groupId>
-        <artifactId>robovm-parent</artifactId>
-        <version>2.3.8-SNAPSHOT</version>
-        <relativePath>../../</relativePath>
-    </parent>
-
+    <groupId>com.mobidevelop.robovm</groupId>
     <artifactId>org.robovm.idea</artifactId>
     <name>RoboVM plugin for Intellij IDEA</name>
     <version>2.3.8-SNAPSHOT</version>
@@ -24,6 +18,19 @@
         <url>https://github.com/MobiVM/robovm.git</url>
         <tag>HEAD</tag>
     </scm>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- include parent pom as bill of material to pick up dependency definitions from it -->
+            <dependency>
+                <groupId>com.mobidevelop.robovm</groupId>
+                <artifactId>robovm-parent</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -46,6 +53,19 @@
 
     <build>
         <plugins>
+            <!-- compiler: produce Java8 code everywhere by default -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>8</release>
+                    <debug>true</debug>
+                    <optimize>true</optimize>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>

--- a/plugins/idea/pom.xml
+++ b/plugins/idea/pom.xml
@@ -10,6 +10,7 @@
     <properties>
         <ij.plugin>true</ij.plugin>
         <ij.pluginDescriptor>src/main/resources/META-INF/plugin.xml</ij.pluginDescriptor>
+        <robovm.version>2.3.8-SNAPSHOT</robovm.version>
     </properties>
 
     <scm>
@@ -39,7 +40,7 @@
             <dependency>
                 <groupId>com.mobidevelop.robovm</groupId>
                 <artifactId>robovm-parent</artifactId>
-                <version>${project.version}</version>
+                <version>${robovm.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/plugins/idea/pom.xml
+++ b/plugins/idea/pom.xml
@@ -19,6 +19,20 @@
         <tag>HEAD</tag>
     </scm>
 
+    <repositories>
+        <repository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencyManagement>
         <dependencies>
             <!-- include parent pom as bill of material to pick up dependency definitions from it -->

--- a/release.sh
+++ b/release.sh
@@ -43,10 +43,6 @@ git push
 #
 cd ../idea
 
-# Set the pom version to the release version
-mvn versions:set -DnewVersion=$RELEASE_VERSION
-mvn versions:commit
-
 # Set the gradle version to the release version
 sed "s/^version *=.*/version = '$RELEASE_VERSION'/" build.gradle | sed "s/roboVMVersion *=.*/roboVMVersion = '$RELEASE_VERSION'/" > build.gradle.tmp
 mv build.gradle.tmp build.gradle
@@ -59,9 +55,12 @@ git push
 # Copy the target/*-dist.jar to whereever you want it
 scp build/distributions/idea-$RELEASE_VERSION.zip robovm@robovm.mobidevelop.com:/usr/share/nginx/html/downloads/releases/idea
 
-# Set the pom version to the next development version
+# Set the pom version to the next development version (it always have to be development)
 mvn versions:set -DnewVersion=$DEVELOPMENT_VERSION-SNAPSHOT
 mvn versions:commit
+mv pom.xml pom.xml.bak && sed "s/<robovm.version>.*<\/robovm.version>/<robovm.version>$DEVELOPMENT_VERSION-SNAPSHOT<\/robovm.version>/" pom.xml.bak > pom.xml
+rm pom.xml.bak
+
 # Set the gradle version to the next development version
 sed "s/^version *=.*/version = '$DEVELOPMENT_VERSION-SNAPSHOT'/" build.gradle | sed "s/roboVMVersion *=.*/roboVMVersion = '$DEVELOPMENT_VERSION-SNAPSHOT'/" > build.gradle.tmp
 mv build.gradle.tmp build.gradle

--- a/release.sh
+++ b/release.sh
@@ -6,16 +6,20 @@ export RELEASE_VERSION=$RELEASE_VERSION
 export DEVELOPMENT_VERSION=$DEVELOPMENT_VERSION
 export TIMESTAMP=`date +"%Y%m%d%H%M"`
 
+#
 # release compiler/ and dist/
+#
 mvn --batch-mode -Dtag=robovm-$RELEASE_VERSION -DreleaseVersion=$RELEASE_VERSION -DdevelopmentVersion=$DEVELOPMENT_VERSION-SNAPSHOT release:prepare
 mvn --batch-mode -Dtag=robovm-$RELEASE_VERSION -DreleaseVersion=$RELEASE_VERSION -DdevelopmentVersion=$DEVELOPMENT_VERSION-SNAPSHOT release:perform
 
+#
 # release plugins/eclipse
+#
 cd plugins/eclipse
 
 # Set the pom version to the release version
-mvn org.eclipse.tycho:tycho-versions-plugin:0.20.0:set-version -DnewVersion="$RELEASE_VERSION.$TIMESTAMP"
-mv ui/pom.xml ui/pom.xml.bak && sed "s/<robovm.version>.*<\/robovm.version>/<robovm.version>$RELEASE_VERSION<\/robovm.version>/" ui/pom.xml.bak > ui/pom.xml
+mvn org.eclipse.tycho:tycho-versions-plugin:1.5.1:set-version -DnewVersion="$RELEASE_VERSION.$TIMESTAMP"
+mv pom.xml pom.xml.bak && sed "s/<robovm.version>.*<\/robovm.version>/<robovm.version>$RELEASE_VERSION<\/robovm.version>/" pom.xml.bak > pom.xml
 
 
 # Create the update site for the release version
@@ -28,37 +32,49 @@ ssh robovm@robovm.mobidevelop.com "mkdir -p /usr/share/nginx/html/downloads/rele
 scp -r update-site/target/site/ robovm@robovm.mobidevelop.com:/usr/share/nginx/html/downloads/releases/eclipse/$RELEASE_VERSION/
 
 # Set the pom version to the next development version
-mv ui/pom.xml.bak ui/pom.xml
-mvn org.eclipse.tycho:tycho-versions-plugin:0.20.0:set-version -DnewVersion="$DEVELOPMENT_VERSION-SNAPSHOT"
+mvn org.eclipse.tycho:tycho-versions-plugin:1.5.1:set-version -DnewVersion="$DEVELOPMENT_VERSION-SNAPSHOT"
+mv pom.xml pom.xml.bak && sed "s/<robovm.version>.*<\/robovm.version>/<robovm.version>$DEVELOPMENT_VERSION-SNAPSHOT<\/robovm.version>/" pom.xml.bak > pom.xml
+rm pom.xml.bak
 git commit -am "Set next development version of Eclipse plugin, $DEVELOPMENT_VERSION"
 git push
 
+#
 # release plugins/idea
+#
 cd ../idea
 
 # Set the pom version to the release version
 mvn versions:set -DnewVersion=$RELEASE_VERSION
 mvn versions:commit
 
-# Create the plugin Jar for the release version
-mvn clean install -Pdeployment
+# Set the gradle version to the release version
+sed "s/^version *=.*/version = '$RELEASE_VERSION'/" build.gradle | sed "s/roboVMVersion *=.*/roboVMVersion = '$RELEASE_VERSION'/" > build.gradle.tmp
+mv build.gradle.tmp build.gradle
+
+# Create the plugin Zip for the release version
+./gradlew clean buildPlugin
 git commit -am "Set release version of IDEA plugin, $RELEASE_VERSION"
 git push
 
 # Copy the target/*-dist.jar to whereever you want it
-scp target/org.robovm.idea-$RELEASE_VERSION-plugin-dist.jar robovm@robovm.mobidevelop.com:/usr/share/nginx/html/downloads/releases/idea
+scp build/distributions/idea-$RELEASE_VERSION.zip robovm@robovm.mobidevelop.com:/usr/share/nginx/html/downloads/releases/idea
 
 # Set the pom version to the next development version
 mvn versions:set -DnewVersion=$DEVELOPMENT_VERSION-SNAPSHOT
 mvn versions:commit
+# Set the gradle version to the next development version
+sed "s/^version *=.*/version = '$DEVELOPMENT_VERSION-SNAPSHOT'/" build.gradle | sed "s/roboVMVersion *=.*/roboVMVersion = '$DEVELOPMENT_VERSION-SNAPSHOT'/" > build.gradle.tmp
+mv build.gradle.tmp build.gradle
 git commit -am "Set next development version of IDEA plugin, $DEVELOPMENT_VERSION"
 git push
 
+#
 # Publish Gradle plugin
+#
 cd ../gradle
 
 # Set release version
-sed "s/^version *=.*/version = '$RELEASE_VERSION'/" build.gradle | sed "s/roboVMVersion *=.*/    roboVMVersion = '$RELEASE_VERSION'/" > build.gradle.tmp
+sed "s/^version *=.*/version = '$RELEASE_VERSION'/" build.gradle | sed "s/roboVMVersion *=.*/roboVMVersion = '$RELEASE_VERSION'/" > build.gradle.tmp
 mv build.gradle.tmp build.gradle
 ./gradlew clean build install
 git commit -am "Set release version of Gradle plugin, $RELEASE_VERSION"
@@ -68,7 +84,7 @@ git push
 ./gradlew uploadArchives
 
 # Set development version
-sed "s/^version *=.*/version = '$DEVELOPMENT_VERSION-SNAPSHOT'/" build.gradle | sed "s/roboVMVersion *=.*/    roboVMVersion = '$DEVELOPMENT_VERSION-SNAPSHOT'/" > build.gradle.tmp
+sed "s/^version *=.*/version = '$DEVELOPMENT_VERSION-SNAPSHOT'/" build.gradle | sed "s/roboVMVersion *=.*/roboVMVersion = '$DEVELOPMENT_VERSION-SNAPSHOT'/" > build.gradle.tmp
 mv build.gradle.tmp build.gradle
 
 git commit -am "Set next development version of Gradle plugin, $DEVELOPMENT_VERSION-SNAPSHOT"


### PR DESCRIPTION
this PR fixes release.sh script in JDK12 branch. it was broken by new maven project tree. 
- eclipse and idea maven scripts are stand-alone now (have no parent, as it was before updates). this is required as maven version update plugins are not able to update version in PARENT section when calling not from project root;
- eclipse tycho plugin updated to stable version 