### PR TITLE
* fixed: java.lang.RuntimeException: No method void <init>() in class java.lang.StringBuilder

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/plugin/desugar/StringConcatRewriter.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/plugin/desugar/StringConcatRewriter.java
@@ -24,7 +24,7 @@ public class StringConcatRewriter {
     }
 
     private void init() {
-        SootClass java_lang_StringBuilder = SootResolver.v().makeClassRef(JAVA_STRINGBUILDER);
+        SootClass java_lang_StringBuilder = SootResolver.v().resolveClass(JAVA_STRINGBUILDER, SootClass.SIGNATURES);
         StringBuilder_init = java_lang_StringBuilder.getMethod(JAVA_STRINGBUILDER_INIT);
         StringBuilder_toString = java_lang_StringBuilder.getMethod(JAVA_STRINGBUILDER_TOSTRING);
 


### PR DESCRIPTION
Issue was reported in [gitter](https://gitter.im/MobiVM/robovm?at=61815b2bfb8ca0572bfb503d) and introduced by #558 

This happens in StringConcat desugarer in case StringBuilder class was not processed yet. And getting reference will not provide any class information. The fix is to resolve this class to make all its information available.