### PR TITLE
* desugar: added compiler plugin that extends ByteBuffer with Java9 API

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/VTable.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/VTable.java
@@ -149,6 +149,13 @@ public class VTable {
             cache.put(clazz.getName(), vtable);
             return vtable;
         }
+
+        /**
+         * Removes clazz from cache in case it was changed (during compilation)
+         */
+        public void remove(SootClass clazz) {
+            cache.remove(clazz.getName());
+        }
     }
     
     public static class Entry {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -40,6 +40,7 @@ import org.robovm.compiler.plugin.TargetPlugin;
 import org.robovm.compiler.plugin.annotation.AnnotationImplPlugin;
 import org.robovm.compiler.plugin.debug.DebugInformationPlugin;
 import org.robovm.compiler.plugin.debug.DebuggerLaunchPlugin;
+import org.robovm.compiler.plugin.desugar.ByteBufferJava9ApiPlugin;
 import org.robovm.compiler.plugin.desugar.StringConcatRewriterPlugin;
 import org.robovm.compiler.plugin.lambda.LambdaPlugin;
 import org.robovm.compiler.plugin.objc.InterfaceBuilderClassesPlugin;
@@ -254,6 +255,7 @@ public class Config {
                 new ObjCBlockPlugin(),
                 new AnnotationImplPlugin(),
                 new StringConcatRewriterPlugin(),
+                new ByteBufferJava9ApiPlugin(),
                 new LambdaPlugin(),         
                 new DebugInformationPlugin(),
                 new DebuggerLaunchPlugin()

--- a/compiler/compiler/src/main/java/org/robovm/compiler/plugin/Plugin.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/plugin/Plugin.java
@@ -50,4 +50,29 @@ public abstract class Plugin {
         }
         return args;
     }
+
+    /**
+     * String type argument accessor
+     */
+    protected String argumentValue(Map<String, String> arguments, String key, String defaultValue) {
+        String v = arguments.get(key);
+        return v != null ? v : defaultValue;
+    }
+
+    /**
+     * Int type argument accessor
+     */
+    protected int argumentValue(Map<String, String> arguments, String key, int defaultValue) {
+        String v = arguments.get(key);
+        return v != null ? Integer.parseInt(v) : defaultValue;
+    }
+
+    /**
+     * Boolean type argument accessor
+     */
+    protected boolean argumentValue(Map<String, String> arguments, String key, boolean defaultValue) {
+        String v = arguments.get(key);
+        return v != null ? Boolean.parseBoolean(v) : defaultValue;
+    }
+
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/plugin/debug/DebuggerLaunchPlugin.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/plugin/debug/DebuggerLaunchPlugin.java
@@ -177,27 +177,12 @@ public class DebuggerLaunchPlugin extends LaunchPlugin {
         }
     }
 
