### PR TITLE
show `RoboVM-New` menu only in case of Android Studio

### DIFF
--- a/plugins/idea/src/main/java/org/robovm/idea/actions/ASNewGroup.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/actions/ASNewGroup.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 Justin Shapcott.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.idea.actions;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.DefaultActionGroup;
+import org.jetbrains.annotations.NotNull;
+import org.robovm.idea.RoboVmPlugin;
+
+public class ASNewGroup extends DefaultActionGroup {
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        // show new Project/Module group only in case of Android Studio
+        e.getPresentation().setVisible(RoboVmPlugin.isAndroidStudio());
+        super.update(e);
+    }
+}

--- a/plugins/idea/src/main/resources/META-INF/plugin.xml
+++ b/plugins/idea/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
-<idea-plugin version="2" url="https://github.com/robovm/robovm-idea">
+<idea-plugin url="https://github.com/robovm/robovm-idea">
     <id>com.mobidevelop.robovm.intellij</id>
     <version>${project.version}</version>
-    <vendor email="robovm@mobidevelop.com" url="http://github.com/mobidevelop/robovm">mobidevelop</vendor>
+    <vendor email="robovm@mobidevelop.com" url="https://github.com/mobidevelop/robovm">mobidevelop</vendor>
 
     <depends optional="true" config-file="">org.jetbrains.idea.maven</depends>
     <depends>org.jetbrains.plugins.gradle</depends>
@@ -79,7 +79,7 @@
                     description="Deletes as files in ~/.robovm/cache folder"/>
             <separator/>
 
-            <group id="org.robovm.idea.as-fixes-new" text="New" description="new Project/Module workaround for Android Studio" popup="true">
+            <group id="org.robovm.idea.as-fixes-new" class="org.robovm.idea.actions.ASNewGroup" text="New" description="new Project/Module workaround for Android Studio" popup="true">
                 <action id="org.robovm.idea.as-fixes-new-project" class="org.robovm.idea.actions.ASNewProjectAction" text="Project..."/>
                 <action id="org.robovm.idea.as-fixes-new-module" class="org.robovm.idea.actions.ASNewModuleAction" text="Module..."/>
             </group>


### PR DESCRIPTION
as in case of non-AS forks of Idea -- new project/new module menus are available.