### PR TITLE
frameworkPath/extensionPath can be qualified (temporal support for xcframeworks)

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/AbstractQualified.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/AbstractQualified.java
@@ -1,0 +1,44 @@
+package org.robovm.compiler.config;
+
+import org.simpleframework.xml.Attribute;
+
+import java.util.Arrays;
+
+/**
+ * base conditionable entry that declares attributes to match interface
+ * @author dkimitsa
+ */
+public abstract class AbstractQualified implements Qualified {
+    @Attribute(name = "platform", required = false)
+    OS[] platforms;
+
+    @Attribute(name = "variant", required = false)
+    PlatformVariant[] variants;
+
+    @Attribute(name = "arch", required = false)
+    Arch[] arches;
+
+    @Override
+    public OS[] filterPlatforms() {
+        return platforms;
+    }
+
+    @Override
+    public PlatformVariant[] filterPlatformVariants() {
+        return variants;
+    }
+
+    @Override
+    public Arch[] filterArch() {
+        return arches;
+    }
+
+    @Override
+    public String toString() {
+        return "if {" +
+                "platforms=" + Arrays.toString(platforms) +
+                ", variants=" + Arrays.toString(variants) +
+                ", arches=" + Arrays.toString(arches) +
+                '}';
+    }
+}

--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -58,6 +58,7 @@ import org.simpleframework.xml.Element;
 import org.simpleframework.xml.ElementList;
 import org.simpleframework.xml.Root;
 import org.simpleframework.xml.Serializer;
+import org.simpleframework.xml.Text;
 import org.simpleframework.xml.convert.Converter;
 import org.simpleframework.xml.convert.Registry;
 import org.simpleframework.xml.convert.RegistryStrategy;
@@ -66,6 +67,8 @@ import org.simpleframework.xml.filter.PlatformFilter;
 import org.simpleframework.xml.stream.Format;
 import org.simpleframework.xml.stream.InputNode;
 import org.simpleframework.xml.stream.OutputNode;
