### PR TITLE
* fixed OOM that happens when compiling class with huge amount of fie…

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/ClassCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/ClassCompiler.java
@@ -781,7 +781,7 @@ public class ClassCompiler {
         catches = new HashSet<String>();
         classFields = getClassFields(config.getOs(), config.getArch(),sootClass);
         instanceFields = getInstanceFields(config.getOs(), config.getArch(),sootClass);
-        classType = getClassType(config.getOs(), config.getArch(),sootClass);
+        classType = getClassType(mb, config.getOs(), config.getArch(),sootClass);
         instanceType = getInstanceType(config.getOs(), config.getArch(),sootClass);
         
         attributesEncoder.encode(mb, sootClass);
@@ -1522,7 +1522,9 @@ public class ClassCompiler {
         // Return the struct {header, body}. To be compatible with the C code in classinfo.c 
         // it is important that the header is padded the same as in C so that the body starts
         // after sizeof(ClassInfoHeader) bytes.
-        return new StructureConstantBuilder().add(header.build()).add(body.build()).build();
+        StructureConstant infoStruct = new StructureConstantBuilder().add(header.build()).add(body.build()).build(INFO_STRUCT_ALIAS);
+        mb.addType(infoStruct.getType());
+        return infoStruct;
     }
 
     private Function compileMethod(AbstractMethodCompiler methodCompiler, SootMethod method) {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/ModuleBuilder.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/ModuleBuilder.java
@@ -135,6 +135,8 @@ public class ModuleBuilder {
     }
     
     public void addType(UserType type) {
+        if (!type.hasAlias())
+            throw new IllegalArgumentException("Expected type alias !");
         types.add(type);
     }
     

--- a/compiler/compiler/src/main/java/org/robovm/compiler/Types.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/Types.java
@@ -91,7 +91,10 @@ public class Types {
     public static final Type OBJECT_PTR = new PointerType(OBJECT);
     public static final Type METHOD_PTR = new PointerType(new OpaqueType("Method"));
     public static final Type FIELD_PTR = new PointerType(new OpaqueType("Field"));
-    
+
+    public static final String INFO_STRUCT_ALIAS = "InfoStruct";
+    public static final String CLASS_TYPE_ALIAS = "ClassType";
+
     public static Type getType(String desc) {
         switch (desc.charAt(0)) {
         case 'Z': return I8;
@@ -502,7 +505,7 @@ public class Types {
         return new PackedStructureType(types.toArray(new Type[types.size()]));
     }
     
-    public static StructureType getClassType(OS os, Arch arch, SootClass clazz) {
+    public static StructureType getClassType(ModuleBuilder mb, OS os, Arch arch, SootClass clazz) {
         List<Type> types = new ArrayList<Type>();
         int offset = 0;
         for (SootField field : getClassFields(os, arch, clazz)) {
@@ -511,7 +514,9 @@ public class Types {
             types.add(padType(getType(field.getType()), padding));
             offset += padding + getFieldSize(arch, field);
         }
-        return new StructureType(CLASS, new StructureType(types.toArray(new Type[types.size()])));
+        StructureType classType = new StructureType(CLASS_TYPE_ALIAS, CLASS, new StructureType(types.toArray(new Type[types.size()])));
+        mb.addType(classType);
+        return classType;
     }
 
     public static StructureType getInstanceType(OS os, Arch arch, SootClass clazz) {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/StructureConstant.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/StructureConstant.java
@@ -30,7 +30,7 @@ public class StructureConstant extends Constant {
     }
     
     @Override
-    public Type getType() {
+    public StructureType getType() {
         return type;
     }
 

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/StructureConstantBuilder.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/StructureConstantBuilder.java
@@ -24,21 +24,32 @@ import java.util.List;
  * @version $Id$
  */
 public class StructureConstantBuilder {
-    private final List<Value> values = new ArrayList<Value>();
+    private final List<Value> values = new ArrayList<>();
 
     public StructureConstantBuilder add(Value v) {
         values.add(v);
         return this;
     }
-    
+
     public StructureConstant build() {
+        return build(null);
+    }
+
+    /**
+     * @param typeAlias if specified structure will be created with type alias
+     */
+    public StructureConstant build(String typeAlias) {
         Type[] types = new Type[values.size()];
         int i = 0;
         for (Value v : values) {
             types[i++] = v.getType();
         }
-        return new StructureConstant(new StructureType(types), 
-                values.toArray(new Value[values.size()]));
+
+        if (typeAlias != null) {
+            return new StructureConstant(new StructureType(typeAlias, types), values.toArray(new Value[0]));
+        } else {
+            return new StructureConstant(new StructureType(types), values.toArray(new Value[0]));
+        }
     }
     
 }


### PR DESCRIPTION
* fixed OOM that happens when compiling class with huge amount of fields (like 8K). 

Root case of this -- huge ClassType struct (about 170KB), that uses multiple times in raw form and this causes huge .ll string outputclass: for example for class with 8K fields: 8K * 3 * 170KB ~ 4GB data only for Class Type. 
The fix introduces typedef for it and uses alias.