### PR TITLE
Switch use of maven http to https since http is no longer supported.

### DIFF
--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -149,7 +149,7 @@
   <pluginRepositories>
     <pluginRepository>
       <id>maven.org</id>
-      <url>http://repo1.maven.org/maven2/</url>
+      <url>https://repo1.maven.org/maven2/</url>
       <releases><enabled>true</enabled></releases>
     </pluginRepository>
     <pluginRepository>

--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMTask.java
@@ -360,7 +360,7 @@ abstract public class AbstractRoboVMTask extends DefaultTask {
 
     private List<RemoteRepository> createRemoteRepositories() {
         List<RemoteRepository> repositories = new ArrayList<>();
-        repositories.add(new RemoteRepository("maven-central", "default", "http://repo1.maven.org/maven2/"));
+        repositories.add(new RemoteRepository("maven-central", "default", "https://repo1.maven.org/maven2/"));
         repositories.add(new RemoteRepository("oss.sonatype.org-snapshots", "default",
                 "https://oss.sonatype.org/content/repositories/snapshots/"));
 

--- a/plugins/resolver/pom.xml
+++ b/plugins/resolver/pom.xml
@@ -12,7 +12,7 @@
   </parent>
 
   <properties>
-    <version.shrinkwrap.resolvers>2.2.6</version.shrinkwrap.resolvers>
+    <version.shrinkwrap.resolvers>3.1.3</version.shrinkwrap.resolvers>
     <robovm.version>${project.version}</robovm.version>
   </properties>
 


### PR DESCRIPTION
Http is no longer supported by the repo1 maven repo and the robovm-maven-resolver test is failing due to the 501 error related to that.

https://support.sonatype.com/hc/en-us/articles/360041287334

This tweaks a few places we use http to be https and updates the shrinkwrap maven resolver to also pull in a change related to https.