### PR TITLE
Fixes min OS version checks and removes hardcoded values

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/framework/FrameworkTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/framework/FrameworkTarget.java
@@ -122,9 +122,9 @@ public class FrameworkTarget extends AbstractTarget {
 	}
 
 	private String getMinimumOSVersion() {
-		NSObject minimumOSVersion = config.getInfoPList().getDictionary().objectForKey("MinimumOSVersion");
+		String minimumOSVersion = config.getInfoPList().getMinimumOSVersion();
 		if (minimumOSVersion != null)
-			return minimumOSVersion.toString();
+			return minimumOSVersion;
 		return config.getOs().getMinVersion();
 	}
 

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/framework/FrameworkTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/framework/FrameworkTarget.java
@@ -120,12 +120,15 @@ public class FrameworkTarget extends AbstractTarget {
 	protected List<String> getTargetExportedSymbols() {
 		return Arrays.asList("JNI_*", "rvmInstantiateFramework");
 	}
-	
-	private String getMinimumOSVersion() {
-		NSObject minimumOSVersion = config.getInfoPList().getDictionary().objectForKey("MinimumOSVersion");
-		if (minimumOSVersion != null)
-			return minimumOSVersion.toString();
-		return "8.0";
+
+	protected String getMinimumOSVersion() {
+		if (config.getIosInfoPList() != null) {
+			String minVersion = config.getIosInfoPList().getMinimumOSVersion();
+			if (minVersion != null) {
+				return minVersion;
+			}
+		}
+		return config.getOs().getMinVersion();
 	}
 
 	@Override
@@ -202,7 +205,7 @@ public class FrameworkTarget extends AbstractTarget {
 		
 		NSDictionary infoPlist = config.getInfoPList().getDictionary();
 		if (infoPlist.objectForKey("MinimumOSVersion") == null)
-			infoPlist.put("MinimumOSVersion", "8.0");
+			infoPlist.put("MinimumOSVersion", config.getOs().getMinVersion());
 		
 		File infoPlistBin = new File(frameworkDir, "Info.plist");
 		config.getLogger().info("Installing Info.plist to: %s", infoPlistBin);

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/framework/FrameworkTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/framework/FrameworkTarget.java
@@ -121,13 +121,10 @@ public class FrameworkTarget extends AbstractTarget {
 		return Arrays.asList("JNI_*", "rvmInstantiateFramework");
 	}
 
-	protected String getMinimumOSVersion() {
-		if (config.getIosInfoPList() != null) {
-			String minVersion = config.getIosInfoPList().getMinimumOSVersion();
-			if (minVersion != null) {
-				return minVersion;
-			}
-		}
+	private String getMinimumOSVersion() {
+		NSObject minimumOSVersion = config.getInfoPList().getDictionary().objectForKey("MinimumOSVersion");
+		if (minimumOSVersion != null)
+			return minimumOSVersion.toString();
 		return config.getOs().getMinVersion();
 	}
 

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -276,7 +276,7 @@ public class IOSTarget extends AbstractTarget {
         int majorVersionNumber = -1;
         try {
             majorVersionNumber = Integer.parseInt(minVersion.substring(0, minVersion.indexOf('.')));
-            int minMajorSupportedVersion = Integer.parseInt(minVersion.substring(0, config.getOs().getMinVersion().indexOf('.')));
+            int minMajorSupportedVersion = Integer.parseInt(config.getOs().getMinVersion().substring(0, config.getOs().getMinVersion().indexOf('.')));
 
             if (majorVersionNumber < minMajorSupportedVersion) {
                 throw new CompilerException("MinimumOSVersion of " + minVersion + " is not supported. "
@@ -937,7 +937,7 @@ public class IOSTarget extends AbstractTarget {
 
         if (dict.objectForKey("MinimumOSVersion") == null) {
             // This is required
-            dict.put("MinimumOSVersion", "6.0");
+            dict.put("MinimumOSVersion", config.getOs().getMinVersion());
         }
 
         customizeInfoPList(dict);


### PR DESCRIPTION
Fixes a bug that caused the min OS SDK check never to fail (allowing building apps with minimum version under the minimum supported one).

Also makes usage of minimum version consistent across the board and removes hardcoded values.