### PR TITLE
fixed: ios14 device session hang

### DIFF
--- a/compiler/libimobiledevice/patches/03-fix-ios14-pr1004-fallback-secure-services.patch
+++ b/compiler/libimobiledevice/patches/03-fix-ios14-pr1004-fallback-secure-services.patch
@@ -38,7 +38,7 @@ diff --git a/src/debugserver.c b/src/debugserver.c
 index c5170171..d8ea52f7 100644
 --- a/src/debugserver.c
 +++ b/src/debugserver.c
-@@ -80,7 +80,12 @@ LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_new(idevice_t device
+@@ -79,7 +79,12 @@ LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_new(idevice_t device
  		debug_info("Creating base service client failed. Error: %i", ret);
  		return ret;
  	}
@@ -56,7 +56,7 @@ diff --git a/src/lockdown.c b/src/lockdown.c
 index 79353f23..6ec9d58b 100644
 --- a/src/lockdown.c
 +++ b/src/lockdown.c
-@@ -38,6 +38,7 @@
+@@ -47,6 +47,7 @@
  #include "property_list_service.h"
  #include "lockdown.h"
  #include "idevice.h"
@@ -64,7 +64,7 @@ index 79353f23..6ec9d58b 100644
  #include "common/debug.h"
  #include "common/userpref.h"
  #include "common/utils.h"
-@@ -1251,6 +1252,36 @@ static lockdownd_error_t lockdownd_build_start_service_request(lockdownd_client_
+@@ -1276,6 +1277,36 @@ static lockdownd_error_t lockdownd_build_start_service_request(lockdownd_client_
  	return LOCKDOWN_E_SUCCESS;
  }
  
@@ -101,7 +101,7 @@ index 79353f23..6ec9d58b 100644
  /**
   * Function used internally by lockdownd_start_service and lockdownd_start_service_with_escrow_bag.
   *
-@@ -1274,39 +1305,39 @@ static lockdownd_error_t lockdownd_do_start_service(lockdownd_client_t client, c
+@@ -1299,39 +1330,39 @@ static lockdownd_error_t lockdownd_do_start_service(lockdownd_client_t client, c
  		// reset fields if service descriptor is reused
  		(*service)->port = 0;
  		(*service)->ssl_enabled = 0;
@@ -163,7 +163,7 @@ index 79353f23..6ec9d58b 100644
  
  		/* read service port number */
  		plist_t node = plist_dict_get_item(dict, "Port");
-@@ -1511,8 +1542,12 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_data_classes_free(char **classe
+@@ -1536,8 +1567,12 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_data_classes_free(char **classe
  
  LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_service_descriptor_free(lockdownd_service_descriptor_t service)
  {

--- a/compiler/libimobiledevice/patches/04-fix-ssl_read_with_timeout.patch
+++ b/compiler/libimobiledevice/patches/04-fix-ssl_read_with_timeout.patch
@@ -2,37 +2,39 @@ diff --git a/src/idevice.c b/src/idevice.c
 index 06991c5..8b6495e 100644
 --- a/src/idevice.c
 +++ b/src/idevice.c
-@@ -28,6 +28,7 @@
+@@ -28,6 +28,9 @@
  #include <stdlib.h>
  #include <string.h>
  #include <errno.h>
-+#include <sys/time.h>
- 
++#include <time.h>
++#include <sys/types.h>
++#include <sys/timeb.h>
+
  #include <usbmuxd.h>
  #ifdef HAVE_OPENSSL
-@@ -449,6 +450,13 @@ static idevice_error_t internal_connection_receive_timeout(idevice_connection_t
+@@ -449,6 +452,13 @@ static idevice_error_t internal_connection_receive_timeout(idevice_connection_t
  	return IDEVICE_E_UNKNOWN_ERROR;
  }
- 
+
 +// TODO: temporally code, move to utils?
-+static long long microseconds() {
-+	struct timeval tm;
-+	gettimeofday(&tm,NULL);
-+	return tm.tv_usec / 1000L;
++static long long miliseconds() {
++	struct timeb rawtime;
++	ftime(&rawtime);
++	return rawtime.time * 1000 + rawtime.millitm;
 +}
 +
  LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_receive_timeout(idevice_connection_t connection, char *data, uint32_t len, uint32_t *recv_bytes, unsigned int timeout)
  {
  	if (!connection || (connection->ssl_data && !connection->ssl_data->session) || len == 0) {
-@@ -458,18 +466,22 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_receive_timeout(idevice_
+@@ -458,18 +468,22 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_receive_timeout(idevice_
  	if (connection->ssl_data) {
  		uint32_t received = 0;
  		int do_select = 1;
 -
 -		while (received < len) {
 +		int timeout_left;
-+		long long timeout_ts = microseconds() + timeout;
-+		while (received < len && (timeout_left = timeout_ts - microseconds()) > 0) {
++		long long timeout_ts = miliseconds() + timeout;
++		while (received < len && (timeout_left = timeout_ts - miliseconds()) > 0) {
  #ifdef HAVE_OPENSSL
  			do_select = (SSL_pending(connection->ssl_data->session) == 0);
  #endif
@@ -40,7 +42,7 @@ index 06991c5..8b6495e 100644
 -				int conn_error = socket_check_fd((int)(long)connection->data, FDM_READ, timeout);
 +				int conn_error = socket_check_fd((int)(long)connection->data, FDM_READ, timeout_left);
  				idevice_error_t error = socket_recv_to_idevice_error(conn_error, len, received);
- 
+
  				switch (error) {
  					case IDEVICE_E_SUCCESS:
  						break;
@@ -50,7 +52,7 @@ index 06991c5..8b6495e 100644
  					case IDEVICE_E_UNKNOWN_ERROR:
  						debug_info("ERROR: socket_check_fd returned %d (%s)", conn_error, strerror(-conn_error));
  					default:
-@@ -484,18 +496,19 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_receive_timeout(idevice_
+@@ -484,18 +498,19 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_receive_timeout(idevice_
  #endif
  			if (r > 0) {
  				received += r;


### PR DESCRIPTION
Root case: time stamp was wrongly calculated -- only usec fraction was used (without seconds) to calculate time stamp. As result at matter of chance loop was never terminated by timeout.

note: libimobiledevice has to be recompiled