### PR TITLE
* fixed bug: debugger hangs class loaded during method invocation

### DIFF
--- a/compiler/vm/core/src/hooks.c
+++ b/compiler/vm/core/src/hooks.c
@@ -1383,7 +1383,9 @@ void _rvmHookClassLoaded(Env* env, Class* clazz, void* classInfo) {
     if(javaThread) writeCallstack(env, callStackLength, callStack);
     rvmUnlockMutex(&writeMutex);
 
-    if(javaThread) {
+    // dkimitsa: do not suspend loop if class was loaded during  method invocation
+    //           e.g. already suspended
+    if(javaThread && !debugEnv->ignoreInstrumented) {
         rvmLockMutex(&debugEnv->suspendMutex);
         suspendLoop(debugEnv);
         rvmUnlockMutex(&debugEnv->suspendMutex);


### PR DESCRIPTION
## Root cause 
if class matches filter for event to be reported VM code was sending an event and suspending thread. As result method invocation was never complete and debugger terminated due operation timeout.

## Fix
 skip suspend for case if method invocation is active

## Sample code 
```kotlin
object Test {
    fun test() {
        println("Test breakpoint at this line")
    }

    override fun toString(): String = onLoad::javaClass.toString()

    class onLoad
}
```