### PR TITLE
fix: debugger was not able to attach to target if run arguments were specified

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ConsoleTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ConsoleTarget.java
@@ -73,7 +73,7 @@ public class ConsoleTarget extends AbstractTarget {
         
         return createExecutor(launchParameters, new File(dir, 
                 config.getExecutableName()).getAbsolutePath(), 
-                launchParameters.getArguments())
+                launchParameters.getArguments(true))
                 .out(out).err(err).closeOutputStreams(true);
     }
     

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/LaunchParameters.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/LaunchParameters.java
@@ -33,7 +33,26 @@ public class LaunchParameters {
     public List<String> getArguments() {
         return arguments;
     }
-    
+
+    public List<String> getArguments(boolean rvmReorder) {
+        if (rvmReorder) {
+            // filter arguments to have all -rvm: to be present in front of any other user specified
+            // otherwise robovm will just stop parsing JVM parameters at first non `-rvm:` one
+            List<String> rvmArgs = new ArrayList<>();
+            List<String> userArgs = new ArrayList<>();
+            for (String arg : arguments) {
+                if (arg.startsWith("-rvm:"))
+                    rvmArgs.add(arg);
+                else
+                    userArgs.add(arg);
+            }
+            rvmArgs.addAll(userArgs);
+            return rvmArgs;
+        } else {
+            return arguments;
+        }
+    }
+
     public void setArguments(List<String> arguments) {
         this.arguments = arguments;
     }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -216,7 +216,7 @@ public class IOSTarget extends AbstractTarget {
         }
                 .stdout(out)
                 .closeOutOnExit(true)
-                .args(launchParameters.getArguments().toArray(new String[0]))
+                .args(launchParameters.getArguments(true).toArray(new String[0]))
                 .env(env)
                 .forward(forwardPort)
                 .appLauncherCallback(callback)

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/SimLauncherProcess.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/SimLauncherProcess.java
@@ -65,7 +65,7 @@ public class SimLauncherProcess extends Process implements Launcher {
         wd = launchParameters.getWorkingDirectory();
         this.appDir = appDir;
         this.bundleId = bundleId;
-        this.arguments = new ArrayList<>(launchParameters.getArguments());
+        this.arguments = new ArrayList<>(launchParameters.getArguments(true));
         if (launchParameters.getEnvironment() != null) {
             this.env = new HashMap<>();
             for (Map.Entry<String, String> entry : launchParameters.getEnvironment().entrySet()) {


### PR DESCRIPTION

## root case 
work flow is messy as result rvm debug parameters are being injected last after user ones.
but runtimes parses rvm at startup and stop at first non rvm. as result debugger arguments are not being parsed and target starts without waiting for debugger.
## the fix
reorder arguments and place rvm parameters in place.
example of wrong order (rvm will stop at -FIRDebugEnabled):
> -rvm:log=warn -FIRDebugEnabled -FIRLoggerForceSTDERR -rvm:EnableHooks -rvm:WaitForResume -rvm:PrintDebugPort=/var/folders/6.port
reordered:
> -rvm:log=warn -rvm:EnableHooks -rvm:WaitForResume -rvm:PrintDebugPort=/var/folders/6.port -FIRDebugEnabled -FIRLoggerForceSTDERR

## possible side effect 
if user specifies `-rvm` arguments the order of user arguments will be changed