### PR TITLE
* watchOS dependant application support (as attachment to iOS robovm app)

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/AppExtension.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/AppExtension.java
@@ -10,16 +10,48 @@ import org.simpleframework.xml.Text;
  */
 
 public class AppExtension {
-    @Attribute(name = "profile", required = false)
-    String profile;
+    public final static AppExtension DEFAULT_RULE = new AppExtension();
+
+    /// name of extension
     @Text
     String name;
+
+    /// if true -- signing of extension is skipped, all fields bellow are ignored
+    @Attribute(name = "skipSigning", required = false)
+    boolean skipSigning = false;
+
+    /// specifies provision profile to be used for signing, otherwise auto search will be used
+    @Attribute(name = "profile", required = false)
+    String profile;
+
+    /// if specified, new bundle ID will be applied: parent + supplied suffix
+    /// if not specified -- new bundle ID will be generated as: parent + existing suffix (extracted from existing ID)
+    @Attribute(name = "suffix", required = false)
+    String suffix;
+
+    /**
+     * returns name with requested extension (attaches if missin)
+     * @param ext starting with '.', e.g. ".appex"
+     */
+    public String getNameWithExt(String ext) {
+        if (name.endsWith(ext))
+            return name;
+        return name + ext;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean skipSigning() {
+        return skipSigning;
+    }
 
     public String getProfile() {
         return profile;
     }
 
-    public String getName() {
-        return name;
+    public String getSuffix() {
+        return suffix;
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -193,6 +193,9 @@ public class Config {
     private File iosEntitlementsPList;
 
     @Element(required = false)
+    private WatchKitApp watchKitApp;
+
+    @Element(required = false)
     private Tools tools;
 
     @Element(required = false)
@@ -602,6 +605,10 @@ public class Config {
 
     public Tools getTools() {
         return tools;
+    }
+
+    public WatchKitApp getWatchKitApp() {
+        return watchKitApp;
     }
 
     private static File makeFileRelativeTo(File dir, File f) {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/WatchKitApp.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/WatchKitApp.java
@@ -1,0 +1,38 @@
+package org.robovm.compiler.config;
+
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementList;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Configuration entry for WatchKit application that to be embedded along with main app
+ */
+public class WatchKitApp {
+    /**
+     * name of watch app to be searched within extensions, example `watch.app`
+     */
+    @Element(required = true, name = "app")
+    private AppExtension app ;
+
+    /**
+     * allows to configure signing parameters for extension used in watch app
+     * (parameters same as in app extension)
+     */
+    @ElementList(required = false, entry = "extension")
+    private ArrayList<AppExtension> extensions;
+
+    public String getWatchAppName() {
+        return app.getNameWithExt(".app");
+    }
+
+    public AppExtension getApp() {
+        return app;
+    }
+
+    public List<AppExtension> getExtensions() {
+        return extensions != null ? Collections.unmodifiableList(extensions) : Collections.emptyList();
+    }
+}

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSSimulatorLaunchParameters.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSSimulatorLaunchParameters.java
@@ -25,11 +25,22 @@ import org.robovm.compiler.target.LaunchParameters;
 public class IOSSimulatorLaunchParameters extends LaunchParameters {
     private DeviceType deviceType;
 
+    /// if specified will deploy and launch watch kit app as well
+    private String pairedWatchAppName;
+
     public DeviceType getDeviceType() {
         return deviceType;
     }
 
     public void setDeviceType(DeviceType type) {
         this.deviceType = type;
+    }
+
+    public String getPairedWatchAppName() {
+        return pairedWatchAppName;
+    }
+
+    public void setPairedWatchAppName(String pairedWatchAppName) {
+        this.pairedWatchAppName = pairedWatchAppName;
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -22,6 +22,7 @@ import com.dd.plist.NSDictionary;
 import com.dd.plist.NSNumber;
 import com.dd.plist.NSObject;
 import com.dd.plist.NSString;
+import com.dd.plist.PropertyListFormatException;
 import com.dd.plist.PropertyListParser;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -38,6 +39,7 @@ import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
 import org.robovm.compiler.config.OS;
 import org.robovm.compiler.config.Resource;
+import org.robovm.compiler.config.WatchKitApp;
 import org.robovm.compiler.log.Logger;
 import org.robovm.compiler.target.AbstractTarget;
 import org.robovm.compiler.target.LaunchParameters;
@@ -51,7 +53,9 @@ import org.robovm.libimobiledevice.IDevice;
 import org.robovm.libimobiledevice.InstallationProxyClient.StatusCallback;
 import org.robovm.libimobiledevice.util.AppLauncher;
 import org.robovm.libimobiledevice.util.AppLauncherCallback;
+import org.xml.sax.SAXException;
 
+import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileNotFoundException;
@@ -59,6 +63,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -99,7 +104,7 @@ public class IOSTarget extends AbstractTarget {
     private static File iosSimPath;
 
     private Arch arch;
-    private SDK sdk;    
+    private SDK sdk;
     private File entitlementsPList;
     private SigningIdentity signIdentity;
     private ProvisioningProfile provisioningProfile;
@@ -339,7 +344,7 @@ public class IOSTarget extends AbstractTarget {
             ccArgs.add("-Xlinker");
             ccArgs.add(simEntitlement.getAbsolutePath());
         }
-        
+
         super.doBuild(outFile, ccArgs, objectFiles, libArgs);
     }
 
@@ -361,12 +366,21 @@ public class IOSTarget extends AbstractTarget {
                         + "be unsigned and will not run on unjailbroken devices");
                 codesignApp(SigningIdentity.ADHOC, getOrCreateEntitlementsPList(false, getBundleId()), installDir);
             } else {
+                String appIdPrefix = provisioningProfile.getAppIdPrefix();
+
                 // Copy the provisioning profile
                 copyProvisioningProfile(provisioningProfile, installDir);
                 boolean getTaskAllow = provisioningProfile.getType() == Type.Development;
                 signFrameworks(signIdentity, installDir);
-                provisionAppExtensions(signIdentity, installDir);
-                signAppExtensions(signIdentity, installDir, getTaskAllow);
+                // app extensions
+                provisionAppExtensions(config.getAppExtensions(), signIdentity, installDir);
+                signAppExtensions(signIdentity, installDir, appIdPrefix, getTaskAllow);
+                // watch app
+                if (config.getWatchKitApp() != null) {
+                    provisionWatchApp(signIdentity, installDir);
+                    signWatchApp(signIdentity, installDir, appIdPrefix, getTaskAllow);
+                }
+                // app
                 codesignApp(signIdentity, getOrCreateEntitlementsPList(getTaskAllow, getBundleId()), installDir);
             }
         }
@@ -394,17 +408,25 @@ public class IOSTarget extends AbstractTarget {
         // strip symbols to reduce application size, all debugger symbols converted into globals
         strip(appDir, getExecutable());
 
-        if (isDeviceArch(arch)) {            
+        if (isDeviceArch(arch)) {
             if (config.isIosSkipSigning()) {
                 config.getLogger().warn("Skiping code signing. The resulting app will "
                         + "be unsigned and will not run on unjailbroken devices");
                 codesignApp(SigningIdentity.ADHOC, getOrCreateEntitlementsPList(true, getBundleId()), appDir);
             } else {
+                String appIdPrefix = provisioningProfile.getAppIdPrefix();
+
                 copyProvisioningProfile(provisioningProfile, appDir);
                 boolean getTaskAllow = provisioningProfile.getType() == Type.Development;
                 signFrameworks(signIdentity, appDir);
-                provisionAppExtensions(signIdentity, appDir);
-                signAppExtensions(signIdentity, appDir, getTaskAllow);
+                // app extensions
+                provisionAppExtensions(config.getAppExtensions(), signIdentity, appDir);
+                signAppExtensions(signIdentity, appDir, appIdPrefix, getTaskAllow);
+                // watch app
+                if (config.getWatchKitApp() != null) {
+                    provisionWatchApp(signIdentity, appDir);
+                    signWatchApp(signIdentity, appDir, appIdPrefix, getTaskAllow);
+                }
                 // sign the app
                 codesignApp(signIdentity, getOrCreateEntitlementsPList(getTaskAllow, getBundleId()), appDir);
             }
@@ -412,7 +434,9 @@ public class IOSTarget extends AbstractTarget {
             if (sdk.getVersionCode() >= 0x0B0300) {
                 // code signing of frameworks and app extensions are required since iOS 11.3
                 signFrameworks(SigningIdentity.ADHOC, appDir);
-                signAppExtensions(SigningIdentity.ADHOC, appDir, true);
+                signAppExtensions(SigningIdentity.ADHOC, appDir, null, true);
+                if (config.getWatchKitApp() != null)
+                    signWatchApp(SigningIdentity.ADHOC, appDir, null, true);
             }
             // sign the app
             // NB: it is not required as app can run without it but Xcode does this
@@ -440,36 +464,68 @@ public class IOSTarget extends AbstractTarget {
         }
     }
 
-    private void signAppExtensions(SigningIdentity identity, File appDir, boolean getTaskAllow) throws IOException {
+    private void signAppExtensions(SigningIdentity identity, File appDir, String appIdPrefix, boolean getTaskAllow) throws IOException {
         // sign dynamic frameworks first
         File extensionsDir = new File(appDir, "PlugIns");
         if (extensionsDir.exists() && extensionsDir.isDirectory()) {
             // sign embedded app-extensions
             for (File extension : extensionsDir.listFiles()) {
-                if (extension.isDirectory() && extension.getName().endsWith(".appex")) {
-                    File entitlements = null;
-                    if (provisioningProfile != null) {
-                        String bundleId =  provisioningProfile.getAppIdPrefix() + "." + getBundleId() + "." + extension.getName().replace(".appex", "");
-                        entitlements = createEntitlementForAppEx(getTaskAllow, bundleId);
-                    }
-
-                    // now sign
-                    codesignAppExtension(identity, entitlements, extension);
-                }
+                if (extension.isDirectory() && extension.getName().endsWith(".appex"))
+                    signSingleAppExtension(identity, extension, appIdPrefix, getTaskAllow);
             }
         }
     }
 
+    private void signSingleAppExtension(SigningIdentity identity, File extDir, String appIdPrefix, boolean getTaskAllow) throws IOException {
+        String appExBundleId = null;
+        // NB: appIdPrefix is null for simulator build
+        if (appIdPrefix != null) {
+            // read extension bundle id from plist (id was generated during copy phase up to robovm.xml config)
+            File infoPlistFile = new File(extDir, "Info.plist");
+            try {
+                NSDictionary infoPlist = (NSDictionary) PropertyListParser.parse(infoPlistFile);
+                appExBundleId = infoPlist.get("CFBundleIdentifier").toString();
+            } catch (PropertyListFormatException | SAXException | ParserConfigurationException | ParseException e) {
+                throw new IOException(e);
+            }
+            appExBundleId = appIdPrefix + "." + appExBundleId;
+        }
+        // create entitlements
+        File entitlements = createEntitlementForAppEx(getTaskAllow, appExBundleId);
+
+        // now sign
+        codesignAppExtension(identity, entitlements, extDir);
+    }
+
+    private void signWatchApp(SigningIdentity identity, File appDir, String appIdPrefix, boolean getTaskAllow) throws IOException {
+        // sign watch app
+        WatchKitApp waConfig = config.getWatchKitApp();
+
+        String waName = waConfig.getWatchAppName();
+        File waDir = new File(appDir, "Watch/" + waName);
+        if (!waDir.exists() || !waDir.isDirectory())
+            throw new IllegalStateException("Error while signing WatchApp, watch directory doesn't exist: " + waDir.getAbsolutePath());
+
+        // sign all extension first
+        signAppExtensions(identity, waDir, appIdPrefix, getTaskAllow);
+
+        // sign watch app (same way as app extension)
+        signSingleAppExtension(identity, waDir, appIdPrefix, getTaskAllow);
+    }
+
     /**
-     * generates simple emtitlement plist which is required for AppEx during submit to app store
+     * generates simple entitlement plist which is required for AppEx during submit to app store
+     * @param bundleId -- might be null for simulator
      */
     private File createEntitlementForAppEx(boolean getTaskAllow, String bundleId) throws IOException {
         try {
             File destFile = new File(config.getTmpDir(), "AppExtEntitlements.plist");
-            NSDictionary dict = (NSDictionary) PropertyListParser.parse(IOUtils.toByteArray(getClass().getResourceAsStream(
-                        "/Entitlements.plist")));
-            dict.put("application-identifier", bundleId);
-            dict.put("get-task-allow", getTaskAllow);
+            NSDictionary dict = new NSDictionary();
+            if (bundleId != null)
+                dict.put("application-identifier", bundleId);
+            // xcode uses prefix for simulators entitlements
+            String prefix = isDeviceArch(arch) ? "" : "com.apple.security.";
+            dict.put(prefix + "get-task-allow", getTaskAllow);
             PropertyListParser.saveAsXML(dict, destFile);
             return destFile;
         } catch (IOException e) {
@@ -480,47 +536,90 @@ public class IOSTarget extends AbstractTarget {
     }
 
     /**
-     * finds and copies provisioning profile for AppExtension
-     * @param signIdentity that matches profile
+     * finds and copies provisioning profiles for AppExtensions
+     *
+     * @param extensions   extension information from robovm.xml
+     * @param signIdentity ideantity used to sign application
+     * @param installDir   of application
+     */
+    private void provisionAppExtensions(List<AppExtension> extensions, SigningIdentity signIdentity, File installDir) throws IOException {
+        File pluginsDir = new File(installDir, "PlugIns");
+        if (pluginsDir.exists() && pluginsDir.isDirectory()) {
+            Map<String, AppExtension> extensionsMap = new HashMap<>();
+            extensions.forEach(e -> extensionsMap.put(e.getNameWithExt(".appex"), e));
+
+            // move through all extensions in directory
+            for (File extPath : pluginsDir.listFiles()) {
+                if (!extPath.isDirectory() || !extPath.getName().endsWith(".appex")) {
+                    config.getLogger().info("Skipping not expected file/dir '%s' in PlugIns folder: %s",
+                            extPath.getName(), pluginsDir.getAbsolutePath());
+                    continue;
+                }
+                String name = extPath.getName();
+                AppExtension extension = extensionsMap.get(name);
+                if (extension == null) {
+                    extension = AppExtension.DEFAULT_RULE;
+                    config.getLogger().info("Using default signing rules for app extension " + name);
+                }
+
+                provisionSingleAppExtension(extension, signIdentity, extPath);
+            }
+        }
+    }
+
+    /**
+     * provision single app extension:
+     * - finds and copies profile for it
+     */
+    private void provisionSingleAppExtension(AppExtension extension, SigningIdentity signIdentity, File extPath) throws IOException {
+        if (extension.skipSigning())
+            return;
+
+        // read extension bundle id from plist (id was generated during copy phase up to robovm.xml config)
+        File infoPlistFile = new File(extPath, "Info.plist");
+        String appExBundleId;
+        try {
+            NSDictionary infoPlist = (NSDictionary) PropertyListParser.parse(infoPlistFile);
+            appExBundleId = infoPlist.get("CFBundleIdentifier").toString();
+        } catch (PropertyListFormatException | SAXException | ParserConfigurationException | ParseException e) {
+            throw new IOException(e);
+        }
+
+        ProvisioningProfile appExtProfile;
+        String profileName = extension.getProfile();
+        if (profileName != null) {
+            // profile is specified in robovm.xml
+            appExtProfile = ProvisioningProfile.find(ProvisioningProfile.list(), profileName);
+        } else {
+            // find profile that matches app ext bundle id
+            appExtProfile = ProvisioningProfile.find(ProvisioningProfile.list(), signIdentity, appExBundleId);
+        }
+
+        if (appExtProfile != null) {
+            config.getLogger().info("Copying %s provisioning profile for : %s (%s)",
+                    appExtProfile.getType(),
+                    appExtProfile.getName(),
+                    appExtProfile.getEntitlements().objectForKey("application-identifier"));
+            FileUtils.copyFile(appExtProfile.getFile(), new File(extPath, "embedded.mobileprovision"));
+        } else {
+            throw new RuntimeException("Failed to locate provisioning profile for " + extPath.getName());
+        }
+    }
+
+    /**
+     * provision WatchApplication and its extensions
+     * @param signIdentity used for signing the application
      * @param installDir of application
      */
-    private void provisionAppExtensions(SigningIdentity signIdentity, File installDir) throws IOException {
-        File pluginsDir = new File(installDir, "PlugIns");
+    private void provisionWatchApp(SigningIdentity signIdentity, File installDir) throws IOException {
+        WatchKitApp waConfig = config.getWatchKitApp();
 
-        for (AppExtension extension : config.getAppExtensions()) {
-            // find extension
-            ProvisioningProfile appExtProfile;
-            String profileName = extension.getProfile();
-            if (profileName != null) {
-                // profile is specified in robovm.xml
-                appExtProfile = ProvisioningProfile.find(ProvisioningProfile.list(), profileName);
-            } else {
-                // find profile that matches app ext bundle id
-                String bundleId = getBundleId() + "." + extension.getName();
-                appExtProfile = ProvisioningProfile.find(ProvisioningProfile.list(), signIdentity, bundleId);
-            }
+        // provision app itself
+        File waDir = new File(installDir, "Watch/" + waConfig.getWatchAppName());
+        provisionSingleAppExtension(waConfig.getApp(), signIdentity, waDir);
 
-
-            if (appExtProfile != null) {
-                File extPath = new File(pluginsDir, extension.getName() + ".appex");
-                config.getLogger().info("Copying %s provisioning profile for : %s (%s)",
-                        appExtProfile.getType(),
-                        appExtProfile.getName(),
-                        appExtProfile.getEntitlements().objectForKey("application-identifier"));
-                FileUtils.copyFile(appExtProfile.getFile(), new File(extPath, "embedded.mobileprovision"));
-            } else {
-
-            }
-            if (provisioningProfile == null) {
-                String bundleId = "*";
-                if (config.getIosInfoPList() != null && config.getIosInfoPList().getBundleIdentifier() != null) {
-                    bundleId = config.getIosInfoPList().getBundleIdentifier();
-                }
-                provisioningProfile = ProvisioningProfile.find(ProvisioningProfile.list(), signIdentity, bundleId);
-            }
-
-
-        }
+        // provision plugins
+        provisionAppExtensions(waConfig.getExtensions(), signIdentity, new File(waDir, "/PlugIns" ));
     }
 
     private void codesignApp(SigningIdentity identity, File entitlementsPList, File appDir) throws IOException {
@@ -770,8 +869,8 @@ public class IOSTarget extends AbstractTarget {
                     File stickersExtSupportStub = new File(xcodePath, "Platforms/iPhoneOS.platform/Library/" +
                             "Application Support/MessagesApplicationExtensionStub/MessagesApplicationExtensionStub");
                     if (!stickersExtSupportStub.exists()) {
-                        throw new FileNotFoundException("Stickers support: bi MessagesApplicationStub or MessagesApplicationExtensionStub found in "
-                                + new File(xcodePath, "Platforms/iPhoneOS.platform/Library/Application Support/").getAbsolutePath());
+                        throw new FileNotFoundException("Stickers support: MessagesApplicationExtensionStub not found in "
+                                + stickersExtSupportStub.getAbsolutePath());
                     }
 
                     File stickersExtSupportDestDir = new File(tmpDir, "MessagesApplicationExtensionSupport");
@@ -781,6 +880,21 @@ public class IOSTarget extends AbstractTarget {
                             StandardCopyOption.COPY_ATTRIBUTES);
                 }
             }
+        }
+
+        if (config.getWatchKitApp() != null) {
+            // copy "WatchKitSupport2/WK: for watch kit app
+            config.getLogger().info("Copying support files for WatchKit app extension");
+            File xcodePath = new File(ToolchainUtil.findXcodePath());
+            File wk = new File(xcodePath, "Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk/" +
+                    "Library/Application Support/WatchKit/WK");
+            if (!wk.exists()) {
+                throw new FileNotFoundException("WatchKitSupport support not found in " + wk.getAbsolutePath());
+            }
+
+            File watchKitSupport2 = new File(tmpDir, "WatchKitSupport2");
+            watchKitSupport2.mkdir();
+            Files.copy(wk.toPath(), new File(watchKitSupport2, wk.getName()).toPath(), StandardCopyOption.COPY_ATTRIBUTES);
         }
 
         config.getLogger().info("Zipping %s to %s", tmpDir, ipaFile);
@@ -840,6 +954,7 @@ public class IOSTarget extends AbstractTarget {
         return tmpFile;
     }
 
+    @Override
     protected File getAppDir() {
         File dir = null;
         if (!config.isSkipInstall()) {
@@ -891,11 +1006,11 @@ public class IOSTarget extends AbstractTarget {
             dict.put(key, value);
         }
     }
-    
+
     protected void customizeInfoPList(NSDictionary dict) {
         if (isSimulatorArch(arch)) {
             dict.put("CFBundleSupportedPlatforms", new NSArray(new NSString("iPhoneSimulator")));
-        } else {            
+        } else {
             dict.put("CFBundleSupportedPlatforms", new NSArray(new NSString("iPhoneOS")));
             dict.put("DTPlatformVersion", sdk.getPlatformVersion());
             dict.put("DTPlatformBuild", sdk.getPlatformBuild());

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/SimLauncherProcess.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/SimLauncherProcess.java
@@ -48,6 +48,7 @@ public class SimLauncherProcess extends Process implements Launcher {
     private final AtomicInteger threadCounter = new AtomicInteger();
     private final Logger log;
     private final DeviceType deviceType;
+    private final String watchAppName;
     private final File wd;
     private final String bundleId;
     private final File appDir;
@@ -62,6 +63,7 @@ public class SimLauncherProcess extends Process implements Launcher {
     public SimLauncherProcess(Logger log, File appDir, String bundleId, IOSSimulatorLaunchParameters launchParameters) {
         this.log = log;
         deviceType = launchParameters.getDeviceType();
+        watchAppName = launchParameters.getPairedWatchAppName();
         wd = launchParameters.getWorkingDirectory();
         this.appDir = appDir;
         this.bundleId = bundleId;
@@ -90,8 +92,8 @@ public class SimLauncherProcess extends Process implements Launcher {
             public void run() {
                 try {
                     Executor executor;
-
-                    if ("shutdown".equals(deviceType.getState(true).toLowerCase())) {
+                    DeviceType freshState = deviceType.refresh();
+                    if (freshState != null && "shutdown".equals(freshState.getState().toLowerCase())) {
                         log.info("Booting simulator %s", deviceType.getUdid());
                         executor = new Executor(log, "xcrun");
                         executor.args("simctl", "boot", deviceType.getUdid());
@@ -109,6 +111,30 @@ public class SimLauncherProcess extends Process implements Launcher {
                     executor = new Executor(log, "xcrun");
                     executor.args("simctl", "install", deviceType.getUdid(), appDir.getAbsolutePath());
                     executor.exec();
+
+                    // launch and deploy to paired watch simulator
+                    if (watchAppName != null && freshState != null  && freshState.getPair() != null) {
+                        DeviceType watchDeviceType = freshState.getPair();
+                        if ("shutdown".equals(watchDeviceType.getState().toLowerCase())) {
+                            log.info("Booting watch simulator %s", watchDeviceType.getUdid());
+                            executor = new Executor(log, "xcrun");
+                            executor.args("simctl", "boot", watchDeviceType.getUdid());
+                            executor.exec();
+                        }
+
+                        // bringing simulator to front (and showing it if it was just booted)
+                        log.info("Showing watch simulator %s", watchDeviceType.getUdid());
+                        executor = new Executor(log, "open");
+                        executor.args("-a", "Simulator", "--args", "-CurrentDeviceUDID", watchDeviceType.getUdid());
+                        executor.exec();
+
+                        File watchAppDir = new File(appDir, "Watch/" + watchAppName);
+                        log.info("Deploying app %s to watch simulator %s", watchAppDir.getAbsolutePath(),
+                                watchDeviceType.getUdid());
+                        executor = new Executor(log, "xcrun");
+                        executor.args("simctl", "install", watchDeviceType.getUdid(), watchAppDir.getAbsolutePath());
+                        executor.exec();
+                    }
 
                     log.info("Launching app %s on simulator %s", appDir.getAbsolutePath(),
                             deviceType.getUdid());
@@ -147,7 +173,7 @@ public class SimLauncherProcess extends Process implements Launcher {
         this.launcherThread.start();
         return this;
     }
-    
+
     @Override
     public OutputStream getOutputStream() {
         return new NullOutputStream();

--- a/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmIOSRunConfigurationSettingsEditor.form
+++ b/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmIOSRunConfigurationSettingsEditor.form
@@ -80,7 +80,7 @@
                   </component>
                 </children>
               </grid>
-              <grid id="f35fa" layout-manager="GridLayoutManager" row-count="3" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="f35fa" layout-manager="GridLayoutManager" row-count="4" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
                   <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -124,6 +124,14 @@
                       <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties/>
+                  </component>
+                  <component id="19bab" class="javax.swing.JCheckBox" binding="pairedWatch" default-binding="true">
+                    <constraints>
+                      <grid row="3" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="5" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value="Launch paired watch:"/>
+                    </properties>
                   </component>
                 </children>
               </grid>

--- a/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmRunConfiguration.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmRunConfiguration.java
@@ -71,6 +71,7 @@ public class RoboVmRunConfiguration extends ModuleBasedConfiguration<RoboVmRunCo
     private EntryType simulatorType;
     private String simulator;
     private int simulatorSdk;
+    private boolean simulatorLaunchWatch;
     private String arguments;
     private String workingDir;
 
@@ -98,6 +99,7 @@ public class RoboVmRunConfiguration extends ModuleBasedConfiguration<RoboVmRunCo
             provisioningProfileType = EntryType.AUTO;
             simulatorType = EntryType.AUTO;
             simulatorArch = Arch.x86_64;
+            simulatorLaunchWatch = false;
         } else if (type instanceof RoboVmConsoleConfigurationType) {
             targetType = TargetType.Console;
         }
@@ -138,6 +140,7 @@ public class RoboVmRunConfiguration extends ModuleBasedConfiguration<RoboVmRunCo
         simulator = JDOMExternalizerUtil.readField(element, "simulatorName");
         simulatorArch = valueOf(Arch.class, JDOMExternalizerUtil.readField(element, "simArch"));
         simulatorSdk = parseInt(JDOMExternalizerUtil.readField(element, "simulatorSdk"), -1);
+        simulatorLaunchWatch = parseInt(JDOMExternalizerUtil.readField(element, "simulatorLaunchPair"), -1)  > 0;
         arguments = JDOMExternalizerUtil.readField(element, "arguments", "");
         workingDir = JDOMExternalizerUtil.readField(element, "workingDir", "");
 
@@ -158,6 +161,7 @@ public class RoboVmRunConfiguration extends ModuleBasedConfiguration<RoboVmRunCo
         JDOMExternalizerUtil.writeField(element, "simulatorType", toStringOrNull(simulatorType));
         JDOMExternalizerUtil.writeField(element, "simulatorName", simulator);
         JDOMExternalizerUtil.writeField(element, "simulatorSdk", Integer.toString(simulatorSdk));
+        JDOMExternalizerUtil.writeField(element, "simulatorLaunchWatch", simulatorLaunchWatch ? "1" : "0");
         JDOMExternalizerUtil.writeField(element, "arguments", arguments);
         JDOMExternalizerUtil.writeField(element, "workingDir", workingDir);
     }
@@ -232,6 +236,14 @@ public class RoboVmRunConfiguration extends ModuleBasedConfiguration<RoboVmRunCo
 
     public void setSimulatorSdk(int simulatorSdk) {
         this.simulatorSdk = simulatorSdk;
+    }
+
+    public boolean simulatorLaunchWatch() {
+        return simulatorLaunchWatch;
+    }
+
+    public void setSimulatorLaunchWatch(boolean simulatorLaunchWatch) {
+        this.simulatorLaunchWatch = simulatorLaunchWatch;
     }
 
     public String getModuleName() {

--- a/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmRunProfileState.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmRunProfileState.java
@@ -104,6 +104,8 @@ public class RoboVmRunProfileState extends CommandLineState {
                 if (exactType == null)
                     throw new ExecutionException("Simulator type is not set or is not available anymore!");
                 simParams.setDeviceType(exactType);
+                simParams.setPairedWatchAppName(config.getWatchKitApp() != null && runConfig.simulatorLaunchWatch()
+                        ? config.getWatchKitApp().getWatchAppName() : null);
             }
         }
     }

--- a/plugins/templates/console/src/main/resources/archetype-resources/robovm.xml
+++ b/plugins/templates/console/src/main/resources/archetype-resources/robovm.xml
@@ -4,4 +4,5 @@
 <config>
     <executableName>${app.executable}</executableName>
     <mainClass>${app.mainclass}</mainClass>
+    <target>console</target>
 </config>


### PR DESCRIPTION
This PR delivers changes to allow integrating of dependent WatchOS application (built in Xcode). 
Code was tested against simulator/device/ipa target (thx to Guillermo Rodríguez).
Complete tutorial can be found in [the post](https://dkimitsa.github.io/2020/05/20/tutorial-packing-dependent-watchos-app/)

Once `watch.app` is build it can be configured in `robovm.xml` to be included in application:
```
<watchKitApp>
        <app>watch.app</app>
</watchKitApp>

<appExtensionPaths>
        <!-- path where app extensions (such as watch.app) will be searched in -->
        <path>exts-sim</path>
</appExtensionPaths>
```

This PR also extends `Idea` plugin run configuration and enables to deploy to both iOS and paired watchOS targets. 
