### PR TITLE
Maven clean removes CMakeCache.txt files 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -416,6 +416,17 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
                     <version>3.1.0</version>
+                    <configuration>
+                      <filesets>
+                        <fileset>
+                          <directory>.</directory>
+                          <includes>
+                            <include>**/CMakeCache.txt</include>
+                          </includes>
+                          <followSymlinks>false</followSymlinks>
+                        </fileset>
+                      </filesets>
+                    </configuration>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
When building MobiVM `cmake` caches data in files called `CMakeCache.txt`. These should be removed when doing `mvn clean` otherwise the build may break if the build environment has changed since the data was cached.

This patch configures the top-level pom.xml clean task to remove any such cache files.

