### PR TITLE
RamDiskTools fixes

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/util/io/RamDiskTools.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/util/io/RamDiskTools.java
@@ -111,11 +111,17 @@ public class RamDiskTools {
                 return;
             }
             File newTmpDir = new File(volume, "tmp");
+            if (tmpDir.getAbsolutePath().startsWith(newTmpDir.getAbsolutePath())) {
+                // tmpDir already build on top of RamDisk, don't add it
+                // happens when building slice config from main one
+                newTmpDir = tmpDir;
+            } else {
+                newTmpDir = new File(newTmpDir, tmpDir.getAbsolutePath());
+            }
             if (!newTmpDir.exists() && !newTmpDir.mkdirs()) {
                 config.getLogger().info("Couldn't create tmp directory on RAM disk, using hard drive");
                 return;
             }
-            newTmpDir = new File(newTmpDir, tmpDir.getAbsolutePath());
             config.getLogger().info("Using RAM disk at %s for cache and tmp directory", ROBOVM_RAM_DISK_PATH);
             this.newCacheDir = newCacheDir;
             this.newTmpDir = newTmpDir;

--- a/compiler/compiler/src/main/java/org/robovm/compiler/util/io/RamDiskTools.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/util/io/RamDiskTools.java
@@ -158,7 +158,7 @@ public class RamDiskTools {
             for (Arch arch : Arch.values()) {
                 for (boolean isDebug : new boolean[] { false, true }) {
                     CacheDir cacheDir = constructCacheDir(volume, os, arch, isDebug);
-                    if (cacheDir != null && !cacheDir.directory.equals(currCacheDir.directory)) {
+                    if (cacheDir != null && (currCacheDir == null || !cacheDir.directory.equals(currCacheDir.directory))) {
                         cacheDirs.add(cacheDir);
                     }
                 }

--- a/compiler/compiler/src/test/java/org/robovm/compiler/AppCompilerTest.java
+++ b/compiler/compiler/src/test/java/org/robovm/compiler/AppCompilerTest.java
@@ -23,12 +23,8 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
+
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.robovm.compiler.clazz.Clazz;
@@ -132,7 +128,7 @@ public class AppCompilerTest {
     }
     
     private static Clazzes createClazzes(final Path... paths) throws Exception {
-        Config cfg = new Config() {
+        Config cfg = new Config(UUID.randomUUID()) {
         };
         Clazzes clazzes = new Clazzes(
                 cfg,


### PR DESCRIPTION
`First commit` fixes issue raised in [gitter](https://gitter.im/MobiVM/robovm?at=5d026f765213b626637bc705)

Reason: while constructing TMP path only `/Volumes/RoboVM RAM Disk/tmp` was created on disk. This caused tools (such as lipo) to fails as full path didn't exists. Also RamDisk prefix is not appended anymore to path if it is there already.

`Second commit` fixes issue when cleanCache failed due broken logic and RamDisk was reject to be used

`Third commit` added logic to clean up tmp/ folder. Without it RamDisk got exhausted and stop working. 