### PR TITLE
Idea plugin maintenance: support for 2021.1 EAP

### DIFF
--- a/plugins/idea/README.md
+++ b/plugins/idea/README.md
@@ -16,9 +16,9 @@ Not supported any more due removed `-extdir` in Java9+
 * Open Intellij IDEA CE, setup the IDEA sdk pointing it at your IDEA installation. Add source path to root of repo cloned above. Also add following JARs to SDK from IDEA directory:
    - /Applications/IntelliJ IDEA CE.app/Contents/plugins/maven/lib/maven.jar
    - /Applications/IntelliJ IDEA CE.app/Contents/plugins/gradle/lib/gradle-common.jar
-   - /Applications/IntelliJ IDEA CE.app/Contents/plugins/gradle/lib/gradle-api-?.?.?-sp1.jar
-   - (pre 2019.3) /Applications/IntelliJ IDEA CE.app/Contents/plugins/gradle/lib/gradle-java.jar
-   - (after 2019.3) /Applications/IntelliJ IDEA CE.app/Contents/plugins/gradle-java/lib/gradle-java.jar!/
+   - /Applications/IntelliJ IDEA CE.app/Contents/plugins/gradle-java/lib/gradle-java.jar!/
+   - (before 2021.1) /Applications/IntelliJ IDEA CE.app/Contents/plugins/gradle/lib/gradle-api-?.?.?-sp1.jar
+   - (after 2021.1) /Applications/IntelliJ IDEA CE.app/Contents/plugins/gradle/lib/gradle-lib.jar
 * Open the project by selecting it's POM
 * Open File -> Project Structure, Click on the Project menu entry, and select the IDEA sdk under Project SDK
 * Click OK

--- a/plugins/idea/src/main/java/org/robovm/idea/components/setupwizard/JdkSetupDialog.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/components/setupwizard/JdkSetupDialog.java
@@ -96,7 +96,7 @@ public class JdkSetupDialog extends JDialog {
 
     private void validateInput() {
         String jdkPath = jdkHome.getText();
-        boolean valid = jdkPath != null && !jdkPath.isEmpty() && JdkUtil.checkForJdk(new File(jdkPath));
+        boolean valid = jdkPath != null && !jdkPath.isEmpty() && JdkUtil.checkForJdk(jdkPath);
         errorLabel.setVisible(!valid);
         nextButton.setEnabled(valid);
     }


### PR DESCRIPTION
code updated as deprecated API was removed in 2021.1 EAP, readme file updated with instructions how to setup maven-based development with 2021.1 EAP