### PR TITLE
* fixed: #500 Build system not linking two static swift libraries

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -166,6 +166,8 @@ public class Config {
     private ArrayList<AppExtension> appExtensions;
     @ElementList(required = false, entry = "path")
     private ArrayList<QualifiedFile> appExtensionPaths;
+    @ElementList(required = false, entry = "path")
+    private ArrayList<File> swiftLibPaths;
     @ElementList(required = false, entry = "resource")
     private ArrayList<Resource> resources;   
     @ElementList(required = false, entry = "classpathentry")
@@ -454,6 +456,11 @@ public class Config {
                 .filter(this::isQualified)
                 .map(e -> e.entry)
                 .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
+    }
+
+    public List<File> getSwiftLibPaths() {
+        return swiftLibPaths == null ? Collections.emptyList()
+                : Collections.unmodifiableList(swiftLibPaths);
     }
 
     public List<Resource> getResources() {
@@ -1495,6 +1502,21 @@ public class Config {
                 config.appExtensionPaths = new ArrayList<>();
             }
             config.appExtensionPaths.add(new QualifiedFile(extensionPath));
+            return this;
+        }
+
+        public Builder clearSwiftLibPaths() {
+            if (config.swiftLibPaths != null) {
+                config.swiftLibPaths.clear();
+            }
+            return this;
+        }
+
+        public Builder addSwiftLibPath(File path) {
+            if (config.swiftLibPaths == null) {
+                config.swiftLibPaths = new ArrayList<>();
+            }
+            config.swiftLibPaths.add(path);
             return this;
         }
 


### PR DESCRIPTION
## root case
swift libraries were picked from `swift5.0` folder.  this is ok for dynamic linkage with swift. in case of static one there are `libswiftCompatibility50.a` and `libswiftCompatibilityDynamicReplacements.a that to be looked in `swift``folder
## fix
now look up is happening in both `swift` and `swift5.0`
## extra changes
config was extended with `<swiftLibPaths><path>path1</path></swiftLibPaths>` configuration options to allow manually specify swift lib location
## other notes
libswiftCompatibility50 references dependencies that are not picked automatically and have to be specified manually, for swift 5.1 following to be added to robovm.xml `<lib>swiftCompatibility51</lib>`