### PR TITLE
debugger maintaince (2020)

### DIFF
--- a/compiler/vm/core/src/hooks.c
+++ b/compiler/vm/core/src/hooks.c
@@ -1177,9 +1177,6 @@ static inline char getSuspendedEvent(DebugEnv* debugEnv, jint lineNumberOffset, 
     if (debugEnv->suspended) {
         return EVT_THREAD_SUSPENDED;
     }
-    if (debugEnv->stepping && ((pc >= debugEnv->pclow && pc < debugEnv->pchigh) || (pc >= debugEnv->pclow2 && pc < debugEnv->pchigh2))) {
-        return EVT_THREAD_STEPPED;
-    }
 
     // we only check for breakpoints if we aren't invoking
     // lineNumberOffset may be < 0 if the instrumented unit
@@ -1189,6 +1186,12 @@ static inline char getSuspendedEvent(DebugEnv* debugEnv, jint lineNumberOffset, 
             return EVT_BREAKPOINT;
         }
     }
+
+    // check stepping only after breakpoint check. Otherwise breakpoint in one line loops will be ignored
+    if (debugEnv->stepping && ((pc >= debugEnv->pclow && pc < debugEnv->pchigh) || (pc >= debugEnv->pclow2 && pc < debugEnv->pchigh2))) {
+        return EVT_THREAD_STEPPED;
+    }
+
     return 0;
 }
 

--- a/plugins/debugger/src/main/java/org/robovm/debugger/delegates/InstanceUtils.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/delegates/InstanceUtils.java
@@ -675,7 +675,8 @@ public class InstanceUtils {
         String name = readStringValue(nameInstance);
         VmThreadGroup threadGroup = getFieldValue(objectPtr, ci, ClassDataConsts.fields.JAVA_LANG_THREAD_GROUP);
 
-        return new VmThread(objectPtr, (Long)threadPtr, ci, name, threadGroup);
+        // allow null threadPtr, when thread object is created but thread is not started (attached)
+        return new VmThread(objectPtr, threadPtr != null ? (Long)threadPtr : 0L, ci, name, threadGroup);
     }
 
     private VmThreadGroup createThreadGroupInstance(ClassInfo ci, long objectPtr, @SuppressWarnings("unused") Object unused) {

--- a/plugins/debugger/src/main/java/org/robovm/debugger/delegates/JdwpEventCenterDelegate.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/delegates/JdwpEventCenterDelegate.java
@@ -732,6 +732,10 @@ public class JdwpEventCenterDelegate implements IJdwpEventDelegate {
             return null;
         }
 
+        // skip synthetic methods from being visible to debugger
+        if (methodInfo.isBridge() || methodInfo.isBroCallback() || methodInfo.isBroBridge())
+            return null;
+
         return new VmStackTrace(classInfo, methodInfo, payload.lineNumber(), payload.fp(), payload.pc() - payload.impl());
     }
 

