### PR TITLE
* Xcode11.4: fix for `source register must be sp if destination is sp`

### DIFF
--- a/compiler/vm/core/src/call0-darwin-thumbv7.s
+++ b/compiler/vm/core/src/call0-darwin-thumbv7.s
@@ -62,6 +62,7 @@ LsetStackArgsDone:
     blx  r9
 
     @ Restore sp to what it was before we pushed the stack args
-    sub sp, r7, #4
+    sub r7, r7, #4
+    mov sp, r7
 
     pop {r4, r7, pc}


### PR DESCRIPTION
recent changes in [LLVM](https://reviews.llvm.org/rG6af366be8ad3199f715c54e84c779e02bb8c18b8) doesn't allow sub/add operations when Rd is SP and Rs is not (as instructions were deprecated by ARM). So code was rewritten as bellow:
from
```
sub sp, r7, #4.  ; sp = r7 - 4
```
to
```
sub r7, r7, #4. ; r7 = r7 - 4
mov sp, r7      ; sp = r7
```

Sadly have no 32 bit enabled device at hand to validate (will check once pick one)