### PR TITLE
suport for AS4.1 canary 

### DIFF
--- a/plugins/idea/build.gradle
+++ b/plugins/idea/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id "org.jetbrains.intellij" version "0.4.18"
+    id "org.jetbrains.intellij" version "0.4.20"
 }
 
 ext {

--- a/plugins/idea/src/main/resources/META-INF/plugin.xml
+++ b/plugins/idea/src/main/resources/META-INF/plugin.xml
@@ -6,6 +6,7 @@
 
     <depends optional="true" config-file="">org.jetbrains.idea.maven</depends>
     <depends>org.jetbrains.plugins.gradle</depends>
+    <depends>com.intellij.java</depends>
 
     <idea-version since-build="191"/>
 


### PR DESCRIPTION
* fixed `plugin defines no module dependencies (supported only in IntelliJ IDEA)`

by adding dependency to Java module as described by link
https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html