### PR TITLE
Robovmconfigurationfactory fix warning from IdeaJ

### DIFF
--- a/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmConfigurationFactory.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmConfigurationFactory.java
@@ -28,8 +28,8 @@ public class RoboVmConfigurationFactory extends ConfigurationFactory {
         super(type);
     }
 
-    @Override
     @NotNull
+    @Override
     public String getId() {
         return "RoboVMConfiguration";
     }


### PR DESCRIPTION
Eliminates warnings from IdeaJ in log:

````
WARN - util.DeprecatedMethodException - The default implementation of method 'com.intellij.execution.configurations.ConfigurationFactory.getId' is deprecated, you need to override it in 'class org.robovm.idea.running.RoboVmConfigurationFactory'. The default implementation delegates to 'getName' which may be localized but return value of this method must not depend on current localization.
````
