### PR TITLE
fix: enabling parallel build of VM native code

### DIFF
--- a/compiler/vm/bc/src/CMakeLists.txt
+++ b/compiler/vm/bc/src/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(robovm-bc STATIC
   classinfo.c
   MurmurHash3.c
 )
+add_dependencies(robovm-bc extgc)
 
 set_target_properties(robovm-bc PROPERTIES SUFFIX "${LIB_SUFFIX}")
 install(TARGETS robovm-bc DESTINATION ${INSTALL_DIR})

--- a/compiler/vm/build.sh
+++ b/compiler/vm/build.sh
@@ -4,6 +4,7 @@ SELF=$(basename $0)
 BASE=$(cd $(dirname $0); pwd -P)
 CLEAN=0
 VERBOSE=
+WORKERS=6
 
 function usage {
   cat <<EOF
@@ -113,7 +114,7 @@ for T in $TARGETS; do
     BUILD_TYPE=$B
     mkdir -p "$BASE/target/build/$T-$B"
     rm -rf "$BASE/binaries/$OS/$ARCH/$B"
-    bash -c "cd '$BASE/target/build/$T-$B'; cmake -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DOS=$OS -DARCH=$ARCH '$BASE'; make $VERBOSE install"
+    bash -c "cd '$BASE/target/build/$T-$B'; cmake -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DOS=$OS -DARCH=$ARCH '$BASE'; make -j $WORKERS $VERBOSE install"
     R=$?
     if [[ $R != 0 ]]; then
       echo "$T-$B build failed"

--- a/compiler/vm/core/src/CMakeLists.txt
+++ b/compiler/vm/core/src/CMakeLists.txt
@@ -51,7 +51,9 @@ set_target_properties(robovm-core PROPERTIES SUFFIX "${LIB_SUFFIX}")
 install(TARGETS robovm-core DESTINATION ${INSTALL_DIR})
 
 add_executable(test_call0 test/test_call0.c test/CuTest.c call0-${OS_FAMILY}-${ARCH}.s unwind.c)
+add_dependencies(test_call0 extgc)
 add_library(test_call0_lib STATIC test/test_call0.c test/CuTest.c call0-${OS_FAMILY}-${ARCH}.s unwind.c)
+add_dependencies(test_call0_lib extgc)
 set_property(SOURCE test/test_call0.c PROPERTY COMPILE_FLAGS "-O0") # Disable optimizations
 add_test(testCall0ReturnByte test_call0 "testCall0ReturnByte")
 add_test(testCall0ReturnInt test_call0 "testCall0ReturnInt")
@@ -64,7 +66,9 @@ add_test(testCall0ManyArgsOfEach test_call0 "testCall0ManyArgsOfEach")
 add_test(testCall0Unwind test_call0 "testCall0Unwind")
 
 add_executable(test_proxy0 test/test_proxy0.c test/CuTest.c proxy0-${OS_FAMILY}-${ARCH}.s unwind.c)
+add_dependencies(test_proxy0 extgc)
 add_library(test_proxy0_lib test/test_proxy0.c test/CuTest.c proxy0-${OS_FAMILY}-${ARCH}.s unwind.c)
+add_dependencies(test_proxy0_lib extgc)
 set_property(SOURCE test/test_proxy0.c PROPERTY COMPILE_FLAGS "-O0") # Disable optimizations
 add_test(testProxy0ReturnByte test_proxy0 "testProxy0ReturnByte")
 add_test(testProxy0ReturnInt test_proxy0 "testProxy0ReturnInt")
@@ -78,7 +82,9 @@ add_test(testProxy0Unwind test_proxy0 "testProxy0Unwind")
 add_test(testProxy0ReturnAddress test_proxy0 "testProxy0ReturnAddress")
 
 add_executable(test_trycatch test/test_trycatch.c test/CuTest.c trycatch-${OS_FAMILY}-${ARCH}.s)
+add_dependencies(test_trycatch extgc)
 add_library(test_trycatch_lib test/test_trycatch.c test/CuTest.c trycatch-${OS_FAMILY}-${ARCH}.s)
+add_dependencies(test_trycatch_lib extgc)
 set_property(SOURCE test/test_trycatch.c PROPERTY COMPILE_FLAGS "-O0") # Disable optimizations
 add_test(testTrycatchEnterLeaveOnce test_trycatch "testTrycatchEnterLeaveOnce")
 add_test(testTrycatchEnterLeaveMultiple test_trycatch "testTrycatchEnterLeaveMultiple")

--- a/compiler/vm/debug/src/CMakeLists.txt
+++ b/compiler/vm/debug/src/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SRC
 )
 
 add_library(robovm-debug STATIC ${SRC})
+add_dependencies(robovm-debug extgc)
 
 set_target_properties(robovm-debug PROPERTIES SUFFIX "${LIB_SUFFIX}")
 install(TARGETS robovm-debug DESTINATION ${INSTALL_DIR})

--- a/compiler/vm/frameworksupport/src/CMakeLists.txt
+++ b/compiler/vm/frameworksupport/src/CMakeLists.txt
@@ -8,7 +8,7 @@ if(APPLE)
 	)
 
 	add_library(robovm-frameworksupport STATIC ${SRC})
-
+	add_dependencies(robovm-frameworksupport extgc)
 	set_target_properties(robovm-frameworksupport PROPERTIES SUFFIX "${LIB_SUFFIX}")
 	install(TARGETS robovm-frameworksupport DESTINATION ${INSTALL_DIR})
 endif()

--- a/compiler/vm/rt/CMakeLists.txt
+++ b/compiler/vm/rt/CMakeLists.txt
@@ -4,6 +4,7 @@ add_subdirectory(robovm)
 add_subdirectory(android)
 
 add_library(robovm-rt STATIC ${ROBOVM_RT_CORE_OBJECTS} ${ANDROID_OBJECTS})
+add_dependencies(robovm-rt extgc)
 set_target_properties(robovm-rt PROPERTIES SUFFIX "${LIB_SUFFIX}")
 merge_static_lib_object_files(robovm-rt 'Java_*' 'rvmRT*')
 install(TARGETS robovm-rt DESTINATION ${INSTALL_DIR})

--- a/compiler/vm/rt/robovm/CMakeLists.txt
+++ b/compiler/vm/rt/robovm/CMakeLists.txt
@@ -42,5 +42,6 @@ if(DARWIN)
 endif()
 
 add_library(robovm-rt-core OBJECT ${SRC})
+add_dependencies(robovm-rt-core extgc)
 set(ROBOVM_RT_CORE_OBJECTS $<TARGET_OBJECTS:robovm-rt-core> PARENT_SCOPE)
 


### PR DESCRIPTION
parallel build was broken as most of modules hadn't no dependency set to extgc as result these failed in parallel mode. 
with these dependencies android RT(has no dependency to extgc) starts building first while libatomic/bdwgc is being downloaded. once dbwgc is ready all other modules being build in parallel. 