### PR TITLE
Support for entitlements for simulator run (fix #529)

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -31,7 +31,6 @@ import org.apache.commons.io.filefilter.AndFileFilter;
 import org.apache.commons.io.filefilter.PrefixFileFilter;
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.apache.commons.io.filefilter.SuffixFileFilter;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.robovm.compiler.CompilerException;
 import org.robovm.compiler.config.AppExtension;
@@ -46,6 +45,7 @@ import org.robovm.compiler.target.LaunchParameters;
 import org.robovm.compiler.target.Launcher;
 import org.robovm.compiler.target.ios.ProvisioningProfile.Type;
 import org.robovm.compiler.util.Executor;
+import org.robovm.compiler.util.PList;
 import org.robovm.compiler.util.ToolchainUtil;
 import org.robovm.compiler.util.io.OpenOnWriteFileOutputStream;
 import org.robovm.libimobiledevice.AfcClient.UploadProgressCallback;
@@ -61,19 +61,13 @@ import java.io.FileFilter;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
+import java.util.*;
 
 /**
  * @author niklas
@@ -100,8 +94,6 @@ public class IOSTarget extends AbstractTarget {
     );
 
     public static final String TYPE = "ios";
-
-    private static File iosSimPath;
 
     private Arch arch;
     private SDK sdk;
@@ -675,7 +667,7 @@ public class IOSTarget extends AbstractTarget {
     }
 
     /**
-     * creates simple entitlement plist from scratch that only containts get-task-allow
+     * creates simple entitlement plist from scratch that only contains get-task-allow
      * used to sign binary for simulator
      */
     private File createEntitlementsPList(boolean getTaskAllow) throws IOException {
@@ -698,12 +690,27 @@ public class IOSTarget extends AbstractTarget {
      */
     private File createSimulatedEntitlementsPList(String bundleId) throws IOException {
         try {
-            // generate random group id as there is no one real available when compiling for simulator
-            String groupId = RandomStringUtils.randomAlphanumeric(10).toUpperCase();
+            // there is no provisioning profile in simulator to pick teamId. check if user have provided in properties
+            String teamID = config.getProperties().getProperty("teamID");
+            if (teamID == null) {
+                // generate team ID from bundle id. use MD5 hash from bundle, then convert it to base-36
+                teamID = new BigInteger(MessageDigest.getInstance("MD5").digest(bundleId.getBytes())).toString(36).toUpperCase();
+                if (teamID.length() > 10)
+                    teamID = teamID.substring(0, 10);
+            }
+
             File destFile = new File(config.getTmpDir(), "Entitlements-Simulated.plist");
-            NSDictionary dict = new NSDictionary();
-            dict.put("application-identifier", groupId + "." + bundleId);
-            dict.put("keychain-access-groups", new NSArray(new NSString(groupId + "." + bundleId)));
+            NSDictionary dict;
+            if (entitlementsPList != null) {
+                // use properties. this allows teamID (and other placeholders) to be used in entitlements
+                Properties properties = new Properties(config.getProperties());
+                properties.setProperty("teamID", teamID);
+                dict = new PList(entitlementsPList).parse(properties).getDictionary();
+            } else {
+                dict = new NSDictionary();
+            }
+
+            dict.put("application-identifier", teamID + "." + bundleId);
             PropertyListParser.saveAsXML(dict, destFile);
             return destFile;
         } catch (IOException e) {
@@ -717,20 +724,24 @@ public class IOSTarget extends AbstractTarget {
         try {
             File destFile = new File(config.getTmpDir(), "Entitlements.plist");
             NSDictionary dict = null;
-            if (entitlementsPList != null) {
-                dict = (NSDictionary) PropertyListParser.parse(entitlementsPList);
-            } else {
-                dict = (NSDictionary) PropertyListParser.parse(IOUtils.toByteArray(getClass().getResourceAsStream(
-                        "/Entitlements.plist")));
-            }
-            if (provisioningProfile != null) {
+            if (entitlementsPList == null) {
+                dict = new NSDictionary();
+            } else if (provisioningProfile != null) {
+                String teamID = provisioningProfile.getAppIdPrefix();
+                // use properties. this allows teamID (and other placeholders) to be used in entitlements
+                Properties properties = new Properties(config.getProperties());
+                properties.setProperty("teamID", teamID);
+                dict = new PList(entitlementsPList).parse(properties).getDictionary();
+
                 NSDictionary profileEntitlements = provisioningProfile.getEntitlements();
                 for (String key : profileEntitlements.allKeys()) {
                     if (dict.objectForKey(key) == null && !excludedKeys.contains(key)) {
                         dict.put(key, profileEntitlements.objectForKey(key));
                     }
                 }
-                dict.put("application-identifier", provisioningProfile.getAppIdPrefix() + "." + bundleId);
+                dict.put("application-identifier", teamID + "." + bundleId);
+            } else {
+                dict = (NSDictionary) PropertyListParser.parse(entitlementsPList);
             }
             dict.put("get-task-allow", getTaskAllow);
             PropertyListParser.saveAsXML(dict, destFile);
@@ -909,41 +920,41 @@ public class IOSTarget extends AbstractTarget {
 
     @Override
     protected boolean processDir(Resource resource, File dir, File destDir) throws IOException {
-        if (dir.getName().endsWith(".atlas")) {
-            destDir.mkdirs();
+                if (dir.getName().endsWith(".atlas")) {
+                    destDir.mkdirs();
 
-            ToolchainUtil.textureatlas(config, dir, destDir);
-            return false;
-        } else if (dir.getName().endsWith(".xcassets")) {
+                    ToolchainUtil.textureatlas(config, dir, destDir);
+                    return false;
+                } else if (dir.getName().endsWith(".xcassets")) {
             ToolchainUtil.actool(config, createPartialInfoPlistFile(dir), dir, getAppDir());
-            return false;
-        }
+                    return false;
+                }
         return super.processDir(resource, dir, destDir);
-    }
+            }
 
-    @Override
+            @Override
     protected void copyFile(Resource resource, File file, File destDir)
             throws IOException {
 
-        if (isDeviceArch(arch) && !resource.isSkipPngCrush()
-                && file.getName().toLowerCase().endsWith(".png")) {
-            destDir.mkdirs();
-            File outFile = new File(destDir, file.getName());
-            ToolchainUtil.pngcrush(config, file, outFile);
-        } else if (file.getName().toLowerCase().endsWith(".strings")) {
-            destDir.mkdirs();
-            File outFile = new File(destDir, file.getName());
-            ToolchainUtil.compileStrings(config, file, outFile);
-        } else if (file.getName().toLowerCase().endsWith(".storyboard")) {
-            destDir.mkdirs();
-            ToolchainUtil.ibtool(config, createPartialInfoPlistFile(file), file, destDir);
-        } else if (file.getName().toLowerCase().endsWith(".xib")) {
-            destDir.mkdirs();
-            String fileName = file.getName();
-            fileName = fileName.substring(0, fileName.lastIndexOf('.')) + ".nib";
-            File outFile = new File(destDir, fileName);
-            ToolchainUtil.ibtool(config, createPartialInfoPlistFile(file), file, outFile);
-        } else {
+                if (isDeviceArch(arch) && !resource.isSkipPngCrush()
+                        && file.getName().toLowerCase().endsWith(".png")) {
+                    destDir.mkdirs();
+                    File outFile = new File(destDir, file.getName());
+                    ToolchainUtil.pngcrush(config, file, outFile);
+                } else if (file.getName().toLowerCase().endsWith(".strings")) {
+                    destDir.mkdirs();
+                    File outFile = new File(destDir, file.getName());
+                    ToolchainUtil.compileStrings(config, file, outFile);
+                } else if (file.getName().toLowerCase().endsWith(".storyboard")) {
+                    destDir.mkdirs();
+                    ToolchainUtil.ibtool(config, createPartialInfoPlistFile(file), file, destDir);
+                } else if (file.getName().toLowerCase().endsWith(".xib")) {
+                    destDir.mkdirs();
+                    String fileName = file.getName();
+                    fileName = fileName.substring(0, fileName.lastIndexOf('.')) + ".nib";
+                    File outFile = new File(destDir, fileName);
+                    ToolchainUtil.ibtool(config, createPartialInfoPlistFile(file), file, outFile);
+                } else {
             super.copyFile(resource, file, destDir);
         }
     }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -920,41 +920,41 @@ public class IOSTarget extends AbstractTarget {
 
     @Override
     protected boolean processDir(Resource resource, File dir, File destDir) throws IOException {
-                if (dir.getName().endsWith(".atlas")) {
-                    destDir.mkdirs();
+        if (dir.getName().endsWith(".atlas")) {
+            destDir.mkdirs();
 
-                    ToolchainUtil.textureatlas(config, dir, destDir);
-                    return false;
-                } else if (dir.getName().endsWith(".xcassets")) {
+            ToolchainUtil.textureatlas(config, dir, destDir);
+            return false;
+        } else if (dir.getName().endsWith(".xcassets")) {
             ToolchainUtil.actool(config, createPartialInfoPlistFile(dir), dir, getAppDir());
-                    return false;
-                }
+            return false;
+        }
         return super.processDir(resource, dir, destDir);
-            }
+    }
 
-            @Override
+    @Override
     protected void copyFile(Resource resource, File file, File destDir)
             throws IOException {
 
-                if (isDeviceArch(arch) && !resource.isSkipPngCrush()
-                        && file.getName().toLowerCase().endsWith(".png")) {
-                    destDir.mkdirs();
-                    File outFile = new File(destDir, file.getName());
-                    ToolchainUtil.pngcrush(config, file, outFile);
-                } else if (file.getName().toLowerCase().endsWith(".strings")) {
-                    destDir.mkdirs();
-                    File outFile = new File(destDir, file.getName());
-                    ToolchainUtil.compileStrings(config, file, outFile);
-                } else if (file.getName().toLowerCase().endsWith(".storyboard")) {
-                    destDir.mkdirs();
-                    ToolchainUtil.ibtool(config, createPartialInfoPlistFile(file), file, destDir);
-                } else if (file.getName().toLowerCase().endsWith(".xib")) {
-                    destDir.mkdirs();
-                    String fileName = file.getName();
-                    fileName = fileName.substring(0, fileName.lastIndexOf('.')) + ".nib";
-                    File outFile = new File(destDir, fileName);
-                    ToolchainUtil.ibtool(config, createPartialInfoPlistFile(file), file, outFile);
-                } else {
+        if (isDeviceArch(arch) && !resource.isSkipPngCrush()
+                && file.getName().toLowerCase().endsWith(".png")) {
+            destDir.mkdirs();
+            File outFile = new File(destDir, file.getName());
+            ToolchainUtil.pngcrush(config, file, outFile);
+        } else if (file.getName().toLowerCase().endsWith(".strings")) {
+            destDir.mkdirs();
+            File outFile = new File(destDir, file.getName());
+            ToolchainUtil.compileStrings(config, file, outFile);
+        } else if (file.getName().toLowerCase().endsWith(".storyboard")) {
+            destDir.mkdirs();
+            ToolchainUtil.ibtool(config, createPartialInfoPlistFile(file), file, destDir);
+        } else if (file.getName().toLowerCase().endsWith(".xib")) {
+            destDir.mkdirs();
+            String fileName = file.getName();
+            fileName = fileName.substring(0, fileName.lastIndexOf('.')) + ".nib";
+            File outFile = new File(destDir, fileName);
+            ToolchainUtil.ibtool(config, createPartialInfoPlistFile(file), file, outFile);
+        } else {
             super.copyFile(resource, file, destDir);
         }
     }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/util/PList.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/util/PList.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.compiler.util;
+
+import java.io.File;
+import java.util.Properties;
+import java.util.function.BiFunction;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.xml.parsers.DocumentBuilder;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.Text;
+
+import com.dd.plist.NSDictionary;
+import com.dd.plist.NSObject;
+import com.dd.plist.XMLPropertyListParser;
+
+public class PList {
+    private final File file;
+    protected NSDictionary dictionary;
+
+    public PList(File file) {
+        this.file = file;
+    }
+
+    public PList parse(Properties props) {
+        return parse(props, true);
+    }
+
+    public PList parse(Properties props, boolean includeSystemProperties) {
+        try {
+            this.dictionary = (NSDictionary) parsePropertyList(file, props, includeSystemProperties);
+        } catch (Throwable t) {
+            throw new IllegalArgumentException("Failed to parse Info.plist XML file: " + file, t);
+        }
+
+        return this;
+    }
+
+    public File getFile() {
+        return file;
+    }
+
+    public NSDictionary getDictionary() {
+        return dictionary;
+    }
+
+    private final static Pattern VARIABLE_PATTERN = Pattern.compile("\\$\\{([^}]+)\\}");
+
+    static void replacePropertyRefs(Node node, BiFunction<String, String, String> props) {
+        if (node instanceof Text) {
+            Text el = (Text) node;
+            String value = el.getNodeValue();
+            if (value != null && value.trim().length() > 0) {
+                Matcher matcher = VARIABLE_PATTERN.matcher(value);
+                StringBuilder sb = new StringBuilder();
+                int pos = 0;
+                while (matcher.find()) {
+                    if (pos < matcher.start()) {
+                        sb.append(value, pos, matcher.start());
+                    }
+                    String key = matcher.group(1);
+                    sb.append(props.apply(key, matcher.group()));
+                    pos = matcher.end();
+                }
+                if (pos < value.length()) {
+                    sb.append(value.substring(pos));
+                }
+                el.setNodeValue(sb.toString());
+            }
+        }
+        NodeList children = node.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            replacePropertyRefs(children.item(i), props);
+        }
+    }
+
+    static NSObject parsePropertyList(File file, Properties props, boolean includeSystemProperties) throws Exception {
+        // can't just merge properties with system ones together.
+        // as properties and system one have parent (default) properties, calling allProps.putAll(props)
+        // will not add parent ones. using supplier
+        Properties sysProps = System.getProperties();
+        BiFunction<String, String, String> propSupplier;
+        propSupplier = (!includeSystemProperties) ? props::getProperty : (key, defValue) -> {
+            String v = props.getProperty(key);
+            if (v == null)
+                v = sysProps.getProperty(key, defValue);
+            return v;
+        };
+
+        DocumentBuilder docBuilder = XMLPropertyListParser.getDocBuilder();
+        Document doc = docBuilder.parse(file);
+        replacePropertyRefs(doc, propSupplier);
+        return XMLPropertyListParser.parse(doc);
+    }
+}

--- a/compiler/compiler/src/main/resources/Entitlements.plist
+++ b/compiler/compiler/src/main/resources/Entitlements.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>get-task-allow</key>
-    <true/>
-</dict>
-</plist>


### PR DESCRIPTION
- base Plist was extracted from InfoPlist class for generic Plist parsing and value placeholder substitution(with values from property file);
- Simulator launch will use entitlements if provided in robovm.xml
- changed way how team ID is generated for simulator launch. Instead of random string for each launch it will now: checks for `teamID` key in properties. If not -- will generate MD5 from bundle id -- to keep it same each launch.
- removed hardcoded sim entitlement `keychain-access-groups` as entitlements can now be specified by user
- for entitlements for device target properties are used as well. this will allow to use placeholders if required
- removed bundled Entitlement.plist as it useless (empty)