### PR TITLE
* reworked way swift dependencies are picked up

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -155,8 +155,8 @@ public class Config {
     private ArrayList<AppExtension> appExtensions;
     @ElementList(required = false, entry = "path")
     private ArrayList<QualifiedFile> appExtensionPaths;
-    @ElementList(required = false, entry = "path")
-    private ArrayList<File> swiftLibPaths;
+    @Element(required = false)
+    private SwiftSupport swiftSupport = null;
     @ElementList(required = false, entry = "resource")
     private ArrayList<Resource> resources;   
     @ElementList(required = false, entry = "classpathentry")
@@ -458,9 +458,20 @@ public class Config {
                 .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
     }
 
+    public SwiftSupport getSwiftSupport() {
+        return swiftSupport;
+    }
+
+    public boolean hasSwiftSupport() {
+        return swiftSupport != null;
+    }
+
     public List<File> getSwiftLibPaths() {
-        return swiftLibPaths == null ? Collections.emptyList()
-                : Collections.unmodifiableList(swiftLibPaths);
+        return swiftSupport == null ? Collections.emptyList()
+                : swiftSupport.getSwiftLibPaths().stream()
+                .filter(this::isQualified)
+                .map(f -> f.entry)
+                .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
     }
 
     public List<Resource> getResources() {
@@ -720,7 +731,7 @@ public class Config {
             if (!Arrays.asList(qualified.filterArch()).contains(sliceArch))
                 return false;
         }
-        // TODO: there is no platform variant, just guess it from arch, applies to iOS temporaly
+        // TODO: there is no platform variant, just guess it from arch, applies to iOS temporally
         if (os == OS.ios && qualified.filterPlatformVariants() != null) {
             PlatformVariant variant = sliceArch.isArm() ? PlatformVariant.device : PlatformVariant.simulator;
             if (!Arrays.asList(qualified.filterPlatformVariants()).contains(variant))
@@ -1506,21 +1517,6 @@ public class Config {
                 config.appExtensionPaths = new ArrayList<>();
             }
             config.appExtensionPaths.add(new QualifiedFile(extensionPath));
-            return this;
-        }
-
-        public Builder clearSwiftLibPaths() {
-            if (config.swiftLibPaths != null) {
-                config.swiftLibPaths.clear();
-            }
-            return this;
-        }
-
-        public Builder addSwiftLibPath(File path) {
-            if (config.swiftLibPaths == null) {
-                config.swiftLibPaths = new ArrayList<>();
-            }
-            config.swiftLibPaths.add(path);
             return this;
         }
 

--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/SwiftSupport.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/SwiftSupport.java
@@ -1,0 +1,26 @@
+package org.robovm.compiler.config;
+
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementList;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Configuration entry for Swift language related configurations
+ */
+public class SwiftSupport {
+    /**
+     * path where swift library to be looked at
+     * also these libraries will be added to linker library search path
+     */
+    @ElementList(required = false, entry = "path")
+    private ArrayList<Config.QualifiedFile> swiftLibPaths;
+
+    public List<Config.QualifiedFile> getSwiftLibPaths() {
+        return swiftLibPaths == null ? Collections.emptyList()
+                : Collections.unmodifiableList(swiftLibPaths);
+    }
+}


### PR DESCRIPTION
- allowing static swift libs to be linked by linker (no need to specify them)
- fixed pattern to not try to copy swift libs that are part of runtime, only @rpath are being copied now;
- application binary is being scanned for swift dependencies as well now. As static linking might introduce ones
- added `<swiftSupport>` config option. Putting this to `robovm.xml` will add swift path to linker library search path