### PR TITLE
* fixed: @ByVal is not working for GlobalValues/Struct getters

### DIFF
--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coregraphics/CGRect.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coregraphics/CGRect.java
@@ -52,8 +52,7 @@ import org.robovm.apple.uikit.*;
     /*</constructors>*/
     
     public CGRect(double x, double y, double width, double height) {
-        getOrigin().setX(x).setY(y);
-        getSize().setWidth(width).setHeight(height);
+        this(new CGPoint(x, y), new CGSize(width, height));
     }
     
     /*<properties>*//*</properties>*/
@@ -78,11 +77,13 @@ import org.robovm.apple.uikit.*;
 
     @WeaklyLinked
     public CGRect inset(UIEdgeInsets insets) {
-        getOrigin().setX(getOrigin().getX() + insets.getLeft());
-        getOrigin().setY(getOrigin().getY() + insets.getTop());
-        getSize().setWidth(getSize().getWidth() - (insets.getLeft() + insets.getRight()));
-        getSize().setHeight(getSize().getHeight() - (insets.getTop() + insets.getBottom()));
-        return this;
+        CGPoint newOrigin = getOrigin()
+                .setX(getOrigin().getX() + insets.getLeft())
+                .setY(getOrigin().getY() + insets.getTop());
+        CGSize newSize = getSize()
+                .setWidth(getSize().getWidth() - (insets.getLeft() + insets.getRight()))
+                .setHeight(getSize().getHeight() - (insets.getTop() + insets.getBottom()));
+        return this.setOrigin(newOrigin).setSize(newSize);
     }
     
     @Override
@@ -187,22 +188,22 @@ import org.robovm.apple.uikit.*;
     }
 
     public CGRect setX(double x) {
-         this.getOrigin().setX(x);
+         this.setOrigin(this.getOrigin().setX(x));
          return this;
     }
 
     public CGRect setY(double y) {
-        this.getOrigin().setY(y);
+        this.setOrigin(this.getOrigin().setY(y));
         return this;
     }
 
     public CGRect setWidth(double w) {
-        this.getSize().setWidth(w);
+        this.setSize(this.getSize().setWidth(w));
         return this;
     }
 
     public CGRect setHeight(double h) {
-        this.getSize().setHeight(h);
+        this.setSize(this.getSize().setHeight(h));
         return this;
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/BroMethodCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/BroMethodCompiler.java
@@ -1028,8 +1028,13 @@ public abstract class BroMethodCompiler extends AbstractMethodCompiler {
         
         Value result = null;
         if (memberType instanceof StructureType) {
-            // The member is a child struct contained in the current struct
-            result = memberPtr;
+            // memberType is StructureType only in the case of @ByVal annotation
+            // copy value into heap before marshaling otherwise it gets @ByRef behaviour
+            DataLayout dataLayout = config.getDataLayout();
+            Variable structResult = fn.newVariable(I8_PTR);
+            fn.add(new Bitcast(structResult, memberPtr, I8_PTR));
+            result = call(fn, BC_COPY_STRUCT, env, structResult.ref(),
+                    new IntegerConstant(dataLayout.getAllocSize(memberType)));
         } else if (memberType instanceof ArrayType) {
             // The member is an array contained in the current struct
             result = memberPtr;


### PR DESCRIPTION
## Bug 
structures are not being copied and only their pointer being marshalled (same as in case of @ByRef). This causes number of bugs:
- expected the copy but struct points to source struct/value. as result changes of "copy" causes changes in the source
- struct might be located in R/O segment and any try to modify it cause GPF [gitter](https://gitter.im/MobiVM/robovm?at=5ff3acf74eba353cdf1aabff).

## The fix
make a copy of structure on heap as its required by @ByVal

## Side effect of the fix
The fix breaks existing code that is built around this bug. An example is `CGRect` constructor that stops working:  
```java
public CGRect(double x, double y, double width, double height) {
    getOrigin().setX(x).setY(y);
    getSize().setWidth(width).setHeight(height);
}
```

After the fix `getOrigin()`/`getSize()` return a copy (byValue) structures. And changes to them doesn't affect `CGRect` struct itself anymore.
