### PR TITLE
fix for "libswiftCore.dylib requires an OS version prior to 12.2.0."

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -312,6 +312,11 @@ public class IOSTarget extends AbstractTarget {
         libArgs.add("-Xlinker");
         libArgs.add(sdk.getVersion());
 
+        // add runtime path to swift libs first to support swift-5 libs location
+        libArgs.add("-Xlinker");
+        libArgs.add("-rpath");
+        libArgs.add("-Xlinker");
+        libArgs.add("/usr/lib/swift");
         // specify dynamic library loading path
         libArgs.add("-Xlinker");
         libArgs.add("-rpath");


### PR DESCRIPTION
fixed runtime issue "This copy of libswiftCore.dylib requires an OS version prior to 12.2.0." by adding runtime path to /usr/lib/swift before @executable_path/Frameworks so this allows bundled iOS Swift 5 framework to be picked instead of embedded