### PR TITLE
debugger: fixed crash on sequent debug sessions, fixed idea hang (rare)

### DIFF
--- a/plugins/debugger/src/main/java/org/robovm/debugger/delegates/InstanceUtils.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/delegates/InstanceUtils.java
@@ -74,7 +74,7 @@ public class InstanceUtils {
     public InstanceUtils(AllDelegates delegates) {
         this.delegates = delegates;
         this.runtimeClassInfoLoader = new RuntimeClassInfoLoader(delegates);
-        this.manipulator = new Manipulator(this);
+        this.manipulator = new Manipulator(this, new Converter());
     }
 
     public RuntimeClassInfoLoader classInfoLoader() {
@@ -789,7 +789,7 @@ public class InstanceUtils {
      * Special subclass for object manipulations
      */
     private static class Manipulator extends ValueManipulator {
-        private Manipulator(InstanceUtils utils) {
+        private Manipulator(InstanceUtils utils, Converter converterInstance) {
             super(
                     fromDevice -> {
                         long ptr = fromDevice.readPointer();
@@ -806,7 +806,7 @@ public class InstanceUtils {
                     (jdwpWriter, o) -> {
                         VmInstance instance = (VmInstance) o;
                         if (instance != null) {
-                            byte typeTag = Converter.jdwpInstanceTag(instance.classInfo(), utils.delegates.state().classInfoLoader());
+                            byte typeTag = converterInstance.jdwpInstanceTag(instance.classInfo(), utils.delegates.state().classInfoLoader());
                             jdwpWriter.writeByte(typeTag);
                             jdwpWriter.writeLong(instance.refId());
                         } else {

--- a/plugins/debugger/src/main/java/org/robovm/debugger/jdwp/JdwpDebugServer.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/jdwp/JdwpDebugServer.java
@@ -78,6 +78,7 @@ import org.robovm.debugger.jdwp.handlers.vm.JdwpVmClassPathsHandler;
 import org.robovm.debugger.jdwp.handlers.vm.JdwpVmClassesBySignatureHandler;
 import org.robovm.debugger.jdwp.handlers.vm.JdwpVmCreateStringHandler;
 import org.robovm.debugger.jdwp.handlers.vm.JdwpVmDisposeHandler;
+import org.robovm.debugger.jdwp.handlers.vm.JdwpVmDisposeObjectsHandler;
 import org.robovm.debugger.jdwp.handlers.vm.JdwpVmExitHandler;
 import org.robovm.debugger.jdwp.handlers.vm.JdwpVmHoldEventsHandler;
 import org.robovm.debugger.jdwp.handlers.vm.JdwpVmIdSizesHandler;
@@ -331,7 +332,7 @@ public class JdwpDebugServer implements IJdwpServerApi{
         registerHandler(new JdwpVmCreateStringHandler(delegates));// CreateString Command (11)
         registerHandler(new JdwpVmCapabilitiesHandler()); // 12
         registerHandler(new JdwpVmClassPathsHandler()); // 13
-        // DisposeObjects Command (14) -- NOT_IMPLEMENTED
+        registerHandler(new JdwpVmDisposeObjectsHandler()); // 14
         registerHandler(new JdwpVmHoldEventsHandler(delegates)); // HoldEvents Command (15)
         registerHandler(new JdwpVmReleaseEventsHandler(delegates)); // ReleaseEvents Command (16)
         registerHandler(new JdwpVmCapabilitiesNewHandler()); // 17

--- a/plugins/debugger/src/main/java/org/robovm/debugger/jdwp/handlers/vm/JdwpVmDisposeObjectsHandler.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/jdwp/handlers/vm/JdwpVmDisposeObjectsHandler.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 Justin Shapcott.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.debugger.jdwp.handlers.vm;
+
+import org.robovm.debugger.jdwp.JdwpConsts;
+import org.robovm.debugger.jdwp.protocol.IJdwpRequestHandler;
+import org.robovm.debugger.utils.bytebuffer.DataBufferReader;
+import org.robovm.debugger.utils.bytebuffer.DataBufferWriter;
+
+/**
+ * @author Demyan Kimitsa
+ * Releases a list of object IDs. For each object in the list, the following applies.
+ * Use of this command is not required.
+ */
+public class JdwpVmDisposeObjectsHandler implements IJdwpRequestHandler {
+
+    @Override
+    public short handle(DataBufferReader payload, DataBufferWriter output) {
+        // doing nothing here.
+        // if error returned -- debug session hangs in Idea
+        return JdwpConsts.Error.NONE;
+    }
+
+    @Override
+    public byte getCommandSet() {
+        return 1;
+    }
+
+    @Override
+    public byte getCommand() {
+        return 14;
+    }
+
+    @Override
+    public String toString() {
+        return "VirtualMachine(1).DisposeObjects(14)";
+    }
+}

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/Converter.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/Converter.java
@@ -155,7 +155,7 @@ public final class Converter {
      * @param loader loader to find out super class if required
      * @return JDPW presentation of instance
      */
-    public static byte jdwpInstanceTag(ClassInfo classInfo, ClassInfoLoader loader) {
+    public byte jdwpInstanceTag(ClassInfo classInfo, ClassInfoLoader loader) {
         if (classInfo.isArray())
             return JdwpConsts.Tag.ARRAY;
 
@@ -219,6 +219,5 @@ public final class Converter {
         return tag;
     }
 
-    private static final Map<Long, Byte> classInfoToTagMap = new HashMap<>();
-
+    private final Map<Long, Byte> classInfoToTagMap = new HashMap<>();
 }


### PR DESCRIPTION
this PR deliver two fixes: 
- debugger was crashing in sequent debug session with ClassCastException (root case -- tag cache was implemented as static field and was keeping values from previous session)
- added dummy JdwpVmDisposeObjectsHandler , if returned NOT_IMPLEMENTED IntelliJ IDEA hang debug session