### PR TITLE
fixed #561: reverted binding of structs with flexible array members

### DIFF
--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreaudio/AudioBufferList.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreaudio/AudioBufferList.java
@@ -92,7 +92,7 @@ import org.robovm.apple.corefoundation.*;
     /*<members>*/
     @StructMember(0) protected native int getNumberBuffers();
     @StructMember(0) protected native AudioBufferList setNumberBuffers(int numberBuffers);
-    @StructMember(1) protected native @ByVal AudioBuffer getBuffers0();
+    @StructMember(1) protected native @Array({1}) AudioBuffer getBuffers0();
     /*</members>*/
     /*<methods>*//*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDIEventList.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDIEventList.java
@@ -56,7 +56,7 @@ import org.robovm.apple.corefoundation.*;
     @StructMember(0) public native MIDIEventList setProtocol(MIDIProtocolID protocol);
     @StructMember(1) public native int getNumPackets();
     @StructMember(1) public native MIDIEventList setNumPackets(int numPackets);
-    @StructMember(2) public native @ByVal MIDIEventPacket getPacket();
+    @StructMember(2) public native @Array({1}) MIDIEventPacket getPacket();
     /*</members>*/
     /*<methods>*//*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDIPacketList.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDIPacketList.java
@@ -47,7 +47,7 @@ import org.robovm.apple.corefoundation.*;
     /*<members>*/
     @StructMember(0) public native int getNumPackets();
     @StructMember(0) public native MIDIPacketList setNumPackets(int numPackets);
-    @StructMember(1) public native @ByVal MIDIPacket getPacket();
+    @StructMember(1) public native @Array({1}) MIDIPacket getPacket();
     /*</members>*/
     /*<methods>*/
     /**


### PR DESCRIPTION
Issue #561 was introduced during ios13 binding generation.
### Root case 
To work with Flexible Array Members (FAM) its required to get pointer to the member and then navigate by it to put/get data. 
When struct member is annotated as `@ByVal` it will return a COPY of first element of FAM instead of pointer to it. 
Updating this element as array will not affect original struct (the issue itself) and is dangerous as will produce memory corruption if items changed at index 1+