### PR TITLE
jni: fixed early JNI_OnLoad, fixed use of BootClassLoader within JNI FindClass call

### DIFF
--- a/compiler/vm/core/src/class.c
+++ b/compiler/vm/core/src/class.c
@@ -752,7 +752,11 @@ jboolean rvmInitPrimitiveWrapperClasses(Env* env) {
 Class* rvmFindClass(Env* env, const char* className) {
     Method* method = rvmGetCallingMethod(env);
     if (rvmExceptionOccurred(env)) return NULL;
-    Object* classLoader = method ? method->clazz->classLoader : systemClassLoader;
+    // dkimitsa: method->clazz->classLoader is NULL in case of BootClassLoader
+    // any try to load user class using BCL will fail as all user classes are not in BC list
+    // it might happen when BC class is on top of stack, for example java.lang.Runtime
+    // will be most top when JNI_OnLoad is called in result of System.loadLibrary()
+    Object* classLoader = (method && method->clazz->classLoader) ? method->clazz->classLoader : systemClassLoader;
     return rvmFindClassUsingLoader(env, className, classLoader);
 }
 


### PR DESCRIPTION
this PR fixes issue reported by [Subsurfer in gitter](https://gitter.im/MobiVM/robovm?at=5f175f7b43d5173b8c0da2a3)
## Fix1: 
JNI FindClass was not successful when was called from JNI_OnLoad (as result of System.loadLibrary)
root case: top java class on stack was `java.lang.Runtime` and its classLoader was NULL (corresponds to BootClassLoader). As result user class was looked in BC list and failed.
fix: use systemClassLoader in case as top java class is BC class.
issue is similar to https://github.com/robovm/robovm/issues/352

## Fix2:
if application uses dynamic framework or library that exposes JNI_OnLoad it being called in context of application image. This happens as dyld loads all symbols from libraries referenced by LC_LOAD_DYLIB command. as result library JNI_OnLoad got called on early state while JNI is not initialized yet. This caused GPF due null pointer de-reference.
fix: ignore JNI_OnLoad for application image