### PR TITLE
* fixed: broken JNI support in case of Framework target

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/plugin/objc/ObjCMemberPlugin.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/plugin/objc/ObjCMemberPlugin.java
@@ -2017,6 +2017,15 @@ public class ObjCMemberPlugin extends AbstractCompilerPlugin {
                 byte[] data = sb.append('\0').toString().getBytes();
                 linker.addBcGlobalData("_bcFrameworkPreloadClasses", data);
             }
+
+            // TODO: probably ObjMemberPlugin is not best place for this logic
+            // but Targets are not integrated into build process and introducing
+            // this infrastructure will require significant changes
+            // disable JVM start up if JNI_CreateJavaVM is listed in exported symbols
+            if (config.getExportedSymbols().contains("JNI_CreateJavaVM")) {
+                byte[] data = new byte[1];
+                linker.addBcGlobalData("_bcFrameworkSkipJavaVMStartup", data);
+            }
         }
     }
 

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/framework/FrameworkTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/framework/FrameworkTarget.java
@@ -118,7 +118,7 @@ public class FrameworkTarget extends AbstractTarget {
 
 	@Override
 	protected List<String> getTargetExportedSymbols() {
-		return Arrays.asList("JNI_*", "rvmInstantiateFramework", "OBJC_CLASS_$_*");
+		return Arrays.asList("JNI_*", "rvmInstantiateFramework", "rvmInitializeFrameworkWithJVM", "OBJC_CLASS_$_*");
 	}
 
 	private String getMinimumOSVersion() {


### PR DESCRIPTION
Root case of issue: JVM was started once Framework was loaded, JVM structures were not exposed, and its not possible to  initialize second JVM using JNI_CreateJavaVM.
Solution: to disable automatic VM creation `JNI_CreateJavaVM` to be exported. Its a trick instead of adding another option to robovm.xml:
```
<exportedSymbols>
    <symbol>JNI_CreateJavaVM</symbol>
</exportedSymbols>
```

Also JNI based class can call back `void rvmInitializeFrameworkWithJVM(JavaVM* externalVm, JNIEnv *externalEnv);` to allow `framework support` code to pre-load objc-classes