### PR TITLE
* this enables deployment to ios14 devices

### DIFF
--- a/compiler/libimobiledevice/patches/03-fix-ios14-pr1004-fallback-secure-services.patch
+++ b/compiler/libimobiledevice/patches/03-fix-ios14-pr1004-fallback-secure-services.patch
@@ -1,0 +1,179 @@
+From de06df7731fea323d544692b221bb67576a52d77 Mon Sep 17 00:00:00 2001
+From: eliyahustern <eliyahu@experitest.com>
+Date: Sun, 23 Aug 2020 21:23:12 +0300
+Subject: [PATCH] Resolves #1004: fallback to secured services
+
+---
+ include/libimobiledevice/debugserver.h |  1 +
+ include/libimobiledevice/lockdown.h    |  1 +
+ src/debugserver.c                      |  7 ++-
+ src/lockdown.c                         | 81 ++++++++++++++++++--------
+ 4 files changed, 66 insertions(+), 24 deletions(-)
+
+diff --git a/include/libimobiledevice/debugserver.h b/include/libimobiledevice/debugserver.h
+index 8ff31fb9..55c4ddc8 100644
+--- a/include/libimobiledevice/debugserver.h
++++ b/include/libimobiledevice/debugserver.h
+@@ -31,6 +31,7 @@ extern "C" {
+ #include <libimobiledevice/lockdown.h>
+ 
+ #define DEBUGSERVER_SERVICE_NAME "com.apple.debugserver"
++#define DEBUGSERVER_SECURED_SERVICE_NAME "com.apple.debugserver.DVTSecureSocketProxy"
+ 
+ /** Error Codes */
+ typedef enum {
+diff --git a/include/libimobiledevice/lockdown.h b/include/libimobiledevice/lockdown.h
+index a660f33e..f19abbd1 100644
+--- a/include/libimobiledevice/lockdown.h
++++ b/include/libimobiledevice/lockdown.h
+@@ -96,6 +96,7 @@ typedef struct lockdownd_pair_record *lockdownd_pair_record_t;
+ struct lockdownd_service_descriptor {
+ 	uint16_t port;
+ 	uint8_t ssl_enabled;
++    char* identifier;
+ };
+ typedef struct lockdownd_service_descriptor *lockdownd_service_descriptor_t;
+ 
+diff --git a/src/debugserver.c b/src/debugserver.c
+index c5170171..d8ea52f7 100644
+--- a/src/debugserver.c
++++ b/src/debugserver.c
+@@ -80,7 +80,12 @@ LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_new(idevice_t device
+ 		debug_info("Creating base service client failed. Error: %i", ret);
+ 		return ret;
+ 	}
+-	service_disable_bypass_ssl(parent, 1);
++    
++    /* Disable service SSL only in iOS 13, where "com.apple.debugserver"
++     is not yet replaced by "com.apple.debugserver.DVTSecureSocketProxy" */
++    if (strcmp(service->identifier, "com.apple.debugserver") == 0) {
++        service_disable_bypass_ssl(parent, 1);
++    }
+ 
+ 	debugserver_client_t client_loc = (debugserver_client_t) malloc(sizeof(struct debugserver_client_private));
+ 	client_loc->parent = parent;
+diff --git a/src/lockdown.c b/src/lockdown.c
+index 79353f23..6ec9d58b 100644
+--- a/src/lockdown.c
++++ b/src/lockdown.c
+@@ -38,6 +38,7 @@
+ #include "property_list_service.h"
+ #include "lockdown.h"
+ #include "idevice.h"
++#include "debugserver.h"
+ #include "common/debug.h"
+ #include "common/userpref.h"
+ #include "common/utils.h"
+@@ -1251,6 +1252,36 @@ static lockdownd_error_t lockdownd_build_start_service_request(lockdownd_client_
+ 	return LOCKDOWN_E_SUCCESS;
+ }
+ 
++static void send_start_service_receive_response(lockdownd_client_t client, plist_t *dict, const char *identifier, lockdownd_error_t *ret, int send_escrow_bag) {
++    /* create StartService request */
++    *ret = lockdownd_build_start_service_request(client, identifier, send_escrow_bag, dict);
++    if (LOCKDOWN_E_SUCCESS != *ret)
++        return;
++
++    /* send to device */
++    *ret = lockdownd_send(client, *dict);
++    plist_free(*dict);
++    *dict = NULL;
++
++    if (LOCKDOWN_E_SUCCESS != *ret)
++        return;
++
++    /* receive respose */
++    *ret = lockdownd_receive(client, dict);
++
++    if (LOCKDOWN_E_SUCCESS != *ret)
++        return;
++
++    if (!*dict) {
++        *ret = LOCKDOWN_E_PLIST_ERROR;
++        return;
++    }
++    
++
++    /* extract response error */
++    *ret = lockdown_check_result(*dict, "StartService");
++}
++
+ /**
+  * Function used internally by lockdownd_start_service and lockdownd_start_service_with_escrow_bag.
+  *
+@@ -1274,39 +1305,39 @@ static lockdownd_error_t lockdownd_do_start_service(lockdownd_client_t client, c
+ 		// reset fields if service descriptor is reused
+ 		(*service)->port = 0;
+ 		(*service)->ssl_enabled = 0;
++        if ((*service)->identifier) {
++            free((*service)->identifier);
++            (*service)->identifier = NULL;
++        }
+ 	}
+ 
+ 	plist_t dict = NULL;
+ 	uint16_t port_loc = 0;
+ 	lockdownd_error_t ret = LOCKDOWN_E_UNKNOWN_ERROR;
+ 
+-	/* create StartService request */
+-	ret = lockdownd_build_start_service_request(client, identifier, send_escrow_bag, &dict);
+-	if (LOCKDOWN_E_SUCCESS != ret)
+-		return ret;
+-
+-	/* send to device */
+-	ret = lockdownd_send(client, dict);
+-	plist_free(dict);
+-	dict = NULL;
+-
+-	if (LOCKDOWN_E_SUCCESS != ret)
+-		return ret;
+-
+-	ret = lockdownd_receive(client, &dict);
+-
+-	if (LOCKDOWN_E_SUCCESS != ret)
+-		return ret;
+-
+-	if (!dict)
+-		return LOCKDOWN_E_PLIST_ERROR;
+-
+-	ret = lockdown_check_result(dict, "StartService");
++    
++    send_start_service_receive_response(client, &dict, identifier, &ret, send_escrow_bag);
++    
++    if (ret == LOCKDOWN_E_INVALID_SERVICE) {
++        /* In iOS 14 some DDI services were removed in favor of a secured version */
++        if (strcmp("com.apple.instruments.remoteserver", identifier) == 0) {
++            identifier = "com.apple.instruments.remoteserver.DVTSecureSocketProxy";
++            send_start_service_receive_response(client, &dict, identifier, &ret, send_escrow_bag);
++        } else if (strcmp("com.apple.testmanagerd.lockdown", identifier) == 0) {
++            identifier = "com.apple.testmanagerd.lockdown.secure";
++            send_start_service_receive_response(client, &dict, identifier, &ret, send_escrow_bag);
++        } else if (strcmp(DEBUGSERVER_SERVICE_NAME, identifier) == 0) {
++            identifier = DEBUGSERVER_SECURED_SERVICE_NAME;
++            send_start_service_receive_response(client, &dict, identifier, &ret, send_escrow_bag);
++        }
++    }
++    
+ 	if (ret == LOCKDOWN_E_SUCCESS) {
+ 		if (*service == NULL)
+ 			*service = (lockdownd_service_descriptor_t)malloc(sizeof(struct lockdownd_service_descriptor));
+ 		(*service)->port = 0;
+ 		(*service)->ssl_enabled = 0;
++        (*service)->identifier = strdup(identifier);
+ 
+ 		/* read service port number */
+ 		plist_t node = plist_dict_get_item(dict, "Port");
+@@ -1511,8 +1542,12 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_data_classes_free(char **classe
+ 
+ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_service_descriptor_free(lockdownd_service_descriptor_t service)
+ {
+-	if (service)
++    if (service) {
++        if (service->identifier) {
++            free(service->identifier);
++        }
+ 		free(service);
++    }
+ 
+ 	return LOCKDOWN_E_SUCCESS;
+ }

--- a/compiler/libimobiledevice/patches/04-fix-ssl_read_with_timeout.patch
+++ b/compiler/libimobiledevice/patches/04-fix-ssl_read_with_timeout.patch
@@ -1,0 +1,76 @@
+diff --git a/src/idevice.c b/src/idevice.c
+index 06991c5..8b6495e 100644
+--- a/src/idevice.c
++++ b/src/idevice.c
+@@ -28,6 +28,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <errno.h>
++#include <sys/time.h>
+ 
+ #include <usbmuxd.h>
+ #ifdef HAVE_OPENSSL
+@@ -449,6 +450,13 @@ static idevice_error_t internal_connection_receive_timeout(idevice_connection_t
+ 	return IDEVICE_E_UNKNOWN_ERROR;
+ }
+ 
++// TODO: temporally code, move to utils?
++static long long microseconds() {
++	struct timeval tm;
++	gettimeofday(&tm,NULL);
++	return tm.tv_usec / 1000L;
++}
++
+ LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_receive_timeout(idevice_connection_t connection, char *data, uint32_t len, uint32_t *recv_bytes, unsigned int timeout)
+ {
+ 	if (!connection || (connection->ssl_data && !connection->ssl_data->session) || len == 0) {
+@@ -458,18 +466,22 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_receive_timeout(idevice_
+ 	if (connection->ssl_data) {
+ 		uint32_t received = 0;
+ 		int do_select = 1;
+-
+-		while (received < len) {
++		int timeout_left;
++		long long timeout_ts = microseconds() + timeout;
++		while (received < len && (timeout_left = timeout_ts - microseconds()) > 0) {
+ #ifdef HAVE_OPENSSL
+ 			do_select = (SSL_pending(connection->ssl_data->session) == 0);
+ #endif
+ 			if (do_select) {
+-				int conn_error = socket_check_fd((int)(long)connection->data, FDM_READ, timeout);
++				int conn_error = socket_check_fd((int)(long)connection->data, FDM_READ, timeout_left);
+ 				idevice_error_t error = socket_recv_to_idevice_error(conn_error, len, received);
+ 
+ 				switch (error) {
+ 					case IDEVICE_E_SUCCESS:
+ 						break;
++					case IDEVICE_E_TIMEOUT:
++						*recv_bytes = received;
++						return IDEVICE_E_TIMEOUT;
+ 					case IDEVICE_E_UNKNOWN_ERROR:
+ 						debug_info("ERROR: socket_check_fd returned %d (%s)", conn_error, strerror(-conn_error));
+ 					default:
+@@ -484,18 +496,19 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_receive_timeout(idevice_
+ #endif
+ 			if (r > 0) {
+ 				received += r;
+-			} else {
++			} else if (r < 0) {
++				*recv_bytes = 0;
++				return IDEVICE_E_SSL_ERROR;
+ 				break;
+ 			}
+ 		}
+ 
+ 		debug_info("SSL_read %d, received %d", len, received);
++		*recv_bytes = received;
+ 		if (received < len) {
+-			*recv_bytes = 0;
+-			return IDEVICE_E_SSL_ERROR;
++			return IDEVICE_E_TIMEOUT;
+ 		}
+ 		
+-		*recv_bytes = received;
+ 		return IDEVICE_E_SUCCESS;
+ 	}
+ 	return internal_connection_receive_timeout(connection, data, len, recv_bytes, timeout);

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/LockdowndServiceDescriptor.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/LockdowndServiceDescriptor.java
@@ -24,10 +24,12 @@ import org.robovm.libimobiledevice.binding.LockdowndServiceDescriptorStruct;
 public class LockdowndServiceDescriptor {
     private final int port;
     private final boolean sslEnabled;
+    private final String identifier;
     
     LockdowndServiceDescriptor(LockdowndServiceDescriptorStruct descriptor) {
         this.port = descriptor.getPort() & 0xffff;
         this.sslEnabled = descriptor.getSslEnabled();
+        this.identifier = descriptor.getIdentifier();
     }
 
     public int getPort() {
@@ -42,6 +44,7 @@ public class LockdowndServiceDescriptor {
         LockdowndServiceDescriptorStruct res = new LockdowndServiceDescriptorStruct();
         res.setPort((short) port);
         res.setSslEnabled(sslEnabled);
+        res.setIdentifier(identifier);
         return res;
     }
 }

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/AfcClientRefOut.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/AfcClientRefOut.java
@@ -21,6 +21,7 @@ public class AfcClientRefOut {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
+  @SuppressWarnings("deprecation")
   protected void finalize() {
     delete();
   }

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/ByteArray.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/ByteArray.java
@@ -21,6 +21,7 @@ public class ByteArray {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
+  @SuppressWarnings("deprecation")
   protected void finalize() {
     delete();
   }

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/ByteArrayOut.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/ByteArrayOut.java
@@ -21,6 +21,7 @@ public class ByteArrayOut {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
+  @SuppressWarnings("deprecation")
   protected void finalize() {
     delete();
   }

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/DebugServerClientRefOut.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/DebugServerClientRefOut.java
@@ -21,6 +21,7 @@ public class DebugServerClientRefOut {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
+  @SuppressWarnings("deprecation")
   protected void finalize() {
     delete();
   }

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/IDeviceConnectionRefOut.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/IDeviceConnectionRefOut.java
@@ -21,6 +21,7 @@ public class IDeviceConnectionRefOut {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
+  @SuppressWarnings("deprecation")
   protected void finalize() {
     delete();
   }

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/IDeviceEvent.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/IDeviceEvent.java
@@ -21,6 +21,7 @@ public class IDeviceEvent {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
+  @SuppressWarnings("deprecation")
   protected void finalize() {
     delete();
   }

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/IDeviceRefOut.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/IDeviceRefOut.java
@@ -21,6 +21,7 @@ public class IDeviceRefOut {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
+  @SuppressWarnings("deprecation")
   protected void finalize() {
     delete();
   }

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/InstproxyClientRefOut.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/InstproxyClientRefOut.java
@@ -21,6 +21,7 @@ public class InstproxyClientRefOut {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
+  @SuppressWarnings("deprecation")
   protected void finalize() {
     delete();
   }

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/IntOut.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/IntOut.java
@@ -21,6 +21,7 @@ public class IntOut {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
+  @SuppressWarnings("deprecation")
   protected void finalize() {
     delete();
   }

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/LibIMobileDevice.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/LibIMobileDevice.java
@@ -166,8 +166,8 @@ public class LibIMobileDevice implements LibIMobileDeviceConstants {
     return LockdowndError.swigToEnum(LibIMobileDeviceJNI.lockdownd_start_service_with_escrow_bag(LockdowndClientRef.getCPtr(client), client, identifier, LockdowndServiceDescriptorStructOut.getCPtr(service), service));
   }
 
-  public static LockdowndError lockdownd_start_session(LockdowndClientRef client, String host_id, StringOut session_id, IntOut ssl_enabled) {
-    return LockdowndError.swigToEnum(LibIMobileDeviceJNI.lockdownd_start_session(LockdowndClientRef.getCPtr(client), client, host_id, StringOut.getCPtr(session_id), session_id, IntOut.getCPtr(ssl_enabled), ssl_enabled));
+  public static LockdowndError lockdownd_start_session(LockdowndClientRef client, String host_id, StringOut session_id, IntOut sslEnabled) {
+    return LockdowndError.swigToEnum(LibIMobileDeviceJNI.lockdownd_start_session(LockdowndClientRef.getCPtr(client), client, host_id, StringOut.getCPtr(session_id), session_id, IntOut.getCPtr(sslEnabled), sslEnabled));
   }
 
   public static LockdowndError lockdownd_stop_session(LockdowndClientRef client, String session_id) {

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/LibIMobileDeviceJNI.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/LibIMobileDeviceJNI.java
@@ -117,6 +117,8 @@ public class LibIMobileDeviceJNI {
   public final static native short LockdowndServiceDescriptorStruct_port_get(long jarg1, LockdowndServiceDescriptorStruct jarg1_);
   public final static native void LockdowndServiceDescriptorStruct_sslEnabled_set(long jarg1, LockdowndServiceDescriptorStruct jarg1_, boolean jarg2);
   public final static native boolean LockdowndServiceDescriptorStruct_sslEnabled_get(long jarg1, LockdowndServiceDescriptorStruct jarg1_);
+  public final static native void LockdowndServiceDescriptorStruct_identifier_set(long jarg1, LockdowndServiceDescriptorStruct jarg1_, String jarg2);
+  public final static native String LockdowndServiceDescriptorStruct_identifier_get(long jarg1, LockdowndServiceDescriptorStruct jarg1_);
   public final static native long new_LockdowndServiceDescriptorStruct();
   public final static native void delete_LockdowndServiceDescriptorStruct(long jarg1);
   public final static native int lockdownd_client_new(long jarg1, IDeviceRef jarg1_, long jarg2, LockdowndClientRefOut jarg2_, String jarg3);

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/LockdowndClientRefOut.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/LockdowndClientRefOut.java
@@ -21,6 +21,7 @@ public class LockdowndClientRefOut {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
+  @SuppressWarnings("deprecation")
   protected void finalize() {
     delete();
   }

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/LockdowndPairRecordStruct.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/LockdowndPairRecordStruct.java
@@ -21,6 +21,7 @@ public class LockdowndPairRecordStruct {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
+  @SuppressWarnings("deprecation")
   protected void finalize() {
     delete();
   }

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/LockdowndServiceDescriptorStruct.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/LockdowndServiceDescriptorStruct.java
@@ -21,6 +21,7 @@ public class LockdowndServiceDescriptorStruct {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
+  @SuppressWarnings("deprecation")
   protected void finalize() {
     delete();
   }
@@ -49,6 +50,14 @@ public class LockdowndServiceDescriptorStruct {
 
   public boolean getSslEnabled() {
     return LibIMobileDeviceJNI.LockdowndServiceDescriptorStruct_sslEnabled_get(swigCPtr, this);
+  }
+
+  public void setIdentifier(String value) {
+    LibIMobileDeviceJNI.LockdowndServiceDescriptorStruct_identifier_set(swigCPtr, this, value);
+  }
+
+  public String getIdentifier() {
+    return LibIMobileDeviceJNI.LockdowndServiceDescriptorStruct_identifier_get(swigCPtr, this);
   }
 
   public LockdowndServiceDescriptorStruct() {

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/LockdowndServiceDescriptorStructOut.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/LockdowndServiceDescriptorStructOut.java
@@ -21,6 +21,7 @@ public class LockdowndServiceDescriptorStructOut {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
+  @SuppressWarnings("deprecation")
   protected void finalize() {
     delete();
   }

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/LongOut.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/LongOut.java
@@ -21,6 +21,7 @@ public class LongOut {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
+  @SuppressWarnings("deprecation")
   protected void finalize() {
     delete();
   }

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/MobileImageMounterClientRefOut.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/MobileImageMounterClientRefOut.java
@@ -21,6 +21,7 @@ public class MobileImageMounterClientRefOut {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
+  @SuppressWarnings("deprecation")
   protected void finalize() {
     delete();
   }

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/PlistRefOut.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/PlistRefOut.java
@@ -21,6 +21,7 @@ public class PlistRefOut {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
+  @SuppressWarnings("deprecation")
   protected void finalize() {
     delete();
   }

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/StringArray.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/StringArray.java
@@ -21,6 +21,7 @@ public class StringArray {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
+  @SuppressWarnings("deprecation")
   protected void finalize() {
     delete();
   }

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/StringArrayOut.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/StringArrayOut.java
@@ -21,6 +21,7 @@ public class StringArrayOut {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
+  @SuppressWarnings("deprecation")
   protected void finalize() {
     delete();
   }

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/StringOut.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/binding/StringOut.java
@@ -21,6 +21,7 @@ public class StringOut {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
+  @SuppressWarnings("deprecation")
   protected void finalize() {
     delete();
   }

--- a/compiler/libimobiledevice/src/main/native/libimobiledevice_wrap.c
+++ b/compiler/libimobiledevice/src/main/native/libimobiledevice_wrap.c
@@ -158,15 +158,16 @@
 
 /* Support for throwing Java exceptions */
 typedef enum {
-  SWIG_JavaOutOfMemoryError = 1, 
-  SWIG_JavaIOException, 
-  SWIG_JavaRuntimeException, 
+  SWIG_JavaOutOfMemoryError = 1,
+  SWIG_JavaIOException,
+  SWIG_JavaRuntimeException,
   SWIG_JavaIndexOutOfBoundsException,
   SWIG_JavaArithmeticException,
   SWIG_JavaIllegalArgumentException,
   SWIG_JavaNullPointerException,
   SWIG_JavaDirectorPureVirtual,
-  SWIG_JavaUnknownError
+  SWIG_JavaUnknownError,
+  SWIG_JavaIllegalStateException,
 } SWIG_JavaExceptionCodes;
 
 typedef struct {
@@ -187,6 +188,7 @@ static void SWIGUNUSED SWIG_JavaThrowException(JNIEnv *jenv, SWIG_JavaExceptionC
     { SWIG_JavaNullPointerException, "java/lang/NullPointerException" },
     { SWIG_JavaDirectorPureVirtual, "java/lang/RuntimeException" },
     { SWIG_JavaUnknownError,  "java/lang/UnknownError" },
+    { SWIG_JavaIllegalStateException, "java/lang/IllegalStateException" },
     { (SWIG_JavaExceptionCodes)0,  "java/lang/UnknownError" }
   };
   const SWIG_JavaExceptions_t *except_ptr = java_exceptions;
@@ -2545,6 +2547,47 @@ SWIGEXPORT jboolean JNICALL Java_org_robovm_libimobiledevice_binding_LibIMobileD
   arg1 = *(struct lockdownd_service_descriptor **)&jarg1; 
   result =  ((arg1)->ssl_enabled);
   jresult = result; 
+  return jresult;
+}
+
+
+SWIGEXPORT void JNICALL Java_org_robovm_libimobiledevice_binding_LibIMobileDeviceJNI_LockdowndServiceDescriptorStruct_1identifier_1set(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jstring jarg2) {
+  struct lockdownd_service_descriptor *arg1 = (struct lockdownd_service_descriptor *) 0 ;
+  char *arg2 = (char *) 0 ;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(struct lockdownd_service_descriptor **)&jarg1; 
+  arg2 = 0;
+  if (jarg2) {
+    arg2 = (char *)(*jenv)->GetStringUTFChars(jenv, jarg2, 0);
+    if (!arg2) return ;
+  }
+  {
+    free(arg1->identifier);
+    if (arg2) {
+      arg1->identifier = (char *) malloc(strlen((const char *)arg2)+1);
+      strcpy((char *)arg1->identifier, (const char *)arg2);
+    } else {
+      arg1->identifier = 0;
+    }
+  }
+  if (arg2) (*jenv)->ReleaseStringUTFChars(jenv, jarg2, (const char *)arg2);
+}
+
+
+SWIGEXPORT jstring JNICALL Java_org_robovm_libimobiledevice_binding_LibIMobileDeviceJNI_LockdowndServiceDescriptorStruct_1identifier_1get(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
+  jstring jresult = 0 ;
+  struct lockdownd_service_descriptor *arg1 = (struct lockdownd_service_descriptor *) 0 ;
+  char *result = 0 ;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(struct lockdownd_service_descriptor **)&jarg1; 
+  result = (char *) ((arg1)->identifier);
+  if (result) jresult = (*jenv)->NewStringUTF(jenv, (const char *)result);
   return jresult;
 }
 

--- a/compiler/libimobiledevice/src/main/swig/include/libimobiledevice/lockdown.h
+++ b/compiler/libimobiledevice/src/main/swig/include/libimobiledevice/lockdown.h
@@ -96,6 +96,7 @@ typedef struct lockdownd_pair_record *lockdownd_pair_record_t;
 struct lockdownd_service_descriptor {
 	uint16_t port;
 	uint8_t ssl_enabled;
+	char* identifier;
 };
 typedef struct lockdownd_service_descriptor *lockdownd_service_descriptor_t;
 


### PR DESCRIPTION
its not upstream with fixes, instead patches are used:

- patch 3: adds support for DVTSecureSocketProxy service, based on https://github.com/libimobiledevice/libimobiledevice/pull/1012 with few my fixes
- patch 4: fixes SSL read with timeout (as its broken for reads more than 1 byte in length)

Also bindings were updated for these changes

## libimobiledevice has to be compiled and pushed ! 