### PR TITLE
* changed: the way how dynamic libraries appears at linker command line

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -1925,6 +1925,9 @@ public class Config {
             boolean force = forceNode == null || Boolean.parseBoolean(forceNode.getValue());
             if (value.endsWith(".a") || value.endsWith(".o")) {
                 return new Lib(fileConverter.read(value).getAbsolutePath(), force);
+            } else if (value.endsWith(".dylib") || value.endsWith(".so")) {
+                File f = fileConverter.read(value);
+                return new Lib(f.isFile() ? f.getAbsolutePath() : value, force);
             } else {
                 return new Lib(value, force);
             }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
@@ -251,7 +251,10 @@ public abstract class AbstractTarget implements Target {
                         }
                     }
                 } else if (p.endsWith(".dylib") || p.endsWith(".so")) {
-                    libs.add(new File(p).getAbsolutePath());
+                    // dkimitsa: add absolute path only if Config.Lib relative file converter was able to resolve it
+                    //           e.g. lib exists, otherwise use it as it is
+                    File f = new File(p);
+                    libs.add(f.isAbsolute() ? f.getAbsolutePath() : p);
                 } else {
                     // link via -l if suffix is omitted
                     libs.add("-l" + p);


### PR DESCRIPTION
# root case:
  dynamic libraries were not converted from relative to absolute path during config parsing. But were converted into absolute during linker command line preparation. As result their absolute path was not related to location of robovm.xml it was mentioned in.
# the fix:
  - during configuration parsing if library exists -- absolute path to it will be used (same as with static libs). If not present -- value from config will be used.
  - during linker command line preparation -- logic exists same. If path is absolute -- it will be used as absolute. Otherwise as library name