### PR TITLE
fixed: crash when custom object instantiated from XIB

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/plugin/objc/ObjCMemberPlugin.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/plugin/objc/ObjCMemberPlugin.java
@@ -170,7 +170,7 @@ public class ObjCMemberPlugin extends AbstractCompilerPlugin {
     private SootMethodRef org_robovm_objc_ObjCObject_getSuper = null;
     private SootFieldRef org_robovm_objc_ObjCObject_customClass = null;
     private SootMethodRef org_robovm_objc_ObjCClass_getByType = null;
-    private SootMethodRef org_robovm_objc_ObjCClass_replaceHandle = null;
+    private SootMethodRef org_robovm_objc_ObjCClass_associateAlias = null;
     private SootMethodRef org_robovm_objc_ObjCRuntime_bind = null;
     private SootMethodRef org_robovm_objc_ObjCObject_updateStrongRef = null;
     private SootMethodRef org_robovm_objc_ObjCExtensions_updateStrongRef = null;
@@ -389,7 +389,7 @@ public class ObjCMemberPlugin extends AbstractCompilerPlugin {
                     Arrays.asList(
                             j.newAssignStmt(objCClassHandle, j.newSpecialInvokeExpr(objCClass, this.org_robovm_rt_bro_NativeObject_getHandle)),
                             j.newAssignStmt(objCClassHandle, j.newStaticInvokeExpr(exposeObjcClassMethod.makeRef(), objCClassHandle)),
-                            j.newInvokeStmt(j.newSpecialInvokeExpr(objCClass, org_robovm_objc_ObjCClass_replaceHandle, objCClassHandle))
+                            j.newInvokeStmt(j.newSpecialInvokeExpr(objCClass, org_robovm_objc_ObjCClass_associateAlias, objCClassHandle))
                     ),
                     units.getLast()
             );
@@ -484,10 +484,10 @@ public class ObjCMemberPlugin extends AbstractCompilerPlugin {
                         "getByType",
                         Arrays.asList(java_lang_Class.getType()),
                         org_robovm_objc_ObjCClass.getType(), true);
-        org_robovm_objc_ObjCClass_replaceHandle =
+        org_robovm_objc_ObjCClass_associateAlias =
                 Scene.v().makeMethodRef(
                         org_robovm_objc_ObjCClass,
-                        "replaceHandle",
+                        "associateAlias",
                         Arrays.asList(LongType.v()),
                         VoidType.v(), false);
         org_robovm_objc_ObjCRuntime_bind =

--- a/compiler/objc/src/main/java/org/robovm/objc/ObjCClass.java
+++ b/compiler/objc/src/main/java/org/robovm/objc/ObjCClass.java
@@ -366,13 +366,13 @@ public final class ObjCClass extends ObjCObject {
      * once data from handle is copied to OBJC_CLASS_$_ there is two class_t struct for same class:
      * - one in OBJC_CLASS_$_
      * - second created runtime and pointed by handle
-     * just to have inside RoboVM and external objc one lets replace handle with alias (pointer to OBJC_CLASS_$_)
+     * Native code can create instances both way. Ownership helper should be able to find parent
+     * class for both class objects
      * WARNING: Shall not be called directly
      */
     @Deprecated
-    public void replaceHandle(long aliasHandle) {
-        ObjCObject.ObjectOwnershipHelper.replaceHandle(getHandle(), aliasHandle);
-        setHandle(aliasHandle);
+    public void associateAlias(long aliasHandle) {
+        ObjCObject.ObjectOwnershipHelper.registerClassAlias(getHandle(), aliasHandle);
     }
 
     @SuppressWarnings("unchecked")

--- a/compiler/objc/src/main/java/org/robovm/objc/ObjCObject.java
+++ b/compiler/objc/src/main/java/org/robovm/objc/ObjCObject.java
@@ -431,14 +431,14 @@ public abstract class ObjCObject extends NativeObject {
             registerCallbackMethod(cls, dealloc, 0, deallocMethod);
         }
 
-        public static void replaceHandle(long cls, long replacementCls) {
+        public static void registerClassAlias(long cls, long aliasCls) {
             synchronized (customClassToNativeSuper) {
-                Long nativeSuper = customClassToNativeSuper.remove(cls);
+                Long nativeSuper = customClassToNativeSuper.get(cls);
                 if (nativeSuper == null) {
                     throw new Error(
                             "Failed to register alias as class for it is not registered");
                 }
-                customClassToNativeSuper.put(replacementCls, nativeSuper);
+                customClassToNativeSuper.put(aliasCls, nativeSuper);
             }
         }
 


### PR DESCRIPTION
fixed crash (Failed to find a custom class to native super class mapping) when custom object is initiated from native side by its name. For example when inflating NIB.

Root case: changes to support native objective-c classes (#457) for framework. We have two copies of objc Class and robovm should be able to find parent class by both pointers.
Fix: alias added to map