### PR TITLE
* hot fix for CompilerException while compiling UIKey.keyCode

### DIFF
--- a/compiler/cocoatouch/src/main/bro-gen/uikit.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/uikit.yaml
@@ -4294,7 +4294,11 @@ classes:
     UIToolbarAppearance: {} #since 13.0
     UIWindowScene: {} #since 13.0
     UIWindowSceneDestructionRequestOptions: {} #since 13.0
-    UIKey: {} #since 13.4
+    UIKey:  #since 13.4
+        properties:
+            'keyCode':
+                name: keyCodeRaw
+                type: "@MachineSizedSInt long"
     NSDiffableDataSourceSectionSnapshot: #since 14.0
         methods:
             '-appendItems:intoParentItem:':

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIKey.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIKey.java
@@ -69,12 +69,13 @@ import org.robovm.apple.linkpresentation.*;
     @Property(selector = "modifierFlags")
     public native UIKeyModifierFlags getModifierFlags();
     @Property(selector = "keyCode")
-    public native UIKeyboardHIDUsage getKeyCode();
+    public native @MachineSizedSInt long getKeyCodeRaw();
     /*</properties>*/
 
-    // manually added method to access keyCodes that are missing in UIKeyboardHIDUsage
-    @Property(selector = "keyCode")
-    public native @MachineSizedSInt long getKeyCodeRaw();
+    // manually added method, converts raw value into UIKeyboardHIDUsage
+    public UIKeyboardHIDUsage getKeyCode() {
+        return UIKeyboardHIDUsage.valueOf(getKeyCodeRaw());
+    }
 
     /*<members>*//*</members>*/
     /*<methods>*/


### PR DESCRIPTION
fix for #548 is not working as expected as produce:
```
org.robovm.compiler.CompilerException: Found multiple overridable @Method or @Property methods in org.robovm.apple.uikit.UIKey with the selector 'keyCode'.
```

the fix is not to use same @Property annotation but implement getKeyCode with separate implementation that calls getKeyCodeRaw