### PR TITLE
* fixed #542: Dagger with Kotlin, IDE IPA Creation Problem

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/SimLauncherProcess.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/SimLauncherProcess.java
@@ -157,7 +157,7 @@ public class SimLauncherProcess extends Process implements Launcher {
                     exitCode = 0;
                 } catch (ExecuteException e) {
                     exitCode = e.getExitValue();
-                    // if process is interrupted Apache Excutor will use this constant, replace with 0 otherwise
+                    // if process is interrupted Apache Executor will use this constant, replace with 0 otherwise
                     // -559038737 looks odd in console output
                     if (exitCode == INVALID_EXITVALUE)
                         exitCode = 0;

--- a/compiler/compiler/src/main/java/org/robovm/compiler/util/ToolchainUtil.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/util/ToolchainUtil.java
@@ -34,8 +34,6 @@ import org.robovm.compiler.log.ConsoleLogger;
 import org.robovm.compiler.log.Logger;
 import org.robovm.compiler.target.ios.IOSTarget;
 
-import static org.apache.commons.exec.Executor.INVALID_EXITVALUE;
-
 /**
  * @author niklas
  *
@@ -156,11 +154,6 @@ public class ToolchainUtil {
             throw new IllegalArgumentException("You must agree to the Xcode/iOS license. "
                     + "Please open Xcode once or run 'sudo xcrun clang' from a Terminal to agree to the terms.");
         }
-        // if process is interrupted Apache Executor will use this -559038737 constant
-        // throw with InterruptedException cause to allow compiler task to properly intercept
-        if (e.getExitValue() == INVALID_EXITVALUE)
-            throw new IllegalArgumentException(e.getMessage(), new InterruptedException());
-
         throw new IllegalArgumentException(e.getMessage());
     }
 

--- a/compiler/compiler/src/main/java/org/robovm/compiler/util/ToolchainUtil.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/util/ToolchainUtil.java
@@ -34,6 +34,8 @@ import org.robovm.compiler.log.ConsoleLogger;
 import org.robovm.compiler.log.Logger;
 import org.robovm.compiler.target.ios.IOSTarget;
 
+import static org.apache.commons.exec.Executor.INVALID_EXITVALUE;
+
 /**
  * @author niklas
  *
@@ -154,6 +156,11 @@ public class ToolchainUtil {
             throw new IllegalArgumentException("You must agree to the Xcode/iOS license. "
                     + "Please open Xcode once or run 'sudo xcrun clang' from a Terminal to agree to the terms.");
         }
+        // if process is interrupted Apache Executor will use this -559038737 constant
+        // throw with InterruptedException cause to allow compiler task to properly intercept
+        if (e.getExitValue() == INVALID_EXITVALUE)
+            throw new IllegalArgumentException(e.getMessage(), new InterruptedException());
+
         throw new IllegalArgumentException(e.getMessage());
     }
 

--- a/plugins/idea/src/main/java/org/robovm/idea/actions/CreateIpaAction.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/actions/CreateIpaAction.java
@@ -18,15 +18,19 @@ package org.robovm.idea.actions;
 
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.compiler.CompileScope;
-import com.intellij.openapi.compiler.CompilerManager;
 import com.intellij.openapi.module.Module;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.ui.MessageType;
 import com.intellij.openapi.util.Key;
+import com.intellij.task.ProjectTaskManager;
+import org.jetbrains.annotations.NotNull;
 import org.robovm.compiler.config.Arch;
 import org.robovm.idea.RoboVmPlugin;
+import org.robovm.idea.compilation.RoboVmCompileTask;
 
 import java.io.File;
 import java.util.List;
@@ -46,11 +50,25 @@ public class CreateIpaAction extends AnAction {
         if (dialog.getExitCode() == DialogWrapper.OK_EXIT_CODE) {
             // create IPA
             IpaConfig ipaConfig = dialog.getIpaConfig();
-            CompileScope scope = CompilerManager.getInstance(project).createModuleCompileScope(ipaConfig.module, true);
-            scope.putUserData(IPA_CONFIG_KEY, ipaConfig);
-            CompilerManager.getInstance(project).compile(scope, (aborted, errors, warnings, compileContext) ->
-                    RoboVmPlugin.logInfo(project, "IPA creation complete, %d errors, %d warnings", errors, warnings)
-            );
+            ProjectTaskManager.getInstance(project)
+                    .build(ipaConfig.module)
+                    .onSuccess(r -> {
+                        if (r.hasErrors()) {
+                            RoboVmPlugin.logInfo(project, "IPA creation failed due errors");
+                        } else if (r.isAborted()) {
+                            RoboVmPlugin.logInfo(project, "IPA creation aborted");
+                        } else
+                            ProgressManager.getInstance().run(new Task.Backgroundable(project, "Building IPA ", true) {
+                                @Override
+                                public void run(@NotNull ProgressIndicator progressIndicator) {
+                                    try {
+                                        RoboVmCompileTask.compileForIpa(project, progressIndicator, ipaConfig);
+                                    } catch (Exception e) {
+                                        RoboVmPlugin.logErrorThrowable(project, "Couldn't create IPA", e, false);
+                                    }
+                                }
+                            });
+                    });
         }
     }
 

--- a/plugins/idea/src/main/java/org/robovm/idea/compilation/RoboVmCompileTask.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/compilation/RoboVmCompileTask.java
@@ -66,43 +66,18 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Registered by {@link org.robovm.idea.RoboVmPlugin} on startup. Responsible
- * for compiling an app in case there's a run configuration in the {@link com.intellij.openapi.compiler.CompileContext}
- * or if we perform an ad-hoc/IPA build from the RoboVM menu.
+ * Initially was a CompileTask that was attached as last chain in compilation
+ * But it doesn't work correctly with Run configuration in Android Studio/Gradle
+ * based projects. .class to native compilation is performed either as BeforeRun task
+ * or by invoking build directly before creating ipa/framework
  */
-public class RoboVmCompileTask implements CompileTask {
+public class RoboVmCompileTask {
     // A list of languages (other than java) for which we might expect to find .class files. Idea compiles these into separate directories,
     // but only provides the /classes/java/main in the list of classpaths.
     private static final String[] jvmLangs = {"groovy", "scala", "kotlin"};
 
-    @Override
-    public boolean execute(CompileContext context) {
-        if (context.getMessageCount(CompilerMessageCategory.ERROR) > 0) {
-            RoboVmPlugin.logError(context.getProject(), "Can't compile application due to previous compilation errors");
-            return false;
-        }
 
-        RunConfiguration c = context.getCompileScope().getUserData(CompilerManager.RUN_CONFIGURATION_KEY);
-        if (!(c instanceof RoboVmRunConfiguration)) {
-            CreateIpaAction.IpaConfig ipaConfig = context.getCompileScope().getUserData(CreateIpaAction.IPA_CONFIG_KEY);
-            if (ipaConfig != null) {
-                return compileForIpa(context, ipaConfig);
-            }
-
-            CreateFrameworkAction.FrameworkConfig frameworkConfig = context.getCompileScope().getUserData(CreateFrameworkAction.FRAMEWORK_CONFIG_KEY);
-            if (frameworkConfig != null) {
-                return compileForFramework(context, frameworkConfig);
-            }
-
-            return true;
-        } else {
-            return compileForRunConfiguration(context, (RoboVmRunConfiguration) c);
-        }
-    }
-
-    private boolean compileForIpa(CompileContext context, final CreateIpaAction.IpaConfig ipaConfig) {
-        ProgressIndicator progress = context.getProgressIndicator();
-        Project project = context.getProject();
+    public static boolean compileForIpa(Project project, ProgressIndicator progress, final CreateIpaAction.IpaConfig ipaConfig) {
         try {
             progress.pushState();
             RoboVmPlugin.focusToolWindow(project);
@@ -124,7 +99,7 @@ public class RoboVmCompileTask implements CompileTask {
             if (ipaConfig.getProvisioningProfile() != null) {
                 builder.iosProvisioningProfile(ProvisioningProfile.find(ProvisioningProfile.list(), ipaConfig.getProvisioningProfile()));
             }
-            configureClassAndSourcepaths(project, context, builder, ipaConfig.getModule());
+            configureClassAndSourcepaths(project, ipaConfig.getModule(), builder);
             builder.home(RoboVmPlugin.getRoboVmHome());
             Config config = builder.build();
 
@@ -134,12 +109,13 @@ public class RoboVmCompileTask implements CompileTask {
             RoboVmCompilerThread thread = new RoboVmCompilerThread(compiler, progress) {
                 protected void doCompile() throws Exception {
                     compiler.build();
-                    compiler.archive();
+                    if (!progress.isCanceled())
+                        compiler.archive();
                 }
             };
             thread.compile();
 
-            if (progress.isCanceled()) {
+            if (progress.isCanceled() || Thread.currentThread().isInterrupted()) {
                 RoboVmPlugin.logInfo(project, "Build canceled");
                 return false;
             }
@@ -155,9 +131,7 @@ public class RoboVmCompileTask implements CompileTask {
         return true;
     }
 
-    private boolean compileForFramework(CompileContext context, final CreateFrameworkAction.FrameworkConfig frameworkConfig) {
-        ProgressIndicator progress = context.getProgressIndicator();
-        Project project = context.getProject();
+    public static boolean compileForFramework(Project project, ProgressIndicator progress, final CreateFrameworkAction.FrameworkConfig frameworkConfig) {
         try {
             progress.pushState();
             RoboVmPlugin.focusToolWindow(project);
@@ -173,7 +147,7 @@ public class RoboVmCompileTask implements CompileTask {
             loadConfig(project, builder, moduleBaseDir, false);
             builder.os(OS.ios);
             builder.installDir(frameworkConfig.getDestinationDir());
-            configureClassAndSourcepaths(project, context, builder, frameworkConfig.getModule());
+            configureClassAndSourcepaths(project, frameworkConfig.getModule(), builder);
 
             // Set the Home to be used, create the Config and AppCompiler
             Config.Home home = RoboVmPlugin.getRoboVmHome();
@@ -192,12 +166,13 @@ public class RoboVmCompileTask implements CompileTask {
             RoboVmCompilerThread thread = new RoboVmCompilerThread(compiler, progress) {
                 protected void doCompile() throws Exception {
                     compiler.build();
-                    compiler.install();
+                    if (!progress.isCanceled())
+                        compiler.install();
                 }
             };
             thread.compile();
 
-            if (progress.isCanceled()) {
+            if (progress.isCanceled() || Thread.currentThread().isInterrupted()) {
                 RoboVmPlugin.logInfo(project, "Build canceled");
                 return false;
             }
@@ -213,11 +188,7 @@ public class RoboVmCompileTask implements CompileTask {
         return true;
     }
 
-    private boolean compileForRunConfiguration(CompileContext context, final RoboVmRunConfiguration runConfig) {
-        return compileForRunConfiguration(context.getProject(), context, context.getProgressIndicator(), runConfig);
-    }
-
-    public static boolean compileForRunConfiguration(Project project, CompileContext context, ProgressIndicator progress, final RoboVmRunConfiguration runConfig) {
+    public static boolean compileForRunConfiguration(Project project, ProgressIndicator progress, final RoboVmRunConfiguration runConfig) {
         try {
             progress.pushState();
             RoboVmPlugin.focusToolWindow(project);
@@ -269,7 +240,7 @@ public class RoboVmCompileTask implements CompileTask {
 
             // setup classpath entries, debug build parameters and target
             // parameters, e.g. signing identity etc.
-            configureClassAndSourcepaths(project, context, runConfig, builder, module);
+            configureClassAndSourcepaths(project, module, builder);
             configureDebugging(builder, runConfig, module);
             configureTarget(builder, runConfig);
 
@@ -355,11 +326,7 @@ public class RoboVmCompileTask implements CompileTask {
         }
     }
 
-    private static void configureClassAndSourcepaths(Project project, CompileContext context, Config.Builder builder, Module module) {
-        configureClassAndSourcepaths(project, context, null, builder, module);
-    }
-
-    private static void configureClassAndSourcepaths(Project project, CompileContext context, RoboVmRunConfiguration runConfig, Config.Builder builder, Module module) {
+    private static void configureClassAndSourcepaths(Project project, Module module, Config.Builder builder) {
         // gather the boot and user classpaths. RoboVM RT libs may be
         // specified in a Maven/Gradle build file, in which case they'll
         // turn up as order entries. We filter them out here.
@@ -373,30 +340,21 @@ public class RoboVmCompileTask implements CompileTask {
         }
 
         // if there is no compile context, build it from run configuration
-        Module[] affectedModules = null;
-        if (context != null) {
-            affectedModules = context.getCompileScope().getAffectedModules();
-        } else if (runConfig != null) {
-            // create scope to get affected modules
-            affectedModules = ((ModuleRunProfile) runConfig).getModules();
-            CompilerManager compilerManager = CompilerManager.getInstance(project);
-            CompileScope scope = compilerManager.createModulesCompileScope(affectedModules, true, true);
-            affectedModules = scope.getAffectedModules();
-        }
+        CompilerManager compilerManager = CompilerManager.getInstance(project);
+        CompileScope scope = compilerManager.createModuleCompileScope(module, true);
+        Module[] affectedModules = scope.getAffectedModules();
 
         // add the output dirs of all affected modules to the
         // classpath. IDEA will make the output directory
         // of a module an order entry after the first compile
         // so we add the path twice. Fixed by using a set.
         // FIXME junit needs to include test output directories
-        if (affectedModules != null) {
-            for (Module mod : affectedModules) {
-                String path = CompilerPaths.getModuleOutputPath(mod, false);
-                if (path != null && !path.isEmpty()) {
-                    addClassPath(path, classPaths);
-                } else {
-                    RoboVmPlugin.logWarn(project, "Output path of module %s not defined", mod.getName());
-                }
+        for (Module mod : affectedModules) {
+            String path = CompilerPaths.getModuleOutputPath(mod, false);
+            if (path != null && !path.isEmpty()) {
+                addClassPath(path, classPaths);
+            } else {
+                RoboVmPlugin.logWarn(project, "Output path of module %s not defined", mod.getName());
             }
         }
 

--- a/plugins/idea/src/main/java/org/robovm/idea/compilation/RoboVmCompilerThread.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/compilation/RoboVmCompilerThread.java
@@ -19,7 +19,10 @@ package org.robovm.idea.compilation;
 import java.io.IOException;
 
 import com.intellij.openapi.progress.ProgressIndicator;
+import org.apache.commons.exec.ExecuteException;
 import org.robovm.compiler.AppCompiler;
+
+import static org.apache.commons.exec.Executor.INVALID_EXITVALUE;
 
 /**
  * {@link Thread} which calls AppCompiler#compile() and waits for it
@@ -65,6 +68,11 @@ public class RoboVmCompilerThread extends Thread {
         try {
             doCompile();
         } catch (Throwable t) {
+            if (t instanceof ExecuteException && ((ExecuteException)t).getExitValue() == INVALID_EXITVALUE) {
+                // if process is interrupted Apache Executor will use this constant as exit code
+                // Ignore as interrupted will be recognized by Thread or Progress
+                return;
+            }
             if (t.getCause() instanceof InterruptedException) {
                 // Ignore
                 return;

--- a/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmBeforeRunTaskProvider.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmBeforeRunTaskProvider.java
@@ -79,12 +79,6 @@ public class RoboVmBeforeRunTaskProvider extends BeforeRunTaskProvider<RoboVmBef
     @Override
     public boolean executeTask(@NotNull DataContext context, @NotNull final RunConfiguration configuration, @NotNull final ExecutionEnvironment env, @NotNull Task task) {
         final RoboVmRunConfiguration runConfig = (RoboVmRunConfiguration) configuration;
-        if (runConfig.getConfig() != null) {
-            // configuration is set when RoboVmCompilerTask is executed.
-            // in this case there is no need to run this workaround
-            return true;
-        }
-
         final Ref<Boolean> result = new Ref<>(Boolean.FALSE);
         final Exception[] exception = {null};
         final Semaphore done = new Semaphore();
@@ -94,7 +88,7 @@ public class RoboVmBeforeRunTaskProvider extends BeforeRunTaskProvider<RoboVmBef
             @Override
             public void run(@NotNull ProgressIndicator progressIndicator) {
                 try {
-                    result.set(RoboVmCompileTask.compileForRunConfiguration(env.getProject(), null, progressIndicator, runConfig));
+                    result.set(RoboVmCompileTask.compileForRunConfiguration(env.getProject(), progressIndicator, runConfig));
                 } catch (Exception e) {
                     exception[0] = e;
                 } finally {

--- a/plugins/idea/src/main/java/org/robovm/idea/sdk/RoboVmSdkType.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/sdk/RoboVmSdkType.java
@@ -21,6 +21,7 @@ import java.io.File;
 import javax.swing.*;
 
 import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.vfs.LocalFileSystem;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -114,7 +115,7 @@ public class RoboVmSdkType extends SdkType implements JavaSdkType {
 
         // add all class and source jars from the SDK lib/ folder
         for(File file: RoboVmPlugin.getSdkLibraries()) {
-            VirtualFile virtualFile = JarFileSystem.getInstance().findLocalVirtualFileByPath(file.getAbsolutePath());
+            VirtualFile virtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file);
             assert virtualFile != null;
             sdkModificator.addRoot(virtualFile, file.getName().endsWith("-sources.jar")?  OrderRootType.SOURCES: OrderRootType.CLASSES);
         }

--- a/plugins/idea/src/main/resources/META-INF/plugin.xml
+++ b/plugins/idea/src/main/resources/META-INF/plugin.xml
@@ -35,7 +35,6 @@
         <projectTemplatesFactory implementation="org.robovm.idea.builder.RoboVmTemplatesFactory"/>
         <sdkType implementation="org.robovm.idea.sdk.RoboVmSdkType"/>
         <buildProcess.parametersProvider implementation="org.robovm.idea.components.RoboVmBuildProcessParametersProvider"/>
-        <compiler.task execute="AFTER" implementation="org.robovm.idea.compilation.RoboVmCompileTask"/>
         <stepsBeforeRunProvider implementation="org.robovm.idea.running.RoboVmBeforeRunTaskProvider"/>
         <!-- dkimitsa: removed as it is not required for open source xcode integration -->
         <!--<applicationConfigurable implementation="org.robovm.idea.config.RoboVmGlobalConfig"></applicationConfigurable>-->


### PR DESCRIPTION
This PR fixed #542 and also changes the way project compilation is triggered (for IPA/Framework creation)

# Root case:
`CompilerManager` is not invoking build plugins such as Dagger. As result intermediate classes are not being generated and RoboVM compilation fails.

# As a fix:
`ProjectTaskManager.build(module)` is now used with is equal to menu `Build/build module`. Once build is success -- RoboVM compiles IPA/Framework binaries.

# other moments
`RoboVmCompileTask` was removed from compilation chain. This means that it will not be triggered automatically. However IPA/Framework was reworked in this fix to call it manually. Also run configuration already has manual RoboVM compilation invocation as pre-launch task

# other fixes
- better cancellation processing during IPA/Framework compilation
- fixed issue during SDK files installation during first launch