-    private String argumentValue(Map<String, String> arguments, String key, String defaultValue) {
-        String v = arguments.get(key);
-        return v != null ? v : defaultValue;
-    }
-
-    private int argumentValue(Map<String, String> arguments, String key, int defaultValue) {
-        String v = arguments.get(key);
-        return v != null ? Integer.parseInt(v) : defaultValue;
-    }
-
     private int argumentIntValue(Map<String, String> arguments, String key) {
         String v = arguments.get(key);
         if (v == null)
             throw new CompilerException("Missing required debugger argument " + key);
 
         return Integer.parseInt(v);
-    }
-
-    private boolean argumentValue(Map<String, String> arguments, String key, boolean defaultValue) {
-        String v = arguments.get(key);
-        return v != null ? Boolean.parseBoolean(v) : defaultValue;
     }
 
     boolean argumentBoolValue(Map<String, String> arguments, String key) {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/plugin/desugar/ByteBufferJava9ApiPlugin.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/plugin/desugar/ByteBufferJava9ApiPlugin.java
@@ -1,0 +1,133 @@
+package org.robovm.compiler.plugin.desugar;
+
+import org.robovm.compiler.ModuleBuilder;
+import org.robovm.compiler.clazz.Clazz;
+import org.robovm.compiler.config.Config;
+import org.robovm.compiler.plugin.AbstractCompilerPlugin;
+import org.robovm.compiler.plugin.PluginArgument;
+import org.robovm.compiler.plugin.PluginArguments;
+import soot.Body;
+import soot.IntType;
+import soot.Local;
+import soot.Modifier;
+import soot.PatchingChain;
+import soot.SootClass;
+import soot.SootMethod;
+import soot.Type;
+import soot.Unit;
+import soot.jimple.Jimple;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This plugin adds support for Java 9+ covariant returns type methods in {@code java.nio.ByteBuffer}.
+ * It adds following covariant return type (ByteBuffer) alternatives to Java8 apis:
+ *   ByteBuffer position(int newPosition)
+ *   ByteBuffer limit(int newLimit)
+ *   ByteBuffer flip()
+ *   ByteBuffer clear()
+ *   ByteBuffer mark()
+ *   ByteBuffer reset()
+ *   ByteBuffer rewind()
+ * Implementation calls super and returns this (instance of ByteBuffer)
+ *
+ * plugin argument to control: 'desugar:enableJdk9ByteBufferApi=false'
+ *
+ * @author DKimitsa
+ */
+public class ByteBufferJava9ApiPlugin extends AbstractCompilerPlugin {
+    private static final String JAVA_NIO_BYTEBUFFER = "java.nio.ByteBuffer";
+    private static final String JAVA_NIO_BUFFER = "java.nio.Buffer";
+    private static final String ARG_KEY_ENABLE_PLUGIN = "enableJdk9ByteBufferApi";
+    private Boolean enabled;
+
+    @Override
+    public PluginArguments getArguments() {
+        // list of arguments as these passed by idea, check idea/compilation/RoboVMCompileTask
+        List<PluginArgument> args = new ArrayList<>();
+        args.add(new PluginArgument(ARG_KEY_ENABLE_PLUGIN, "false", "Flag: disables Java9 changes to java.nio.ByteBuffer"));
+        return new PluginArguments("desugar", args);
+    }
+
+    private boolean isEnabled(Config config) {
+        if (enabled == null) {
+            enabled = argumentValue(parseArguments(config), ARG_KEY_ENABLE_PLUGIN, true);
+        }
+        return enabled;
+    }
+
+    @Override
+    public void beforeConfig(Config.Builder builder, Config config) throws IOException {
+        super.beforeConfig(builder, config);
+        // config to be built, reset enabled flag
+        enabled = null;
+    }
+
+    @Override
+    public void beforeClass(Config config, Clazz clazz, ModuleBuilder moduleBuilder) throws IOException {
+        if (isEnabled(config) && isAcceptableByteBuffer(clazz.getSootClass())) {
+            // injects JDK9 compatible trampolines
+            SootClass sootClass = clazz.getSootClass();
+            injectMethod(sootClass, "flip", false);
+            injectMethod(sootClass, "clear", false);
+            injectMethod(sootClass, "mark", false);
+            injectMethod(sootClass, "reset", false);
+            injectMethod(sootClass, "rewind", false);
+            injectMethod(sootClass, "position", true);
+            injectMethod(sootClass, "limit", true);
+        }
+    }
+
+    private boolean isAcceptableByteBuffer(SootClass sootClass) {
+        return JAVA_NIO_BYTEBUFFER.equals(sootClass.getName()) &&
+                JAVA_NIO_BUFFER.equals(sootClass.getSuperclass().getName());
+    }
+
+    /**
+     * injects method with signature '${name}()ByteBuffer' that just calls super and returns ByteBuffer
+     */
+    private void injectMethod(SootClass bbSootClass, String name, boolean withIntParam) {
+        String paramSignature = withIntParam ? "(int)" : "()";
+        String subSignature = JAVA_NIO_BYTEBUFFER  + " " + name + paramSignature ;
+        if (findMethod(bbSootClass, subSignature) == null) {
+            // find super method
+            subSignature = JAVA_NIO_BUFFER  + " " + name + paramSignature ;
+            SootMethod zuperMethod = findMethod(bbSootClass.getSuperclass(), subSignature);
+            if (zuperMethod == null)
+                throw new IllegalArgumentException(JAVA_NIO_BUFFER + ": missing method " + subSignature);
+
+            // there is no JDK9 method and present expected in Buffer
+            List<Type> paramTypes = withIntParam ? Collections.singletonList(IntType.v()) : Collections.emptyList();
+            SootMethod m = new SootMethod(name, paramTypes, bbSootClass.getType(), Modifier.PUBLIC);
+            Jimple j = Jimple.v();
+            Body body = j.newBody(m);
+            PatchingChain<Unit> units = body.getUnits();
+            Local thiz = j.newLocal("$this", bbSootClass.getType());
+            body.getLocals().add(thiz);
+            units.add(j.newIdentityStmt(thiz, j.newThisRef(bbSootClass.getType())));
+            if (withIntParam) {
+                // with integer param
+                Local i = j.newLocal("$i", IntType.v());
+                body.getLocals().add(i);
+                units.add(j.newIdentityStmt(i, j.newParameterRef(IntType.v(), 0)));
+                units.add(j.newInvokeStmt(j.newSpecialInvokeExpr(thiz, zuperMethod.makeRef(), i)));
+            } else {
+                // void params
+                units.add(j.newInvokeStmt(j.newSpecialInvokeExpr(thiz, zuperMethod.makeRef())));
+            }
+            units.add(j.newReturnStmt(thiz));
+            m.setActiveBody(body);
+            bbSootClass.addMethod(m);
+        }
+    }
+
+    private SootMethod findMethod(SootClass sootClass, String subSignature) {
+        return sootClass.getMethods()
+                .stream()
+                .filter(method -> subSignature.equals(method.getSubSignature()))
+                .findFirst().orElse(null);
+    }
+}

--- a/compiler/compiler/src/main/java/org/robovm/compiler/plugin/desugar/ByteBufferJava9ApiPlugin.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/plugin/desugar/ByteBufferJava9ApiPlugin.java
@@ -78,6 +78,9 @@ public class ByteBufferJava9ApiPlugin extends AbstractCompilerPlugin {
             injectMethod(sootClass, "rewind", false);
             injectMethod(sootClass, "position", true);
             injectMethod(sootClass, "limit", true);
+
+            // remove this class from vtable cache as it has to be rebuilt to include new methods
+            config.getVTableCache().remove(sootClass);
         }
     }
 


### PR DESCRIPTION
## Overview
Java9 adds overridden methods with covariant return types in ByteBuffer:
- flip
- clear
- mark
- reset
- rewind
- position
- limit
It becomes problem when using external dependency that was compiled as `-release 9` and caused exceptions:
> java.lang.NoSuchMethodError: java.nio.ByteBuffer.limit(I)Ljava/nio/ByteBuffer
The only options is to re-compile the dependency. But it is not always possible.

## Discussion
This might be achieved by just adapting runtime classes but having it as Plugin allows to enable or disable the behaviour.

## Other changes
Desugar plugins were extended with option to disable using plugin arguments:
```
<pluginArguments>
    <argument>desugar:enableJdk9ByteBufferApi=false</argument>
    <argument>desugar:enableJava9StringConcat=false</argument>
</pluginArguments>
```