--- a/plugins/debugger/src/main/java/org/robovm/debugger/delegates/RuntimeUtils.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/delegates/RuntimeUtils.java
@@ -23,6 +23,7 @@ import org.robovm.debugger.state.instances.VmThread;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * @author Demyan Kimitsa
@@ -119,7 +120,7 @@ public class RuntimeUtils {
      * @param thread to step
      * @param depth of step, {@link org.robovm.debugger.jdwp.JdwpConsts.StepDepth}
      */
-    public RuntimeStepReference step(VmThread thread, int depth) {
+    public RuntimeStepReference step(VmThread thread, int depth, Predicate<VmStackTrace> stackTraceValidator) {
         long pclow;
         long pchigh;
         long pclow2;
@@ -137,7 +138,7 @@ public class RuntimeUtils {
             // find out previous not native entry
             VmStackTrace prevStackEntry = null;
             for (int idx = 1; idx < stack.length; idx++) {
-                if (stack[idx].methodInfo().isNative())
+                if (stack[idx].methodInfo().isNative() || !stackTraceValidator.test(stack[idx]))
                     continue;
                 prevStackEntry = stack[idx];
                 break;

--- a/plugins/debugger/src/main/java/org/robovm/debugger/delegates/ThreadDelegate.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/delegates/ThreadDelegate.java
@@ -50,7 +50,7 @@ public class ThreadDelegate implements IJdwpThreadDelegate {
         int suspendCount = thread.markSuspended();
         if (suspendCount == 1) {
             delegates.hooksApi().threadSuspend(thread.threadPtr());
-            thread.setStatus(VmThread.Status.SUPENDED);
+            thread.setStatus(VmThread.Status.SUSPENDED);
         }
     }
 
@@ -103,7 +103,7 @@ public class ThreadDelegate implements IJdwpThreadDelegate {
         if (keepSuspended) {
             setThreadStack(thread, stack);
             thread.markSuspended();
-            thread.setStatus(VmThread.Status.SUPENDED);
+            thread.setStatus(VmThread.Status.SUSPENDED);
         } else {
             if (thread.suspendCount() == 0) {
                 // thread is not suspended and this event is filtered out, so resume thread
@@ -166,7 +166,7 @@ public class ThreadDelegate implements IJdwpThreadDelegate {
      */
     public VmThread anySuspendedThread() {
         for (VmThread thread : delegates.state().threads()) {
-            if (thread.status() == VmThread.Status.SUPENDED)
+            if (thread.status() == VmThread.Status.SUSPENDED)
                 return thread;
         }
         return null;

--- a/plugins/debugger/src/main/java/org/robovm/debugger/jdwp/handlers/eventrequest/events/JdwpEventRequest.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/jdwp/handlers/eventrequest/events/JdwpEventRequest.java
@@ -48,6 +48,14 @@ public class JdwpEventRequest {
         return true;
     }
 
+    public boolean test(EventData data, int modifierKind) {
+        // test through specific predicates
+        for (EventPredicate predicate : predicates)
+            if (predicate.modifierKind() == modifierKind && !predicate.test(data))
+                return false;
+        return true;
+    }
+
     public int requestId() {
         return requestId;
     }

--- a/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/ClassInfoImpl.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/ClassInfoImpl.java
@@ -214,7 +214,7 @@ public class ClassInfoImpl extends ClassInfo {
             MethodInfo methodInfo = new MethodInfo();
             methods[idx] = methodInfo;
             methodInfo.readMethodInfo(reader);
-            if (methodInfo.isBridge() || methodInfo.isBroCallback() || methodInfo.isBroCallback() || methodInfo.isBroBridge()) {
+            if (methodInfo.isBridge() || methodInfo.isBroCallback() || methodInfo.isBroBridge()) {
                 // mark bridge and callbacks as native just to keep debugger away from attempts to get information about
                 // these methods(line tables etc)
                 methodInfo.markAsNative();

--- a/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/MethodInfo.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/MethodInfo.java
@@ -166,11 +166,11 @@ public class MethodInfo extends BaseModifiersInfo {
         return spFpAlign;
     }
 
-    boolean isBroCallback() {
+    public boolean isBroCallback() {
         return (flags & ClassDataConsts.methodinfo.BRO_CALLBACK) != 0;
     }
 
-    boolean isBroBridge() {
+    public boolean isBroBridge() {
         return (flags & ClassDataConsts.methodinfo.BRO_BRIDGE) != 0;
     }
 

--- a/plugins/debugger/src/main/java/org/robovm/debugger/state/instances/VmThread.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/state/instances/VmThread.java
@@ -24,12 +24,12 @@ import org.robovm.debugger.state.classdata.ClassInfo;
 public class VmThread extends VmInstance {
 
     public enum Status {
-        SUPENDED,
+        SUSPENDED,
         RUNNING
     }
 
     /** native (not java) thread object pointer */
-    private final long threadPtr;
+    private long threadPtr;
 
     /** thread name */
     private final String name;
@@ -79,6 +79,10 @@ public class VmThread extends VmInstance {
 
     public long threadPtr() {
         return threadPtr;
+    }
+
+    public void attach(long threadPtr) {
+        this.threadPtr = threadPtr;
     }
 
     public VmStackTrace[] stack() {

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/bytebuffer/ByteBufferReader.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/bytebuffer/ByteBufferReader.java
@@ -260,7 +260,13 @@ public abstract class ByteBufferReader {
             throw new DebuggerException("Cant read zero number of bytes!");
 
         expects(numBytes);
-        return Arrays.copyOfRange(byteBuffer.array(), byteBuffer.position(),  byteBuffer.position() + numBytes);
+        if (byteBuffer.hasArray())
+            return Arrays.copyOfRange(byteBuffer.array(), byteBuffer.position(),  byteBuffer.position() + numBytes);
+        else {
+            byte[] res = new byte[numBytes];
+            byteBuffer.get(res);
+            return res;
+        }
     }
 
 

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/MachOLoader.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/MachOLoader.java
@@ -209,7 +209,7 @@ public class MachOLoader {
             return null;
 
         return new ByteBufferMemoryReader(rootReader, 0, rootReader.size(), isPatform64Bit(),
-                regions.toArray(new ByteBufferMemoryReader.MemoryRegion[regions.size()]));
+                regions.toArray(new ByteBufferMemoryReader.MemoryRegion[0]));
     }
 
     public static void main(String[] argv) {


### PR DESCRIPTION
* fixed: debugger crash resolving Thread objects that wasn't started
* improvement: debugger reports now only line number where breakpoint can be hit
* improvement: Idea settings: debugger/stepping filter -- extended with  `dalvik.*`, `libcore.*`
* improvement: removed synthetic bro-bridges/bro-callbacks from back-stack entries
* fixed: not working step-out (if stepping out into ignored class)