### PR TITLE
Fixes for artifact repositories

### DIFF
--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -149,12 +149,8 @@
   <pluginRepositories>
     <pluginRepository>
       <id>maven.org</id>
-      <url>http://repo1.maven.org/maven2/</url>
+      <url>https://repo1.maven.org/maven2/</url>
       <releases><enabled>true</enabled></releases>
-    </pluginRepository>
-    <pluginRepository>
-      <id>Codehaus repository</id>
-      <url>http://repository.codehaus.org/</url>
     </pluginRepository>
   </pluginRepositories>
   

--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMTask.java
@@ -360,7 +360,7 @@ abstract public class AbstractRoboVMTask extends DefaultTask {
 
     private List<RemoteRepository> createRemoteRepositories() {
         List<RemoteRepository> repositories = new ArrayList<>();
-        repositories.add(new RemoteRepository("maven-central", "default", "http://repo1.maven.org/maven2/"));
+        repositories.add(new RemoteRepository("maven-central", "default", "https://repo1.maven.org/maven2/"));
         repositories.add(new RemoteRepository("oss.sonatype.org-snapshots", "default",
                 "https://oss.sonatype.org/content/repositories/snapshots/"));
 


### PR DESCRIPTION
Changed to HTTPS for Maven Central (required from January 15, 2020). Removed no longer existing Codehaus repository.