### PR TITLE
* fixed: debugger crash when setting breakpoint 

### DIFF
--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/MachOLoader.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/MachOLoader.java
@@ -212,8 +212,8 @@ public class MachOLoader {
                         continue;
                 } else {
                     // data
-                    if ("__bss".equals(sec.sectname())) {
-                        // zero initialized zeros data goes to __bss so have to read it as well
+                    if ("__bss".equals(sec.sectname()) || "__common".equals(sec.sectname())) {
+                        // zero initialized zeros data goes to __bss(static)/__common(global) so have to read it as well
                         region = new NullDataBufferReader(sec.addr(), (int) sec.size(), isPatform64Bit());
                     } else if (!"__const".equals(sec.sectname()) && !"__data".equals(sec.sectname()))
                         continue;


### PR DESCRIPTION
Fixed debugger crash when breakpoint is set in method where number of line is multiple of 8. this was fixed already when bptable was going to .bss section. This fix covers case when it goes to __common section.

Method example where setting of breakpoint causes a crash (method line is first line):
```
    private void demo() {
        System.out.println(0);
        System.out.println(1);
        System.out.println(2);
        System.out.println(3);
        System.out.println(4);
        System.out.println(5);
        System.out.println(6);
    }
```