+import org.simpleframework.xml.transform.RegistryMatcher;
+import org.simpleframework.xml.transform.Transform;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -77,6 +80,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
+import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -95,6 +99,7 @@ import java.util.ServiceLoader;
 import java.util.TreeMap;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -156,11 +161,11 @@ public class Config {
     @ElementList(required = false, entry = "framework")
     private ArrayList<String> weakFrameworks;
     @ElementList(required = false, entry = "path")
-    private ArrayList<File> frameworkPaths;
+    private ArrayList<QualifiedFile> frameworkPaths;
     @ElementList(required = false, entry = "extension")
     private ArrayList<AppExtension> appExtensions;
     @ElementList(required = false, entry = "path")
-    private ArrayList<File> appExtensionPaths;
+    private ArrayList<QualifiedFile> appExtensionPaths;
     @ElementList(required = false, entry = "resource")
     private ArrayList<Resource> resources;   
     @ElementList(required = false, entry = "classpathentry")
@@ -432,7 +437,10 @@ public class Config {
 
     public List<File> getFrameworkPaths() {
         return frameworkPaths == null ? Collections.emptyList()
-                : Collections.unmodifiableList(frameworkPaths);
+                : frameworkPaths.stream()
+                .filter(this::isQualified)
+                .map(f -> f.entry)
+                .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
     }
 
     public List<AppExtension> getAppExtensions() {
@@ -442,7 +450,10 @@ public class Config {
 
     public List<File> getAppExtensionPaths() {
         return appExtensionPaths == null ? Collections.emptyList()
-                : Collections.unmodifiableList(appExtensionPaths);
+                : appExtensionPaths.stream()
+                .filter(this::isQualified)
+                .map(e -> e.entry)
+                .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
     }
 
     public List<Resource> getResources() {
@@ -684,6 +695,28 @@ public class Config {
     public File getGeneratedClassDir(Path path) {
         File pathCacheDir = getCacheDir(path);
         return new File(pathCacheDir.getParentFile(), pathCacheDir.getName() + ".generated");
+    }
+
+    /**
+     * tests if qualified item matches this config
+     */
+    protected boolean isQualified(Qualified qualified) {
+        if (qualified.filterPlatforms() != null) {
+            if (!Arrays.asList(qualified.filterPlatforms()).contains(os))
+                return false;
+        }
+        if (qualified.filterArch() != null) {
+            if (!Arrays.asList(qualified.filterArch()).contains(sliceArch))
+                return false;
+        }
+        // TODO: there is no platform variant, just guess it from arch, applies to iOS temporaly
+        if (os == OS.ios && qualified.filterPlatformVariants() != null) {
+            PlatformVariant variant = sliceArch.isArm() ? PlatformVariant.device : PlatformVariant.simulator;
+            if (!Arrays.asList(qualified.filterPlatformVariants()).contains(variant))
+                return false;
+        }
+
+        return true;
     }
 
     private static Map<Object, Object> getManifestAttributes(File jarFile) throws IOException {
@@ -1428,7 +1461,7 @@ public class Config {
             if (config.frameworkPaths == null) {
                 config.frameworkPaths = new ArrayList<>();
             }
-            config.frameworkPaths.add(frameworkPath);
+            config.frameworkPaths.add(new QualifiedFile(frameworkPath));
             return this;
         }
 
@@ -1461,7 +1494,7 @@ public class Config {
             if (config.appExtensionPaths == null) {
                 config.appExtensionPaths = new ArrayList<>();
             }
-            config.appExtensionPaths.add(extensionPath);
+            config.appExtensionPaths.add(new QualifiedFile(extensionPath));
             return this;
         }
 
@@ -1736,13 +1769,19 @@ public class Config {
 
             Registry registry = new Registry();
             RegistryStrategy registryStrategy = new RegistryStrategy(registry);
+            RegistryMatcher matcher = new RegistryMatcher();
             Serializer serializer = new Persister(registryStrategy,
-                    new PlatformFilter(config.properties), new Format(2));
+                    new PlatformFilter(config.properties), matcher, new Format(2));
 
             registry.bind(File.class, fileConverter);
             registry.bind(Lib.class, new RelativeLibConverter(fileConverter));
             registry.bind(Resource.class, new ResourceConverter(fileConverter, resourceSerializer));
             registry.bind(StripArchivesConfig.class, new StripArchivesConfigConverter());
+
+            // converters for attributes (comma separated arrays)
+            matcher.bind(OS[].class, new EnumArrayConverter<>(OS.class));
+            matcher.bind(Arch[].class, new EnumArrayConverter<>(Arch.class));
+            matcher.bind(PlatformVariant[].class, new EnumArrayConverter<>(PlatformVariant.class));
 
             return serializer;
         }
@@ -1818,6 +1857,30 @@ public class Config {
         }
     }
 
+    /**
+     * Container for file entry with platform/arch constraints
+     */
+    public static final class QualifiedFile extends AbstractQualified {
+        @Text File entry;
+
+        protected QualifiedFile() {
+        }
+
+        public QualifiedFile(File file) {
+            entry = file;
+        }
+
+        public File getEntry() {
+            return entry;
+        }
+
+        @Override
+        public String toString() {
+            return entry + " " + super.toString();
+        }
+    }
+
+
     private static final class RelativeLibConverter implements Converter<Lib> {
         private final RelativeFileConverter fileConverter;
 
@@ -1852,6 +1915,37 @@ public class Config {
             if (!force) {
                 node.setAttribute("force", "false");
             }
+        }
+    }
+
+    /**
+     * transformer for xml attribute/entry that transforms comma separated values into
+     * enum array
+     */
+    private static final class EnumArrayConverter<T extends Enum<T>> implements Transform<T[]> {
+        private final Class<T> enumClass;
+
+        private EnumArrayConverter(Class<T> enumClass) {
+            this.enumClass = enumClass;
+        }
+
+        @Override
+        public T[] read(String s) {
+            s = s.trim();
+            if (s.isEmpty())
+                return null;
+
+            String[] tokens = s.split(",");
+            @SuppressWarnings("unchecked")
+            T[] res = (T[])Array.newInstance(enumClass, tokens.length);
+            for (int idx = 0; idx < tokens.length; idx++)
+                res[idx] = Enum.valueOf(enumClass, tokens[idx].trim());
+            return res;
+        }
+
+        @Override
+        public String write(T[] ts) {
+            return Arrays.stream(ts).map(Enum::name).collect(Collectors.joining());
         }
     }
 

--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/PlatformVariant.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/PlatformVariant.java
@@ -1,0 +1,14 @@
+package org.robovm.compiler.config;
+
+/**
+ * enum that specifies variant of platform (OS) currently building/launching
+ */
+public enum PlatformVariant {
+    /// device or default platform
+    device,
+
+    /// simulator where applicable
+    simulator
+
+    // later... maccatalyst
+}

--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Qualified.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Qualified.java
@@ -1,0 +1,17 @@
+package org.robovm.compiler.config;
+
+/**
+ * Common interface for items in robovm.xml that available only if
+ * condition constraints are met
+ * @author dkimitsa
+ */
+public interface Qualified {
+    /// specifies platform entry applicable for
+    OS[] filterPlatforms();
+
+    /// specifies platform variant (e.g. simulator) entry applicable for
+    PlatformVariant[] filterPlatformVariants();
+
+    /// specifies architectures entry applicable for
+    Arch[] filterArch();
+}


### PR DESCRIPTION
This PR makes <path> tags for extensionPaths and frameworkPaths customisable using constraints, following are:
- platform: array of supported  platform, corresponds to OS enum
- variant: array of supported platform variants (device/simulator)
- arch: array of supported platform arches  

To have one folder with only sim frameworks and another with only device use config as bellow:
```xml
    <frameworkPaths>
        <path variant="device">arm_libs</path>
        <path variant="simulator">sim_libs</path>
    </frameworkPaths>
```