### PR TITLE
* fixed: GlobalValueEnumeration crash #567

### DIFF
--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVMetadataObjectType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVMetadataObjectType.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2013-2015 RoboVM AB
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -130,19 +130,28 @@ import org.robovm.apple.audiotoolbox.*;
     /*</constants>*/
     
     private static /*<name>*/AVMetadataObjectType/*</name>*/[] values = new /*<name>*/AVMetadataObjectType/*</name>*/[] {/*<value_list>*/HumanBody, CatBody, DogBody, SalientObject, Face, UPCECode, Code39Code, Code39Mod43Code, EAN13Code, EAN8Code, Code93Code, Code128Code, PDF417Code, QRCode, AztecCode, Interleaved2of5Code, ITF14Code, DataMatrixCode/*</value_list>*/};
-    
+
     /*<name>*/AVMetadataObjectType/*</name>*/ (String getterName) {
         super(Values.class, getterName);
     }
-    
+    /*<name>*/AVMetadataObjectType/*</name>*/ (/*<type>*/NSString/*</type>*/ value) {
+        super(value);
+    }
+
     public static /*<name>*/AVMetadataObjectType/*</name>*/ valueOf(/*<type>*/NSString/*</type>*/ value) {
-        for (/*<name>*/AVMetadataObjectType/*</name>*/ v : values) {
-            if (v.value().equals(value)) {
-                return v;
+        synchronized (/*<name>*/AVMetadataObjectType/*</name>*/.class) {
+            for (/*<name>*/AVMetadataObjectType/*</name>*/ v : values) {
+                if (v.isAvailable() && v.value().equals(value)) {
+                    return v;
+                }
             }
+            // entry was not known compilation time. probably new entry available on new OS version, extending instead
+            // of crashing with exception
+            /*<name>*/AVMetadataObjectType/*</name>*/ v = new /*<name>*/AVMetadataObjectType/*</name>*/(value);
+            values = Arrays.copyOf(values, values.length + 1);
+            values[values.length - 1] = v;
+            return v;
         }
-        throw new IllegalArgumentException("No constant with value " + value + " found in " 
-            + /*<name>*/AVMetadataObjectType/*</name>*/.class.getName());
     }
     
     /*<methods>*//*</methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/GlobalValueEnumeration.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/GlobalValueEnumeration.java
@@ -16,21 +16,65 @@
 
 package org.robovm.apple.foundation;
 
+import org.robovm.rt.bro.GlobalValueSupplier;
 import org.robovm.rt.bro.LazyGlobalValue;
 
-public class GlobalValueEnumeration<T> {
-    private final LazyGlobalValue<T> lazyGlobalValue;
+import java.util.Objects;
+
+public class GlobalValueEnumeration<T> extends GlobalValueSupplier<T> {
+    private final GlobalValueSupplier<T> globalValueSupplier;
 
     protected GlobalValueEnumeration (Class<?> clazz, String getterName) {
-        lazyGlobalValue = new LazyGlobalValue<>(clazz, getterName);
+        globalValueSupplier = new LazyGlobalValue<>(clazz, getterName);
     }
 
+    protected GlobalValueEnumeration (T value) {
+        globalValueSupplier = new Constant<>(value);
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return globalValueSupplier.isAvailable();
+    }
+
+    @Override
     public T value () {
-        return lazyGlobalValue.value();
+        return globalValueSupplier.value();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GlobalValueEnumeration<?> that = (GlobalValueEnumeration<?>) o;
+        if (!globalValueSupplier.isAvailable() || !that.globalValueSupplier.isAvailable())
+            return false;
+        return Objects.equals(globalValueSupplier.value(), that.globalValueSupplier.value());
     }
 
     @Override
     public String toString () {
         return value().toString();
+    }
+
+    /**
+     * Constant supplier
+     */
+    private static class Constant<T> extends GlobalValueSupplier<T> {
+        private final T constValue;
+
+        private Constant(T value) {
+            this.constValue = value;
+        }
+
+        @Override
+        public boolean isAvailable() {
+            return true;
+        }
+
+        @Override
+        public T value() {
+            return constValue;
+        }
     }
 }

--- a/compiler/rt/robovm/src/main/java/org/robovm/rt/bro/GlobalValueSupplier.java
+++ b/compiler/rt/robovm/src/main/java/org/robovm/rt/bro/GlobalValueSupplier.java
@@ -1,0 +1,23 @@
+package org.robovm.rt.bro;
+
+import org.robovm.rt.bro.annotation.GlobalValue;
+
+/**
+ * Supplier interface for a {@link GlobalValue}
+ */
+public abstract class GlobalValueSupplier<T> {
+
+    /**
+     * Returns true if global value is available (e.g. there is no UnsatisfiedLinkError when accessing it)
+     *
+     * @return true if available
+     */
+    abstract public boolean isAvailable();
+
+    /**
+     * Returns the value of the {@link GlobalValue}.
+     *
+     * @return the value.
+     */
+    abstract public T value();
+}


### PR DESCRIPTION
## Background
[issue #567](https://github.com/MobiVM/robovm/issues/567).  
[not exact issue but same problem](https://github.com/MobiVM/robovm/issues/548).  
In general native-to-Java enum mapping is fragile in RoboVM as most likely app will crash if set of enum items in app differs from one available in system:  
<!-- more -->
## case 1: global value is not available on target os   
(case as described in MobiVM#567) -- fails with `UnsatisfiedLinkError`. Happens when app was built for newer API version but run on old device. As result global value is not available in the binary.  
### Root case: native to java marshaller code looks like bellow `valueOf`:
```
for (GlobalValueEnumeration v : values) {
  if (v.value().equals(value)) {
    return v;
}
```
If entry is missing -- v.value() will cause `UnsatisfiedLinkError`

### the fix:
code to be added to check if `v.isAvailable()` before doing `v.value().equals(value)`

## case 2: value is unknown for application. 
Happens when marshalling value returned by system API and it is not known for application. Happens when old app runs on new OS. In this case same `valueOf` marshaller will not find the value in known `values` list and throw `IllegalArgumentException("No constant with value")`.  

### the fix:
It is against enum concept (e.g. it has to be fixed runtime but `GlobalValueEnumeration` is not a true enum) - the fix is to dynamically create new entry of enumeration item and add it to `values`. 

## discussion 
This PR updates only `AVMetadataObjectType` but in general all bindings for `GlobalValueEnumeration` to be updated