### PR TITLE
* cocoatouch: fixed typo in parameter name that was blocking `CHHapticEventParameterID` key

### DIFF
--- a/compiler/cocoatouch/src/main/bro-gen/corehaptic.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/corehaptic.yaml
@@ -30,9 +30,9 @@ typed_enums:
                 type: double
             EventParameters:
                 type: NSArray<?>
-            KeyParameter:
+            Parameter:
                 type: NSDictionary<?, ?>
-            KeyParameterID:
+            ParameterID:
                 type: CHHapticEventParameterID
             ParameterValue:
                 type: double

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corehaptic/CHHapticPatternDict.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corehaptic/CHHapticPatternDict.java
@@ -246,6 +246,40 @@ import org.robovm.apple.avfoundation.*;
     /**
      * @since Available in iOS 13.0 and later.
      */
+    public NSDictionary<?, ?> getParameter() {
+        if (has(Keys.Parameter())) {
+            NSDictionary<?, ?> val = (NSDictionary<?, ?>) get(Keys.Parameter());
+            return val;
+        }
+        return null;
+    }
+    /**
+     * @since Available in iOS 13.0 and later.
+     */
+    public CHHapticPatternDict setParameter(NSDictionary<?, ?> parameter) {
+        set(Keys.Parameter(), parameter);
+        return this;
+    }
+    /**
+     * @since Available in iOS 13.0 and later.
+     */
+    public CHHapticEventParameterID getParameterID() {
+        if (has(Keys.ParameterID())) {
+            NSString val = (NSString) get(Keys.ParameterID());
+            return CHHapticEventParameterID.valueOf(val);
+        }
+        return null;
+    }
+    /**
+     * @since Available in iOS 13.0 and later.
+     */
+    public CHHapticPatternDict setParameterID(CHHapticEventParameterID parameterID) {
+        set(Keys.ParameterID(), parameterID.value());
+        return this;
+    }
+    /**
+     * @since Available in iOS 13.0 and later.
+     */
     public double getParameterValue() {
         if (has(Keys.ParameterValue())) {
             NSNumber val = (NSNumber) get(Keys.ParameterValue());


### PR DESCRIPTION
issue in [gitter](https://gitter.im/MobiVM/robovm?at=613b7a5fd206b85e4f8f062d)