### PR TITLE
fixed: missing iOS 13.3 simulators

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/SDK.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/SDK.java
@@ -16,31 +16,21 @@
  */
 package org.robovm.compiler.target.ios;
 
-import static java.util.Collections.emptyList;
-import static org.apache.commons.lang3.Validate.notNull;
+import com.dd.plist.NSDictionary;
+import com.dd.plist.NSObject;
+import com.dd.plist.PropertyListParser;
+import org.apache.commons.exec.util.StringUtils;
+import org.robovm.compiler.util.ToolchainUtil;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import com.dd.plist.NSDictionary;
-import com.dd.plist.NSObject;
-import com.dd.plist.PropertyListParser;
-import org.apache.commons.exec.util.StringUtils;
-import org.apache.commons.lang3.Validate;
-import org.robovm.compiler.util.ToolchainUtil;
 
 /**
  * Contains info on an SDK installed on the system.
  */
 public class SDK implements Comparable<SDK> {
-    private static final String ADDITIONAL_SDK_LOCATION = "/Library/Developer/CoreSimulator/Profiles/Runtimes";
-    private static final String IOS_SIMULATOR_MAJOR_MINOR_VERSION_REGEX = "iOS ([0-9]{1,2}).([0-9]{1,2}).simruntime";
-    private static final Pattern IOS_SIMULATOR_MAJOR_MINOR_VERSION_REGEX_PATTERN = Pattern.compile(IOS_SIMULATOR_MAJOR_MINOR_VERSION_REGEX);
-
     private String displayName;
     private String minimalDisplayName;
     private String canonicalName;
@@ -114,49 +104,6 @@ public class SDK implements Comparable<SDK> {
         return allSdks;
     }
 
-    private static Collection<? extends SDK> listAdditionalFileFormatSdks() {
-        File sdksDir = new File(ADDITIONAL_SDK_LOCATION);
-        if (!sdksDir.isDirectory()) {
-            return emptyList();
-        }
-
-        List<SDK> sdks = new ArrayList<>();
-
-        for (File sdkRoot : notNull(sdksDir.listFiles())) {
-            if (sdkRoot.getName().matches(IOS_SIMULATOR_MAJOR_MINOR_VERSION_REGEX)) {
-                sdks.add(createAdditionalFileFormatSdk(sdkRoot));
-            }
-        }
-
-        return sdks;
-    }
-
-    /**
-     * New directory format SDKs, as downloaded by Xcode version >= 8.3.
-     * <p>Fills only some of the data of the SDK, but enough to use it as Simulator.</p>
-     */
-    static SDK createAdditionalFileFormatSdk(File sdkRootDir) {
-
-        Matcher matcher = IOS_SIMULATOR_MAJOR_MINOR_VERSION_REGEX_PATTERN.matcher(sdkRootDir.getName());
-        Validate.isTrue(matcher.find());
-
-        String majorVersion = matcher.group(1);
-        String minorVersion = matcher.group(2);
-
-        String name = sdkRootDir.getName();
-
-        SDK sdk = new SDK();
-        sdk.major = Integer.valueOf(majorVersion);
-        sdk.minor = Integer.valueOf(minorVersion);
-        sdk.minimalDisplayName = name;
-        sdk.displayName = name;
-        sdk.canonicalName = name;
-        sdk.version = majorVersion + "." + minorVersion;
-        sdk.root = sdkRootDir;
-
-        return sdk;
-    }
-
     /**
      * List SDKs bundled with Xcode.
      */
@@ -188,7 +135,6 @@ public class SDK implements Comparable<SDK> {
 
     public static List<SDK> listSimulatorSDKs() {
         List<SDK> sdks = listSDKs("iPhoneSimulator");
-        sdks.addAll(listAdditionalFileFormatSdks());
         return sdks;
     }
 

--- a/compiler/compiler/src/test/java/org/robovm/compiler/target/ios/SDKTest.java
+++ b/compiler/compiler/src/test/java/org/robovm/compiler/target/ios/SDKTest.java
@@ -11,26 +11,6 @@ import org.junit.Test;
 public class SDKTest {
 
     @Test
-    public void createAdditionalFileFormatSdkWorksFor8_1() {
-        File rootDir = new File("/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 8.1.simruntime");
-        SDK sdk = SDK.createAdditionalFileFormatSdk(rootDir);
-
-        assertEquals(8, sdk.getMajor());
-        assertEquals(1, sdk.getMinor());
-        assertEquals(rootDir, sdk.getRoot());
-    }
-
-    @Test
-    public void createAdditionalFileFormatSdkWorksFor10_11() {
-        File rootDir = new File("/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 10.11.simruntime");
-        SDK sdk = SDK.createAdditionalFileFormatSdk(rootDir);
-
-        assertEquals(10, sdk.getMajor());
-        assertEquals(11, sdk.getMinor());
-        assertEquals(rootDir, sdk.getRoot());
-    }
-
-    @Test
     public void listSimulatorSdksShouldNotCrash() {
         if (isXcodeInstalled()) {
             // No real asserts, as response depends on building machine. At least it should not throw an exception.

--- a/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmIOSRunConfigurationSettingsEditor.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmIOSRunConfigurationSettingsEditor.java
@@ -72,7 +72,7 @@ public class RoboVmIOSRunConfigurationSettingsEditor extends SettingsEditor<Robo
         config.setProvisioningProfile(provisioningProfile.getSelectedItem().toString());
         config.setSimArch((Arch) simArch.getSelectedItem());
         config.setSimulatorName(((SimTypeWrapper) simType.getSelectedItem()).getType().getDeviceName());
-        config.setSimulatorSdk(((SimTypeWrapper) simType.getSelectedItem()).getType().getSdk().getVersionCode());
+        config.setSimulatorSdk(((SimTypeWrapper) simType.getSelectedItem()).getType().getVersion().versionCode);
         config.setArguments(args.getText());
     }
 
@@ -121,15 +121,15 @@ public class RoboVmIOSRunConfigurationSettingsEditor extends SettingsEditor<Robo
         int bestDefaultSimMatchIdx = -1, bestDefaultSimMatchVersion = -1;
         for (DeviceType type : DeviceType.listDeviceTypes()) {
             simType.addItem(new SimTypeWrapper(type));
-            if (type.getDeviceName().equals(config.getSimulatorName()) && type.getSdk().getVersionCode() == config.getSimulatorSdk()) {
+            if (type.getDeviceName().equals(config.getSimulatorName()) && type.getVersion().versionCode == config.getSimulatorSdk()) {
                 exactSimVersonMatchIdx = simType.getItemCount() - 1;
-            } else if (type.getDeviceName().equals(config.getSimulatorName()) && type.getSdk().getVersionCode() > bestSimNameMatchVersion) {
+            } else if (type.getDeviceName().equals(config.getSimulatorName()) && type.getVersion().versionCode > bestSimNameMatchVersion) {
                 bestSimNameMatchIdx = simType.getItemCount() - 1;
-                bestSimNameMatchVersion = type.getSdk().getVersionCode();
+                bestSimNameMatchVersion = type.getVersion().versionCode;
             } else if (config.getSimulatorName().isEmpty() && type.getDeviceName().contains("iPhone-6") &&
-                    !type.getDeviceName().contains("Plus") && type.getSdk().getVersionCode() > bestDefaultSimMatchVersion) {
+                    !type.getDeviceName().contains("Plus") && type.getVersion().versionCode > bestDefaultSimMatchVersion) {
                 bestDefaultSimMatchIdx = simType.getItemCount() - 1;
-                bestDefaultSimMatchVersion = type.getSdk().getVersionCode();
+                bestDefaultSimMatchVersion = type.getVersion().versionCode;
             }
         }
         if (exactSimVersonMatchIdx < 0) {
@@ -229,7 +229,7 @@ public class RoboVmIOSRunConfigurationSettingsEditor extends SettingsEditor<Robo
 
         @Override
         public String toString() {
-            return type.getSimpleDeviceName() + " - " + type.getSdk().getVersion();
+            return type.getSimpleDeviceName() + " - " + type.getVersion();
         }
     }
 }

--- a/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmRunProfileState.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmRunProfileState.java
@@ -101,12 +101,12 @@ public class RoboVmRunProfileState extends CommandLineState {
                 DeviceType bestType = null;
                 int bestTypeVersion = -1;
                 for(DeviceType type: DeviceType.listDeviceTypes()) {
-                    if (type.getDeviceName().equals(runConfig.getSimulatorName()) && type.getSdk().getVersionCode() == runConfig.getSimulatorSdk()) {
+                    if (type.getDeviceName().equals(runConfig.getSimulatorName()) && type.getVersion().versionCode == runConfig.getSimulatorSdk()) {
                         exactType = type;
                         break;
-                    } else if (type.getDeviceName().equals(runConfig.getSimulatorName()) && type.getSdk().getVersionCode() > bestTypeVersion) {
+                    } else if (type.getDeviceName().equals(runConfig.getSimulatorName()) && type.getVersion().versionCode > bestTypeVersion) {
                         bestType = type;
-                        bestTypeVersion = type.getSdk().getVersionCode();
+                        bestTypeVersion = type.getVersion().versionCode;
                     }
                 }
                 if (exactType == null)


### PR DESCRIPTION
Simulator device type doesn't depend now on SDK available with Xcode.
Missing of iOS 13.3 SDK caused robovm to skip simulators.