### PR TITLE
framework target: producing xcframework

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/AbstractMethodCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/AbstractMethodCompiler.java
@@ -23,8 +23,8 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.robovm.compiler.clazz.Clazz;
-import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
+import org.robovm.compiler.config.CpuArch;
 import org.robovm.compiler.config.OS.Family;
 import org.robovm.compiler.llvm.BasicBlockRef;
 import org.robovm.compiler.llvm.Function;
@@ -91,7 +91,7 @@ public abstract class AbstractMethodCompiler {
          * strong and we behave as if tree shaking was disabled.
          */
         return FunctionBuilder.method(method,
-                !(config.getOs().getFamily() == Family.darwin && config.getArch() == Arch.x86));
+                !(config.getOs().getFamily() == Family.darwin && config.getArch().getCpuArch() == CpuArch.x86));
     }
 
     private void compileSynchronizedWrapper(ModuleBuilder moduleBuilder, SootMethod method) {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/AppCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/AppCompiler.java
@@ -747,15 +747,12 @@ public class AppCompiler {
                 } else if ("-arch".equals(args[i])) {
                     String s = args[++i];
                     if (!"auto".equals(s)) {
-                        archs.add(Arch.valueOf(s));
+                        archs.add(Arch.parse(s));
                     }
-                } else if ("-env".equals(args[i])) {
-                    String s = args[++i];
-                    builder.env(Environment.valueOf(s));
                 } else if ("-archs".equals(args[i])) {
                     for (String s : args[++i].split(":")) {
                         if (!"auto".equals(s)) {
-                            archs.add(Arch.valueOf(s));
+                            archs.add(Arch.parse(s));
                         }
                     }
                 } else if ("-target".equals(args[i])) {
@@ -835,7 +832,7 @@ public class AppCompiler {
                 } else if ("-ipaarchs".equals(args[i])) {
                     for (String s : args[++i].split(":")) {
                         if (!"auto".equals(s)) {
-                            archs.add(Arch.valueOf(s));
+                            archs.add(Arch.parse(s));
                         }
                     }
                 } else if (args[i].startsWith("-D")) {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/ClassCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/ClassCompiler.java
@@ -295,10 +295,9 @@ public class ClassCompiler {
         
         Arch arch = config.getArch();
         OS os = config.getOs();
-        Environment env = config.getEnv();
 
         try {
-            config.getLogger().info("Compiling %s (%s %s%s %s)", clazz, os, arch, env.asLlvmSuffix("-"),
+            config.getLogger().info("Compiling %s (%s %s %s)", clazz, os, arch,
                     config.isDebug() ? "debug" : "release");
             output.reset();
             compile(clazz, output);
@@ -815,7 +814,7 @@ public class ClassCompiler {
             sootClass.addMethod(offset);
         }
         
-        mb.addInclude(getClass().getClassLoader().getResource(String.format("header-%s-%s.ll", config.getOs().getFamily(), config.getArch())));
+        mb.addInclude(getClass().getClassLoader().getResource(String.format("header-%s-%s.ll", config.getOs().getFamily(), config.getArch().getCpuArch())));
         mb.addInclude(getClass().getClassLoader().getResource("header.ll"));
 
         mb.addFunction(createLdcClass());

--- a/compiler/compiler/src/main/java/org/robovm/compiler/Linker.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/Linker.java
@@ -206,7 +206,7 @@ public class Linker {
                 os, arch, config.isDebug() ? "debug" : "release");
 
         ModuleBuilder mb = new ModuleBuilder();
-        mb.addInclude(getClass().getClassLoader().getResource(String.format("header-%s-%s.ll", os.getFamily(), arch)));
+        mb.addInclude(getClass().getClassLoader().getResource(String.format("header-%s-%s.ll", os.getFamily(), arch.getCpuArch())));
         mb.addInclude(getClass().getClassLoader().getResource("header.ll"));
 
         mb.addGlobal(new Global("_bcRuntimeData", runtimeDataToBytes()));
@@ -300,7 +300,7 @@ public class Linker {
         for (int i = 1; i < mbs.length; i++) {
             mbs[i] = new ModuleBuilder();
             mbs[i].addInclude(getClass().getClassLoader().getResource(
-                    String.format("header-%s-%s.ll", os.getFamily(), arch)));
+                    String.format("header-%s-%s.ll", os.getFamily(), arch.getCpuArch())));
             mbs[i].addInclude(getClass().getClassLoader().getResource("header.ll"));
 
             Function fn = new FunctionBuilder("_stripped_method" + i, new FunctionType(VOID, ENV_PTR))

--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Arch.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Arch.java
@@ -18,79 +18,139 @@ package org.robovm.compiler.config;
 
 import java.nio.ByteOrder;
 
-import org.robovm.compiler.CompilerException;
-import org.robovm.llvm.Target;
-
 /**
- * @author niklas
+ * Information about build slice -- incorporates arch, os and Environment
+ * such as x86_64, x86_64-simulator or x86_64-macosx
  *
+ * @author dkimitsa
  */
-public enum Arch {
-    x86("i386", "i386", "penryn", true, false),
-    x86_64("x86_64", "x86_64", "penryn", false, false),
-    thumbv7("thumbv7", "armv7", true, true),
-    arm64("arm64", "arm64", false, true);
-    
-    private final String llvmName;
-    private final String clangName;
-    private final String llvmCpu;
-    private final boolean is32Bit;
-    private final boolean isArm;
-    private final ByteOrder byteOrder;
-    
-    private Arch(String llvmName, String clangName, boolean is32Bit, boolean isArm) {
-        this(llvmName, clangName, "generic", is32Bit, isArm);
+public class Arch implements Comparable<Arch> {
+    // constants to keep old code
+    public static final Arch thumbv7 = new Arch(CpuArch.thumbv7);
+    public static final Arch arm64 = new Arch(CpuArch.arm64);
+    public static final Arch x86 = new Arch(CpuArch.x86);
+    public static final Arch x86_64 = new Arch(CpuArch.x86_64);
+
+    private final CpuArch cpuArch;
+    private final Environment env;
+
+    public Arch(CpuArch arch, Environment env) {
+        this.cpuArch = arch;
+        this.env = env;
     }
 
-    private Arch(String llvmName, String clangName, String llvmCpu, boolean is32Bit, boolean isArm) {
-        this(llvmName, clangName, llvmCpu, is32Bit, isArm, ByteOrder.LITTLE_ENDIAN);
+    public Arch(CpuArch arch) {
+        this.cpuArch = arch;
+        this.env = Environment.Native;
     }
-    
-    private Arch(String llvmName, String clangName, String llvmCpu, boolean is32Bit, boolean isArm, ByteOrder byteOrder) {
-        this.llvmName = llvmName;
-        this.clangName = clangName;
-        this.llvmCpu = llvmCpu;
-        this.is32Bit = is32Bit;
-        this.isArm = isArm;
-        this.byteOrder = byteOrder;
-    }
-    
-    public String getLlvmName() {
-        return llvmName;
-    }
-    
-    public String getClangName() {
-        return clangName;
-    }
-    
-    public String getLlvmCpu() {
-        return llvmCpu;
-    }
-    
-    public boolean isArm() {
-        return isArm;
-    }
-    
-    public boolean is32Bit() {
-        return is32Bit;
-    }
-    
-    public ByteOrder getByteOrder() {
-        return byteOrder;
-    }
-    
+
     public static Arch getDefaultArch() {
-        String hostTriple = Target.getHostTriple();
-        if (hostTriple.matches("^(x86.64|amd64).*")) {
-            return Arch.x86_64;
+        return new Arch(CpuArch.getDefaultArch());
+    }
+
+    /**
+     * promote CpuArch with environment if it wasn't specified
+     * E.g. x86_64 and iOS exists only for Simulator environment
+     */
+    public Arch promoteTo(OS os) {
+        if (os == OS.ios && env == Environment.Native && (cpuArch == CpuArch.x86 || cpuArch == CpuArch.x86_64))
+            return new Arch(cpuArch, Environment.Simulator);
+        return this;
+    }
+
+    /**
+     * returns possible supported arches for given os
+     */
+    public static Arch[] supported(OS os) {
+        switch (os) {
+            case linux:
+                return new Arch[]{Arch.x86_64, Arch.x86};
+            case macosx:
+                return new Arch[]{Arch.x86_64, Arch.x86, Arch.arm64};
+            case ios:
+                return new Arch[]{
+                        new Arch(CpuArch.x86_64, Environment.Simulator),
+                        new Arch(CpuArch.x86, Environment.Simulator),
+                        new Arch(CpuArch.arm64, Environment.Simulator),
+                        Arch.arm64, Arch.thumbv7};
+            default:
+                throw new IllegalArgumentException("Unexpected OS");
         }
-        if (hostTriple.matches("^(x86|i\\d86).*")) {
-            return Arch.x86;
+    }
+
+    public CpuArch getCpuArch() {
+        return cpuArch;
+    }
+
+    public Environment getEnv() {
+        return env;
+    }
+
+    public Arch copy(Environment anotherEnv) {
+        return new Arch(cpuArch, anotherEnv);
+    }
+
+    @Override
+    public String toString() {
+        return cpuArch + env.asLlvmSuffix("-");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Arch arch = (Arch) o;
+        if (cpuArch != arch.cpuArch) return false;
+        return env == arch.env;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = cpuArch.hashCode();
+        result = 31 * result + env.hashCode();
+        return result;
+    }
+
+    @Override
+    public int compareTo(Arch o) {
+        int res = cpuArch.compareTo(o.cpuArch);
+        if (res == 0)
+            res = env.compareTo(o.env);
+        return res;
+    }
+
+
+    static public Arch parse(String s) {
+        String[] chunks = s.split("-");
+        CpuArch cpuArch;
+        Environment env = Environment.Native;
+        if (chunks.length == 1) {
+            // arch only, already parsed s
+            cpuArch = CpuArch.valueOf(chunks[0]);
+        } else if (chunks.length == 2) {
+            cpuArch = CpuArch.valueOf(chunks[0]);
+            env = Environment.parse(chunks[1]);
+        } else {
+            throw new IllegalArgumentException("Unexpected Slice configuration `" + s + "`");
         }
-        if (hostTriple.matches("^(arm-apple-darwin).*")) {
-            // MacOSX m1 CPU
-            return Arch.arm64;
-        }
-        throw new CompilerException("Unrecognized arch in host triple: " + hostTriple);
-    }    
+
+        return new Arch(cpuArch, env);
+    }
+
+    public boolean is32Bit() {
+        return cpuArch.is32Bit();
+    }
+
+    public ByteOrder getByteOrder() {
+        return cpuArch.getByteOrder();
+    }
+
+    public boolean isArm() {
+        return cpuArch.isArm();
+    }
+
+    public String getLlvmCpu() {
+        return cpuArch.getLlvmCpu();
+    }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -986,8 +986,8 @@ public class Config {
                 target = new ConsoleTarget();
             } else if (IOSTarget.TYPE.equals(targetType)) {
                 target = new IOSTarget();
-            } else if (FrameworkTarget.TYPE.equals(targetType)) {
-                target = new FrameworkTarget();
+            } else if (FrameworkTarget.matches(targetType)) {
+                target = new FrameworkTarget(targetType);
             } else {
                 for (TargetPlugin plugin : getTargetPlugins()) {
                     if (plugin.getTarget().getType().equals(targetType)) {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/CpuArch.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/CpuArch.java
@@ -80,17 +80,15 @@ public enum CpuArch {
     }
 
     public static CpuArch getDefaultArch() {
-        String hostTriple = Target.getHostTriple();
-        if (hostTriple.matches("^(x86.64|amd64).*")) {
+        String archProp = System.getProperty("os.arch").toLowerCase();
+        if (archProp.matches("amd64|x86[-_]64")) {
             return CpuArch.x86_64;
-        }
-        if (hostTriple.matches("^(x86|i\\d86).*")) {
+        } else if (archProp.matches("i386|x86")) {
             return CpuArch.x86;
-        }
-        if (hostTriple.matches("^(arm-apple-darwin).*")) {
+        } else if (archProp.matches("aarch64|arm64")) {
             // MacOSX m1 CPU
             return CpuArch.arm64;
         }
-        throw new CompilerException("Unrecognized arch in host triple: " + hostTriple);
+        throw new CompilerException("Unrecognized arch in os.arch: " + archProp);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/CpuArch.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/CpuArch.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2012 RoboVM AB
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/gpl-2.0.html>.
+ */
+package org.robovm.compiler.config;
+
+import java.nio.ByteOrder;
+
+import org.robovm.compiler.CompilerException;
+import org.robovm.llvm.Target;
+
+/**
+ * @author niklas
+ *
+ */
+public enum CpuArch {
+    x86("i386", "i386", "penryn", true, false),
+    x86_64("x86_64", "x86_64", "penryn", false, false),
+    thumbv7("thumbv7", "armv7", true, true),
+    arm64("arm64", "arm64", false, true);
+
+    private final String llvmName;
+    private final String clangName;
+    private final String llvmCpu;
+    private final boolean is32Bit;
+    private final boolean isArm;
+    private final ByteOrder byteOrder;
+
+    private CpuArch(String llvmName, String clangName, boolean is32Bit, boolean isArm) {
+        this(llvmName, clangName, "generic", is32Bit, isArm);
+    }
+
+    private CpuArch(String llvmName, String clangName, String llvmCpu, boolean is32Bit, boolean isArm) {
+        this(llvmName, clangName, llvmCpu, is32Bit, isArm, ByteOrder.LITTLE_ENDIAN);
+    }
+
+    private CpuArch(String llvmName, String clangName, String llvmCpu, boolean is32Bit, boolean isArm, ByteOrder byteOrder) {
+        this.llvmName = llvmName;
+        this.clangName = clangName;
+        this.llvmCpu = llvmCpu;
+        this.is32Bit = is32Bit;
+        this.isArm = isArm;
+        this.byteOrder = byteOrder;
+    }
+
+    public String getLlvmName() {
+        return llvmName;
+    }
+
+    public String getClangName() {
+        return clangName;
+    }
+
+    public String getLlvmCpu() {
+        return llvmCpu;
+    }
+
+    public boolean isArm() {
+        return isArm;
+    }
+
+    public boolean is32Bit() {
+        return is32Bit;
+    }
+
+    public ByteOrder getByteOrder() {
+        return byteOrder;
+    }
+
+    public static CpuArch getDefaultArch() {
+        String hostTriple = Target.getHostTriple();
+        if (hostTriple.matches("^(x86.64|amd64).*")) {
+            return CpuArch.x86_64;
+        }
+        if (hostTriple.matches("^(x86|i\\d86).*")) {
+            return CpuArch.x86;
+        }
+        if (hostTriple.matches("^(arm-apple-darwin).*")) {
+            // MacOSX m1 CPU
+            return CpuArch.arm64;
+        }
+        throw new CompilerException("Unrecognized arch in host triple: " + hostTriple);
+    }
+}

--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Environment.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Environment.java
@@ -18,7 +18,14 @@ public enum Environment {
         return llvmName;
     }
 
-    public String asLlvmSuffix(String prefix) {
-        return  (llvmName != null && !llvmName.isEmpty()) ? (prefix + llvmName) : "";
+    public String asLlvmSuffix(String delimiter) {
+        return (llvmName != null && !llvmName.isEmpty()) ? (delimiter + llvmName) : "";
+    }
+
+    public static Environment parse(String s) {
+        for (Environment e: values())
+            if (e.llvmName.equals(s))
+                return e;
+        throw new IllegalArgumentException("Failed to parse Environment with llvmName="+s);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/plugin/debug/DebuggerLaunchPlugin.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/plugin/debug/DebuggerLaunchPlugin.java
@@ -101,7 +101,7 @@ public class DebuggerLaunchPlugin extends LaunchPlugin {
         builder.setJdwpClienMode(jdwpClientMode);
         builder.setLogToConsole(logConsole);
         builder.setLogDir(new File(logDir));
-        builder.setArch(DebuggerConfig.Arch.valueOf(target.getArch().name()));
+        builder.setArch(DebuggerConfig.Arch.valueOf(target.getArch().getCpuArch().name()));
 
         // make list of arguments for target
         if (ConsoleTarget.TYPE.equals(target.getType())) {
@@ -121,7 +121,7 @@ public class DebuggerLaunchPlugin extends LaunchPlugin {
             File appDir = new File(config.isSkipInstall() ? config.getTmpDir() : config.getInstallDir(), config.getExecutableName() + ".app");
             builder.setAppfile(new File(appDir, config.getExecutableName()));
 
-            if (IOSTarget.isSimulatorArch(config.getArch(), config.getEnv())) {
+            if (IOSTarget.isSimulatorArch(config.getArch())) {
                 // launching on simulator, it can write down port number to file on local system
                 File hooksPortFile;
                 try {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/plugin/objc/ObjCMemberPlugin.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/plugin/objc/ObjCMemberPlugin.java
@@ -2003,7 +2003,7 @@ public class ObjCMemberPlugin extends AbstractCompilerPlugin {
     }
 
     private void preloadClassesForFramework(Config config, Linker linker, Set<Clazz> classes) {
-        if (FrameworkTarget.TYPE.equals(config.getTargetType())) {
+        if (FrameworkTarget.matches(config.getTargetType())) {
             // for framework target it is required to make list of @CustomClasses to be preloaded
             // once framework is loaded
             // generate byte array of zero terminated string for frameworksupport.m class

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
@@ -745,14 +745,16 @@ public abstract class AbstractTarget implements Target {
     }
 
     protected void doInstall(File installDir, String image, File resourcesDir) throws IOException {
-        File executable;
-        if (!config.getTmpDir().equals(installDir) || !image.equals(config.getExecutableName())) {
-            executable = new File(installDir, image);
-            FileUtils.copyFile(new File(config.getTmpDir(), config.getExecutableName()), executable);
+        File executable = new File(installDir, image);;
+        File f = new File(config.getTmpDir(), config.getExecutableName());
+        if (!f.equals(executable)) {
+            FileUtils.copyFile(f, executable);
             executable.setExecutable(true, false);
-        } else {
-            executable = new File(config.getTmpDir(), config.getExecutableName());
         }
+        doInstall(installDir, executable, resourcesDir);
+    }
+
+    protected void doInstall(File installDir, File executable, File resourcesDir) throws IOException {
         for (File f : config.getOsArchDepLibDir().listFiles()) {
             if (f.getName().matches(".*\\.(so|dylib)(\\.1)?")) {
                 FileUtils.copyFileToDirectory(f, installDir);

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
@@ -43,6 +43,7 @@ import org.robovm.compiler.clazz.Path;
 import org.robovm.compiler.config.AppExtension;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
+import org.robovm.compiler.config.CpuArch;
 import org.robovm.compiler.config.OS;
 import org.robovm.compiler.config.Resource;
 import org.robovm.compiler.config.Resource.Walker;
@@ -680,11 +681,11 @@ public abstract class AbstractTarget implements Target {
         List<String> archesToRemove = new ArrayList<>();
 
         // simulator ones
-        if(archs.contains(Arch.x86.getClangName())) {
-            archesToRemove.add(Arch.x86.getClangName());
+        if(archs.contains(CpuArch.x86.getClangName())) {
+            archesToRemove.add(CpuArch.x86.getClangName());
         }
-        if(archs.contains(Arch.x86_64.getClangName())) {
-            archesToRemove.add(Arch.x86_64.getClangName());
+        if(archs.contains(CpuArch.x86_64.getClangName())) {
+            archesToRemove.add(CpuArch.x86_64.getClangName());
         }
         // also arm64e has to be removed since Xcode10.1
         if (archs.contains("arm64e")) {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ConsoleTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ConsoleTarget.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
+import org.robovm.compiler.config.CpuArch;
 import org.robovm.compiler.config.OS;
 import org.robovm.compiler.util.Executor;
 import org.robovm.compiler.util.io.OpenOnWriteFileOutputStream;
@@ -105,7 +106,7 @@ public class ConsoleTarget extends AbstractTarget {
 
         if (config.getOs() == OS.macosx) {
             ccArgs.add("--target=" + config.getClangTriple());
-            if (config.getArch() == Arch.x86 || config.isDebug()) {
+            if (config.getArch().getCpuArch() == CpuArch.x86 || config.isDebug()) {
                 ccArgs.add("-Wl,-no_pie");
             }
         }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/Target.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/Target.java
@@ -58,15 +58,6 @@ public interface Target {
     Arch getArch();
 
     /**
-     * @return the {@link Environment} this {@link Target} will build for. Used
-     * to differ target with same {@link Arch}.
-     * For ex. Arm64 iOS device and Arm64 m1 iOS simulator
-     */
-    default Environment getEnv() {
-        return Environment.Native;
-    }
-
-    /**
      * Returns a list of the default archs to build for if no archs have been
      * specified in the {@link Config}. Returns an empty list if there are no
      * defaults.

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/framework/FrameworkTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/framework/FrameworkTarget.java
@@ -1,7 +1,6 @@
 package org.robovm.compiler.target.framework;
 
 import com.dd.plist.NSDictionary;
-import com.dd.plist.NSObject;
 import com.dd.plist.PropertyListParser;
 import org.apache.commons.io.FileUtils;
 import org.robovm.compiler.clazz.Path;
@@ -13,27 +12,38 @@ import org.robovm.compiler.config.OS;
 import org.robovm.compiler.target.AbstractTarget;
 import org.robovm.compiler.target.ios.SDK;
 import org.robovm.compiler.util.Executor;
+import org.robovm.compiler.util.ToolchainUtil;
+import org.robovm.compiler.util.XCFrameworkPlist;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.robovm.compiler.target.ios.IOSTarget.isDeviceArch;
 import static org.robovm.compiler.target.ios.IOSTarget.isSimulatorArch;
 
 public class FrameworkTarget extends AbstractTarget {
 
-	public static final String TYPE = "framework";
+	private static final String TYPE = "framework";
+	private static final String XC_TYPE = "xcframework";
+	public static boolean matches(String candidate) {
+		return (candidate.matches(TYPE) || candidate.matches((XC_TYPE)));
+	}
 
     private OS os;
     private Arch arch;
-    private Environment env;
     private SDK sdk;
+	private boolean xcframework;
 
-    public FrameworkTarget() {
+    public FrameworkTarget(String targetType) {
+		this.xcframework = targetType.equals(XC_TYPE);
 	}
 
 	@Override
@@ -77,13 +87,13 @@ public class FrameworkTarget extends AbstractTarget {
 
 		if (os.getFamily() != OS.Family.darwin)
 			throw new IllegalArgumentException("Frameworks can only be built for Darwin platforms");
-		
+
 		if (paramConfig.getInfoPList() == null)
 			throw new IllegalArgumentException("Frameworks must have a Info.plist file");
 		paramConfig.getIosInfoPList().parse(paramConfig.getProperties());
-		
+
 		String sdkVersion = config.getIosSdkVersion();
-        
+
 		List<SDK> sdks = getSDKs();
         if (sdkVersion == null) {
             if (sdks.isEmpty()) {
@@ -103,7 +113,27 @@ public class FrameworkTarget extends AbstractTarget {
             if (sdk == null) {
                 throw new IllegalArgumentException("No SDK found matching version string " + sdkVersion);
             }
-        }		
+        }
+
+		if (!xcframework) {
+			// regular framework
+			// if building for fat binary -- check if it fits (e.g. if there is no arch and os conflict)
+			Set<CpuArch> duplicateCpuArches = config.getArchs().stream()
+					.collect(Collectors.groupingBy(Arch::getCpuArch, Collectors.counting()))
+					.entrySet()
+					.stream().filter(e -> e.getValue() > 1)
+					.map(Map.Entry::getKey)
+					.collect(Collectors.toSet());
+			if (!duplicateCpuArches.isEmpty()) {
+				List<Arch> duplicateArches = config.getArchs().stream()
+						.filter(a -> duplicateCpuArches.contains(a.getCpuArch()))
+						.sorted()
+						.collect(Collectors.toList());
+				throw new IllegalArgumentException("Wrong configuration: unable to create fat framework due duplicate CPU architectures: " +
+						duplicateArches.stream().map(Arch::toString).collect(Collectors.joining(", ")) +
+						". Use xcframework instead.");
+			}
+		}
 	}
 
 	@Override
@@ -126,7 +156,7 @@ public class FrameworkTarget extends AbstractTarget {
 	@Override
 	protected List<String> getTargetCcArgs() {
 		List<String> ccArgs = new ArrayList<String>();
-		
+
 		ccArgs.add("-stdlib=libc++");
 
 		ccArgs.add("--target=" + config.getClangTriple(getMinimumOSVersion()));
@@ -138,7 +168,7 @@ public class FrameworkTarget extends AbstractTarget {
 
 		ccArgs.add("-isysroot");
 		ccArgs.add(sdk.getRoot().getAbsolutePath());
-		
+
 		ccArgs.add("-dynamiclib");
 		ccArgs.add("-single_module");
 		ccArgs.add("-compatibility_version");
@@ -150,7 +180,7 @@ public class FrameworkTarget extends AbstractTarget {
 			ccArgs.add("-read_only_relocs");
 			ccArgs.add("suppress");
 		}
-		
+
 		ccArgs.add("-install_name");
 		ccArgs.add(String.format("@rpath/%s.framework/%s", config.getImageName(), config.getImageName()));
 
@@ -165,47 +195,173 @@ public class FrameworkTarget extends AbstractTarget {
 	}
 
 
+	/**
+	 * Array of arches per one binary. Each entry contains arches that can be
+	 * combined by lipo into single binary.
+	 * Currently, these are separated with by Environment only, e.g.
+	 * [
+	 *     [x86_64, x86, arm64-simulator],   // simulator arches
+	 *     [arm64, thumbv7]                  // native arches
+	 * ]
+	 */
+	private Arch[][] xcFrameworkArches;
+
+	private Arch[][] getXCFrameworkArches() {
+		if (xcFrameworkArches == null) {
+			Map<Environment, List<Map.Entry<Arch, File>>> fatBinaries = new HashMap<>();
+			List<Arch> configArches = config.getArchs();
+			if (configArches.size() == 1) {
+				xcFrameworkArches = new Arch[][]{{configArches.get(0)}};
+			} else {
+				xcFrameworkArches = configArches.stream()
+						.collect(Collectors.groupingBy(Arch::getEnv, Collectors.toList()))
+						.values().stream()
+						.map(arches -> arches.stream().sorted().toArray(Arch[]::new))
+						.toArray(Arch[][]::new);
+			}
+		}
+		return xcFrameworkArches;
+	}
+
+	@Override
+	public void buildFat(Map<Arch, File> slices) throws IOException {
+		// lipo is not able to combine different platform variants of same CpuArch. E.g. macos-arm64, ios-arm64 and
+		// ios-arm64-simulator can't be combined into single binary.
+		// in this case we have to produce multiple fat binaries and create XCFramework
+
+		if (xcframework) {
+            // if building for xcframework -- just split by os and environment and build each library
+			Arch[][] archesInBinaries = getXCFrameworkArches();
+			Map<Arch, File> slicesToConsume = new HashMap<>(slices);
+
+			for (Arch[] archesInBinary: archesInBinaries) {
+				List<File> filesForLipo = new ArrayList<>(archesInBinary.length);
+				for (Arch arch: archesInBinary) {
+					File f = slicesToConsume.remove(arch);
+					if (f == null)
+						throw new IllegalStateException("Required arch " + arch + " is missing in slices!");
+					filesForLipo.add(f);
+				}
+
+				if (archesInBinary.length == 1) {
+					// single file, copy to expected location
+					File f = filesForLipo.get(0);
+					String archDir = archesInBinary[0].toString();
+					File destDir = new File(config.getTmpDir(), archDir);
+					destDir.mkdirs();
+					File destFile = new File(destDir, getExecutable());
+					if (!f.equals(destFile)) {
+						FileUtils.copyFile(f, destFile);
+						destFile.setExecutable(true, false);
+					}
+				} else {
+					// build fat
+					String archDir = Arrays.stream(archesInBinary)
+							.map(Arch::getCpuArch)
+							.map(CpuArch::getClangName)
+							.collect(Collectors.joining("_"));
+					archDir = archDir + archesInBinary[0].getEnv().asLlvmSuffix("-");
+					config.getLogger().info("Building fat binary for archs " + archDir);
+
+					File destDir = new File(config.getTmpDir(), archDir);
+					destDir.mkdirs();
+					File destFile = new File(destDir, getExecutable());
+					ToolchainUtil.lipo(config, destFile, filesForLipo);
+				}
+			}
+		} else {
+            // build fat binary
+            super.buildFat(slices);
+		}
+	}
+
 	@Override
 	protected void doInstall(File installDir, String image, File resourcesDir) throws IOException {
-		File frameworkDir = new File(installDir, image + ".framework");
-		
-		config.getLogger().info("Creating framework: %s", frameworkDir);
-		
+		if (xcframework) {
+			File xcFrameworkDir = new File(installDir, image + ".xcframework");
+			if (xcFrameworkDir.exists())
+				FileUtils.deleteDirectory(xcFrameworkDir);
+			xcFrameworkDir.mkdirs();
+
+			XCFrameworkPlist.Builder builder = new XCFrameworkPlist.Builder();
+
+			config.getLogger().info("Creating framework: %s", xcFrameworkDir);
+			// writing multiple framework copies maintaining xcframework directory structure
+			Arch[][] archesInBinaries = getXCFrameworkArches();
+			for (Arch[] archesInBinary : archesInBinaries) {
+				String identifier;
+				if (archesInBinary.length == 1) {
+					identifier = archesInBinary[0].toString();
+				} else {
+					// build fat
+					identifier = Arrays.stream(archesInBinary)
+							.map(Arch::getCpuArch)
+							.map(CpuArch::getClangName)
+							.collect(Collectors.joining("_"));
+					identifier = identifier + archesInBinary[0].getEnv().asLlvmSuffix("-");
+				}
+				File frameworkArchDir = new File(xcFrameworkDir, identifier);
+				File frameworkDir = new File(frameworkArchDir, image + ".framework");
+				File dsymDir = new File(frameworkArchDir, "dSYMs/" + image + ".dSYM");
+				File executable = new File(new File(config.getTmpDir(), identifier), getExecutable());
+				config.getLogger().info("Creating " + identifier + "framework slice: %s", frameworkDir);
+				installFramework(frameworkDir, dsymDir, executable, image);
+
+
+				XCFrameworkPlist.Library library = new XCFrameworkPlist.Library(identifier,
+						image + ".framework", config.getOs(),
+						Arrays.stream(archesInBinary).map(Arch::getCpuArch).toArray(CpuArch[]::new),
+						archesInBinary[0].getEnv(), "dSYMs");
+				builder.addLibrary(library);
+			}
+
+			XCFrameworkPlist plist = builder.build();
+			File infoPlist = new File(xcFrameworkDir, "Info.plist");
+			config.getLogger().info("Installing XCFramework/Info.plist to: %s", infoPlist);
+			plist.writeTo(infoPlist);
+		} else {
+			// classic framework
+			File executable = new File(new File(config.getTmpDir(), getExecutable()), image);
+			File frameworkDir = new File(installDir, image + ".framework");
+			File dsymDir = new File(installDir, image + ".dSYM");
+			config.getLogger().info("Creating framework: %s", frameworkDir);
+			installFramework(frameworkDir, dsymDir, executable, image);
+		}
+	}
+
+	private void installFramework(File frameworkDir, File dsymDir, File executable, String image) throws IOException {
 		if (frameworkDir.exists())
 			FileUtils.deleteDirectory(frameworkDir);
 		frameworkDir.mkdirs();
-		
+
 		File bundleDir = new File(frameworkDir, image + ".bundle");
 		bundleDir.mkdirs();
-		
+
 		File bundleResourcesDir = new File(bundleDir, "Resources");
 		bundleResourcesDir.mkdirs();
-				
-		super.doInstall(frameworkDir, image, bundleResourcesDir);
-		
-		File frameworkBinaryFile = new File(frameworkDir, image);
-		File dsymDir = new File(installDir, image + ".dSYM");
-		
+
+		super.doInstall(frameworkDir, executable, bundleResourcesDir);
+
 		config.getLogger().info("Creating framework symbol directory: %s", dsymDir);
 		if (dsymDir.exists())
 			FileUtils.deleteDirectory(dsymDir);
 		dsymDir.mkdirs();
-		new Executor(config.getLogger(), "xcrun").args("dsymutil", "-o", dsymDir, frameworkBinaryFile).exec();
-		
+		new Executor(config.getLogger(), "xcrun").args("dsymutil", "-o", dsymDir, executable).exec();
+
 		if (!config.isDebug()) {
-			config.getLogger().info("Striping framework binary: %s", frameworkBinaryFile);
-			new Executor(config.getLogger(), "xcrun").args("strip", "-x", frameworkBinaryFile).exec();
+			config.getLogger().info("Striping framework binary: %s", executable);
+			new Executor(config.getLogger(), "xcrun").args("strip", "-x", executable).exec();
 		}
 		// remove bitcode to minimize binary size if not required
 		if (!config.isEnableBitcode()) {
-			config.getLogger().info("Striping bitcode from binary: %s", frameworkBinaryFile);
-			stripBitcode(frameworkBinaryFile);
+			config.getLogger().info("Striping bitcode from binary: %s", executable);
+			stripBitcode(executable);
 		}
 
 		NSDictionary infoPlist = config.getInfoPList().getDictionary();
 		if (infoPlist.objectForKey("MinimumOSVersion") == null)
 			infoPlist.put("MinimumOSVersion", config.getOs().getMinVersion());
-		
+
 		File infoPlistBin = new File(frameworkDir, "Info.plist");
 		config.getLogger().info("Installing Info.plist to: %s", infoPlistBin);
 		PropertyListParser.saveAsBinary(infoPlist, infoPlistBin);

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/DeviceType.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/DeviceType.java
@@ -21,6 +21,8 @@ import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.robovm.compiler.config.Arch;
+import org.robovm.compiler.config.CpuArch;
+import org.robovm.compiler.config.Environment;
 import org.robovm.compiler.log.Logger;
 import org.robovm.compiler.util.Executor;
 
@@ -52,13 +54,13 @@ public class DeviceType implements Comparable<DeviceType> {
     }
 
     // depending on x86_64 or m1 CPU use different host simulator arches
-    public final static Arch DEFAULT_HOST_ARCH;
+    public final static CpuArch DEFAULT_HOST_ARCH;
     static {
         String archProp = System.getProperty("os.arch").toLowerCase();
         if (archProp.matches("aarch64|arm64")) {
-            DEFAULT_HOST_ARCH = Arch.arm64;
+            DEFAULT_HOST_ARCH = CpuArch.arm64;
         } else {
-            DEFAULT_HOST_ARCH = Arch.x86_64;
+            DEFAULT_HOST_ARCH = CpuArch.x86_64;
         }
     }
 
@@ -196,13 +198,13 @@ public class DeviceType implements Comparable<DeviceType> {
                         Set<Arch> archs = new HashSet<>();
                         if (!Arrays.asList(ONLY_32BIT_DEVICES).contains(deviceName)) {
                             // This is assumption that on M1 ios versions starting from ios14 can run arm64 target
-                            if (DEFAULT_HOST_ARCH == Arch.arm64 && version.isSameOrBetter(ARM64_IOS_VERSION))
-                                archs.add(Arch.arm64);
-                            archs.add(Arch.x86_64);
+                            if (DEFAULT_HOST_ARCH == CpuArch.arm64 && version.isSameOrBetter(ARM64_IOS_VERSION))
+                                archs.add(new Arch(CpuArch.arm64, Environment.Simulator));
+                            archs.add(new Arch(CpuArch.x86_64, Environment.Simulator));
                         }
-                        if (DEFAULT_HOST_ARCH != Arch.arm64 && !version.isSameOrBetter(ONLY_64BIT_IOS_VERSION)) {
+                        if (DEFAULT_HOST_ARCH != CpuArch.arm64 && !version.isSameOrBetter(ONLY_64BIT_IOS_VERSION)) {
                             // 32 bit device. not supported on Arm
-                            archs.add(Arch.x86);
+                            archs.add(new Arch(CpuArch.x86, Environment.Simulator));
                         }
 
                         String udid = device.get("udid").toString();

--- a/compiler/compiler/src/main/java/org/robovm/compiler/util/ToolchainUtil.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/util/ToolchainUtil.java
@@ -17,23 +17,22 @@
  */
 package org.robovm.compiler.util;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import org.apache.commons.exec.ExecuteException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
-import org.robovm.compiler.config.Environment;
+import org.robovm.compiler.config.CpuArch;
 import org.robovm.compiler.config.OS;
 import org.robovm.compiler.config.tools.TextureAtlas;
 import org.robovm.compiler.log.ConsoleLogger;
 import org.robovm.compiler.log.Logger;
 import org.robovm.compiler.target.ios.IOSTarget;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * @author niklas
@@ -256,9 +255,9 @@ public class ToolchainUtil {
         }
 
         opts.add("--platform");
-        if (IOSTarget.isDeviceArch(config.getArch(), config.getEnv())) {
+        if (IOSTarget.isDeviceArch(config.getArch())) {
             opts.add("iphoneos");
-        } else if (IOSTarget.isSimulatorArch(config.getArch(), config.getEnv())) {
+        } else if (IOSTarget.isSimulatorArch(config.getArch())) {
             opts.add("iphonesimulator");
         }
 
@@ -415,7 +414,7 @@ public class ToolchainUtil {
         if (config.getCcBinPath() != null) {
             ccPath = config.getCcBinPath().getAbsolutePath();
         } else if (config.getOs() == OS.ios) {
-            if (config.getArch() == Arch.x86) {
+            if (config.getArch().getCpuArch() == CpuArch.x86) {
                 ccPath = getIOSSimClang();
             } else {
                 ccPath = getIOSDevClang();

--- a/compiler/compiler/src/main/java/org/robovm/compiler/util/XCFrameworkPlist.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/util/XCFrameworkPlist.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.compiler.util;
+
+import com.dd.plist.NSArray;
+import com.dd.plist.NSDictionary;
+import com.dd.plist.NSObject;
+import com.dd.plist.PropertyListParser;
+import org.robovm.compiler.config.CpuArch;
+import org.robovm.compiler.config.Environment;
+import org.robovm.compiler.config.OS;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Reads/Writes .xcframework/Info.plist
+ */
+public class XCFrameworkPlist {
+    private static final String KEY_AVAILABLE_LIBRARIES = "AvailableLibraries";
+    private static final String KEY_LIBRARY_IDENTIFIER = "LibraryIdentifier";
+    private static final String KEY_LIBRARY_PATH = "LibraryPath";
+    private static final String KEY_SUPPORTED_ARCHITECTURES = "SupportedArchitectures";
+    private static final String KEY_SUPPORTED_PLATFORM = "SupportedPlatform";
+    private static final String KEY_SUPPORTED_PLATFORM_VARIANT = "SupportedPlatformVariant";
+    private static final String KEY_DEBUG_SYMBOLS_PATH = "DebugSymbolsPath";
+    private static final String KEY_CFBUNDLE_PACKAGE_TYPE = "CFBundlePackageType";
+    private static final String KEY_XCFRAMEWORK_FORMAT_VERSION = "XCFrameworkFormatVersion";
+
+    private final Library[] availableLibraries;
+
+    public XCFrameworkPlist(Library[] availableLibraries) {
+        this.availableLibraries = availableLibraries;
+    }
+
+    public Library[] getAvailableLibraries() {
+        return availableLibraries;
+    }
+
+    public static class Library {
+        private final String identifier;
+        private final String path;
+        private final OS platform;
+        private final CpuArch[] supportedArchitectures;
+        private final Environment variant;
+        private final String debugSymbolPath;
+
+        public Library(String identifier, String path, OS platform, CpuArch[] supportedArchitectures,
+                       Environment variant, String debugSymbolPath) {
+            this.identifier = identifier;
+            this.path = path;
+            this.platform = platform;
+            this.supportedArchitectures = supportedArchitectures;
+            this.variant = variant;
+            this.debugSymbolPath = debugSymbolPath;
+        }
+
+        public String getIdentifier() {
+            return identifier;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public OS getPlatform() {
+            return platform;
+        }
+
+        public CpuArch[] getSupportedArchitectures() {
+            return supportedArchitectures;
+        }
+
+        public Environment getVariant() {
+            return variant;
+        }
+    }
+
+    public static class Builder {
+        private final List<Library> libraries = new ArrayList<>();
+
+        public Builder addLibrary(Library lib) {
+            libraries.add(lib);
+            return this;
+        }
+
+        public XCFrameworkPlist build() {
+            return new XCFrameworkPlist(libraries.toArray(new Library[0]));
+        }
+    }
+
+    /**
+     * Builds plist and writes to file
+     */
+    public void writeTo(File infoPlistFile) throws IOException {
+        // construct plist object
+        NSDictionary plist = new NSDictionary();
+        if (availableLibraries.length > 0) {
+            NSArray arrayLibs = new NSArray(availableLibraries.length);
+            for (int libIdx = 0; libIdx < availableLibraries.length; libIdx++) {
+                Library lib = availableLibraries[libIdx];
+
+                NSDictionary dictLib = new NSDictionary();
+                dictLib.put(KEY_LIBRARY_IDENTIFIER, lib.identifier);
+                dictLib.put(KEY_LIBRARY_PATH, lib.path);
+                dictLib.put(KEY_SUPPORTED_PLATFORM, lib.platform.toString());
+                if (lib.variant != Environment.Native)
+                    dictLib.put(KEY_SUPPORTED_PLATFORM_VARIANT, lib.variant.getLlvmName());
+                if (lib.debugSymbolPath != null)
+                    dictLib.put(KEY_DEBUG_SYMBOLS_PATH, lib.debugSymbolPath);
+                NSArray arrayArches = new NSArray(lib.supportedArchitectures.length);
+                for (int archIdx = 0; archIdx < lib.supportedArchitectures.length; archIdx++)
+                    arrayArches.setValue(archIdx, lib.supportedArchitectures[archIdx].getClangName());
+                dictLib.put(KEY_SUPPORTED_ARCHITECTURES, arrayArches);
+
+                arrayLibs.setValue(libIdx, dictLib);
+            }
+            plist.put(KEY_AVAILABLE_LIBRARIES, arrayLibs);
+            plist.put(KEY_CFBUNDLE_PACKAGE_TYPE, "XFWK");
+            plist.put(KEY_XCFRAMEWORK_FORMAT_VERSION, "1.0");
+        }
+
+        PropertyListParser.saveAsXML(plist, infoPlistFile);
+    }
+
+    /**
+     * Parses XCFramework structure from plist
+     */
+    public static XCFrameworkPlist load(File f) throws IOException {
+        try {
+            List<Library> libraries = new ArrayList<>();
+            NSDictionary plist = (NSDictionary) PropertyListParser.parse(f);
+            NSArray arrayLibs = (NSArray) plist.get(KEY_AVAILABLE_LIBRARIES);
+            for (NSObject o: arrayLibs.getArray()) {
+                // if something failed -- just ignore the entry
+                try {
+                    // pick values
+                    NSDictionary dictLib = (NSDictionary) o;
+                    String identifier = dictLib.get(KEY_LIBRARY_IDENTIFIER).toString();
+                    String libraryPath = dictLib.get(KEY_LIBRARY_PATH).toString();
+                    String supportedPlatform = dictLib.get(KEY_SUPPORTED_PLATFORM).toString();
+                    String supportedPlatformVariant = dictLib.get(KEY_SUPPORTED_PLATFORM_VARIANT).toString();
+                    String debugSymbolsPath = dictLib.get(KEY_DEBUG_SYMBOLS_PATH).toString();
+                    NSArray arrayArches = (NSArray) dictLib.get(KEY_SUPPORTED_ARCHITECTURES);
+
+                    // parse
+                    OS os = OS.valueOf(supportedPlatform);
+                    Environment env = supportedPlatformVariant != null ? Environment.parse(supportedPlatformVariant)
+                            : Environment.Native;
+                    Set<CpuArch> arches = new LinkedHashSet<>();
+                    for (NSObject archO: arrayArches.getArray()) {
+                        CpuArch arch = parse(archO.toString());
+                        if (arch != null)
+                            arches.add(arch);
+                    }
+
+                    // if there are all object add library
+                    if (!arches.isEmpty())
+                        libraries.add(new Library(identifier, libraryPath, os, arches.toArray(new CpuArch[0]), env,
+                                debugSymbolsPath));
+                } catch (Throwable ignored) {
+                }
+            }
+
+            return new XCFrameworkPlist(libraries.toArray(new Library[0]));
+        } catch (IOException e) {
+            throw e;
+        } catch (Throwable t) {
+            throw new IOException(t);
+        }
+    }
+
+    private static CpuArch parse(String s) {
+        for (CpuArch v: CpuArch.values())
+            if (s.equals(v.getClangName()))
+                return v;
+        return null;
+    }
+}

--- a/compiler/compiler/src/main/java/org/robovm/compiler/util/io/RamDiskTools.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/util/io/RamDiskTools.java
@@ -16,17 +16,10 @@
  */
 package org.robovm.compiler.util.io;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.FileStore;
-import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.List;
-
+import com.dd.plist.NSDictionary;
+import com.dd.plist.NSNumber;
+import com.dd.plist.NSObject;
+import com.dd.plist.PropertyListParser;
 import org.apache.commons.io.FileUtils;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
@@ -34,10 +27,15 @@ import org.robovm.compiler.config.OS;
 import org.robovm.compiler.log.Logger;
 import org.robovm.compiler.util.Executor;
 
-import com.dd.plist.NSDictionary;
-import com.dd.plist.NSNumber;
-import com.dd.plist.NSObject;
-import com.dd.plist.PropertyListParser;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
 
 /**
  * Will modify cache and tmpdir paths given a {@link Config#builder()} and prun
@@ -179,10 +177,10 @@ public class RamDiskTools {
 
         // Enumerate all directories that are not our current cache
         // dir
-        List<CacheDir> cacheDirs = new ArrayList<CacheDir>();
+        List<CacheDir> cacheDirs = new ArrayList<>();
         for (OS os : OS.values()) {
-            for (Arch arch : Arch.values()) {
-                for (boolean isDebug : new boolean[] { false, true }) {
+            for (Arch arch : Arch.supported(os)) {
+                for (boolean isDebug : new boolean[]{false, true}) {
                     CacheDir cacheDir = constructCacheDir(volume, os, arch, isDebug);
                     if (cacheDir != null && (currCacheDir == null || !cacheDir.directory.equals(currCacheDir.directory))) {
                         cacheDirs.add(cacheDir);
@@ -229,14 +227,9 @@ public class RamDiskTools {
                 + (isDebug ? "debug" : "release"));
         if (!dir.exists())
             return null;
-        List<File> objFiles = new ArrayList<File>((Collection<File>) FileUtils.listFiles(dir, new String[] { "o" },
+        List<File> objFiles = new ArrayList<>(FileUtils.listFiles(dir, new String[]{"o"},
                 true));
-        Collections.sort(objFiles, new Comparator<File>() {
-            @Override
-            public int compare(File f1, File f2) {
-                return new Date(f2.lastModified()).compareTo(new Date(f1.lastModified()));
-            }
-        });
+        objFiles.sort((f1, f2) -> new Date(f2.lastModified()).compareTo(new Date(f1.lastModified())));
         long lastModified = 0;
         for (File file : objFiles) {
             lastModified = Math.max(lastModified, file.lastModified());

--- a/compiler/compiler/src/test/java/org/robovm/compiler/config/ConfigTest.java
+++ b/compiler/compiler/src/test/java/org/robovm/compiler/config/ConfigTest.java
@@ -176,7 +176,7 @@ public class ConfigTest {
         Config.Lib lib1 = new Config.Lib("ios_arm64", true, new OS[]{OS.ios},
                 new PlatformVariant[]{PlatformVariant.device}, new Arch[]{Arch.arm64} );
         Config.Lib lib2 = new Config.Lib("iossim_arm64", true, new OS[]{OS.ios},
-                new PlatformVariant[]{PlatformVariant.simulator}, new Arch[]{Arch.arm64} );
+                new PlatformVariant[]{PlatformVariant.simulator}, new Arch[]{Arch.arm64.copy(Environment.Simulator)} );
         Config.Lib lib3 = new Config.Lib("mac_arm64", true, new OS[]{OS.macosx},
                 new PlatformVariant[]{PlatformVariant.device}, new Arch[]{Arch.arm64} );
         builder.addLib(lib1);
@@ -186,21 +186,18 @@ public class ConfigTest {
         // case 1
         builder.os(OS.ios);
         builder.archs(Arch.arm64);
-        builder.env(Environment.Native);
         Config config = builder.build();
         assertEquals(Collections.singletonList(lib1), config.getLibs());
 
         // case 2
         builder.os(OS.ios);
-        builder.archs(Arch.arm64);
-        builder.env(Environment.Simulator);
+        builder.archs(Arch.arm64.copy(Environment.Simulator));
         config = builder.build();
         assertEquals(Collections.singletonList(lib2), config.getLibs());
 
         // case 3
         builder.os(OS.macosx);
         builder.archs(Arch.arm64);
-        builder.env(Environment.Native);
         config = builder.build();
         assertEquals(Collections.singletonList(lib3), config.getLibs());
     }
@@ -208,7 +205,7 @@ public class ConfigTest {
     private File createMergeConfig(File tmpDir, String dir, String id, OS os, Arch arch, boolean jar) throws Exception {
         File p = new File(tmpDir, dir);
         for (OS os2 : OS.values()) {
-            for (Arch arch2 : Arch.values()) {
+            for (Arch arch2 : Arch.supported(os2)) {
                 File root = new File(p, "META-INF/robovm/" + os2 + "/" + arch2);
                 root.mkdirs();
                 if (!new File(root, "robovm.xml").exists()) {

--- a/plugins/eclipse/ui/src/org/robovm/eclipse/RoboVMPlugin.java
+++ b/plugins/eclipse/ui/src/org/robovm/eclipse/RoboVMPlugin.java
@@ -81,6 +81,7 @@ import org.osgi.framework.BundleContext;
 import org.robovm.compiler.Version;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
+import org.robovm.compiler.config.CpuArch;
 import org.robovm.compiler.config.OS;
 import org.robovm.compiler.config.Resource;
 import org.robovm.compiler.log.Logger;
@@ -106,23 +107,24 @@ public class RoboVMPlugin extends AbstractUIPlugin implements IStartup {
     public static final String IMAGE_NEW_IOS_VIEW_CONTROLLER_BANNER = PLUGIN_ID + ".image.newIOSViewControllerBanner";
     public static final String IMAGE_NEW_IOS_VIEW_BANNER = PLUGIN_ID + ".image.newIOSViewBanner";
 
-    public static final Arch[] ALL_ARCH_VALUES = new Arch[] { Arch.thumbv7, Arch.arm64, Arch.x86, Arch.x86_64 };
+    public static final CpuArch[] ALL_ARCH_VALUES = new CpuArch[] { CpuArch.thumbv7, CpuArch.arm64, CpuArch.x86, CpuArch.x86_64 };
     public static final String[] ALL_ARCH_NAMES =
             new String[] {
-                "32-bit ARM (" + Arch.thumbv7 + ")",
-                "64-bit ARM (" + Arch.arm64 + ")",
-                "32-bit x86 (" + Arch.x86 + ")",
-                "64-bit x86 (" + Arch.x86_64 + ")" };
-    public static final Arch[] IOS_DEVICE_ARCH_VALUES = new Arch[] { Arch.thumbv7, Arch.arm64 };
+                "32-bit ARM (" + CpuArch.thumbv7 + ")",
+                "64-bit ARM (" + CpuArch.arm64 + ")",
+                "32-bit x86 (" + CpuArch.x86 + ")",
+                "64-bit x86 (" + CpuArch.x86_64 + ")" };
+    public static final CpuArch[] IOS_DEVICE_ARCH_VALUES = new CpuArch[] { CpuArch.thumbv7, CpuArch.arm64 };
     public static final String[] IOS_DEVICE_ARCH_NAMES =
             new String[] {
-                "32-bit (" + Arch.thumbv7 + ")",
-                "64-bit (" + Arch.arm64 + ")" };
-    public static final Arch[] IOS_SIM_ARCH_VALUES = new Arch[] { Arch.x86, Arch.x86_64 };
+                "32-bit (" + CpuArch.thumbv7 + ")",
+                "64-bit (" + CpuArch.arm64 + ")" };
+    public static final CpuArch[] IOS_SIM_ARCH_VALUES = new CpuArch[] { CpuArch.x86, CpuArch.x86_64, CpuArch.arm64 };
     public static final String[] IOS_SIM_ARCH_NAMES =
             new String[] {
-                "32-bit (" + Arch.x86 + ")",
-                "64-bit (" + Arch.x86_64 + ")" };
+                "32-bit (" + CpuArch.x86 + ")",
+                "64-bit (" + CpuArch.x86_64 + ")",
+                "64-bit (" + CpuArch.arm64 + ")" };
 
     private static RoboVMPlugin plugin;
     private static IPreferenceStore pluginPreferencesStore;
@@ -475,15 +477,15 @@ public class RoboVMPlugin extends AbstractUIPlugin implements IStartup {
         return digest.digest();
     }
 
-    public static Arch getDefaultArch() {
-        return Arch.getDefaultArch();
+    public static CpuArch getDefaultArch() {
+        return CpuArch.getDefaultArch();
     }
 
-    public static Arch getArch(String s) {
+    public static CpuArch getArch(String s) {
         if (ARCH_AUTO.equals(s)) {
             return getDefaultArch();
         }
-        return Arch.valueOf(s);
+        return CpuArch.valueOf(s);
     }
 
     public static OS getDefaultOS() {

--- a/plugins/eclipse/ui/src/org/robovm/eclipse/internal/ConsoleLaunchConfigurationDelegate.java
+++ b/plugins/eclipse/ui/src/org/robovm/eclipse/internal/ConsoleLaunchConfigurationDelegate.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
+import org.robovm.compiler.config.Environment;
 import org.robovm.compiler.config.OS;
 import org.robovm.compiler.target.ConsoleTarget;
 import org.robovm.eclipse.RoboVMPlugin;
@@ -36,7 +37,7 @@ public class ConsoleLaunchConfigurationDelegate extends AbstractLaunchConfigurat
 
     @Override
     protected Arch getArch(ILaunchConfiguration configuration, String mode) {
-        return RoboVMPlugin.getDefaultArch();
+        return new Arch(RoboVMPlugin.getDefaultArch(), Environment.Native);
     }
 
     @Override

--- a/plugins/eclipse/ui/src/org/robovm/eclipse/internal/IOSDeviceLaunchConfigurationDelegate.java
+++ b/plugins/eclipse/ui/src/org/robovm/eclipse/internal/IOSDeviceLaunchConfigurationDelegate.java
@@ -22,6 +22,8 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
+import org.robovm.compiler.config.CpuArch;
+import org.robovm.compiler.config.Environment;
 import org.robovm.compiler.config.OS;
 import org.robovm.compiler.target.ios.IOSTarget;
 import org.robovm.compiler.target.ios.ProvisioningProfile;
@@ -45,16 +47,16 @@ public class IOSDeviceLaunchConfigurationDelegate extends AbstractLaunchConfigur
 
     public static final String SIGNING_ID_SKIP_SIGNING = "SkipSigning";
 
-    public static final Arch DEFAULT_ARCH = Arch.thumbv7;
+    public static final CpuArch DEFAULT_ARCH = CpuArch.arm64;
 
     @Override
     protected Arch getArch(ILaunchConfiguration configuration, String mode) throws CoreException {
-        Arch arch = DEFAULT_ARCH;
+    	CpuArch arch = DEFAULT_ARCH;
         try {
-            arch = Arch.valueOf(configuration.getAttribute(ATTR_IOS_DEVICE_ARCH, DEFAULT_ARCH.toString()));
+            arch = CpuArch.valueOf(configuration.getAttribute(ATTR_IOS_DEVICE_ARCH, DEFAULT_ARCH.toString()));
         } catch (Throwable t) {
         }
-        return arch;
+        return new Arch(arch, Environment.Native);
     }
 
     @Override

--- a/plugins/eclipse/ui/src/org/robovm/eclipse/internal/IOSDeviceLaunchConfigurationTabGroup.java
+++ b/plugins/eclipse/ui/src/org/robovm/eclipse/internal/IOSDeviceLaunchConfigurationTabGroup.java
@@ -38,6 +38,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.robovm.compiler.config.Arch;
+import org.robovm.compiler.config.CpuArch;
 import org.robovm.compiler.target.ios.ProvisioningProfile;
 import org.robovm.compiler.target.ios.SigningIdentity;
 import org.robovm.eclipse.RoboVMPlugin;
@@ -61,7 +62,7 @@ public class IOSDeviceLaunchConfigurationTabGroup extends AbstractLaunchConfigur
     }
 
     public static class DeviceTab extends RoboVMTab {
-        private static final Arch[] POSSIBLE_ARCH_VALUES = RoboVMPlugin.IOS_DEVICE_ARCH_VALUES;
+        private static final CpuArch[] POSSIBLE_ARCH_VALUES = RoboVMPlugin.IOS_DEVICE_ARCH_VALUES;
         private static final String[] POSSIBLE_ARCH_NAMES = RoboVMPlugin.IOS_DEVICE_ARCH_NAMES;
 
         private List<SigningIdentity> signingIdentities;
@@ -202,7 +203,7 @@ public class IOSDeviceLaunchConfigurationTabGroup extends AbstractLaunchConfigur
             }
             
             try {
-                Arch v = Arch.valueOf(config.getAttribute(IOSDeviceLaunchConfigurationDelegate.ATTR_IOS_DEVICE_ARCH,
+            	CpuArch v = CpuArch.valueOf(config.getAttribute(IOSDeviceLaunchConfigurationDelegate.ATTR_IOS_DEVICE_ARCH,
                         IOSDeviceLaunchConfigurationDelegate.DEFAULT_ARCH.toString()));
                 int idx = Arrays.asList(POSSIBLE_ARCH_VALUES).indexOf(v);
                 if (idx != -1) {
@@ -233,7 +234,7 @@ public class IOSDeviceLaunchConfigurationTabGroup extends AbstractLaunchConfigur
             wc.setAttribute(IOSDeviceLaunchConfigurationDelegate.ATTR_IOS_DEVICE_PROVISIONING_PROFILE, 
                     profile != null ? profile.getUuid() : null);
 
-            Arch arch = POSSIBLE_ARCH_VALUES[archCombo.getSelectionIndex()];
+            CpuArch arch = POSSIBLE_ARCH_VALUES[archCombo.getSelectionIndex()];
             wc.setAttribute(IOSDeviceLaunchConfigurationDelegate.ATTR_IOS_DEVICE_ARCH, arch.toString());
         }
 

--- a/plugins/eclipse/ui/src/org/robovm/eclipse/internal/IOSSimulatorLaunchConfigurationDelegate.java
+++ b/plugins/eclipse/ui/src/org/robovm/eclipse/internal/IOSSimulatorLaunchConfigurationDelegate.java
@@ -22,6 +22,8 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
+import org.robovm.compiler.config.CpuArch;
+import org.robovm.compiler.config.Environment;
 import org.robovm.compiler.config.OS;
 import org.robovm.compiler.target.LaunchParameters;
 import org.robovm.compiler.target.ios.DeviceType;
@@ -39,16 +41,16 @@ public class IOSSimulatorLaunchConfigurationDelegate extends AbstractLaunchConfi
     public static final String TYPE_NAME = "iOS Simulator App";
     public static final String ATTR_IOS_SIM_DEVICE_TYPE = RoboVMPlugin.PLUGIN_ID + ".IOS_SIM_DEVICE_TYPE";
     public static final String ATTR_IOS_SIM_ARCH = RoboVMPlugin.PLUGIN_ID + ".IOS_SIM_ARCH";
-    public static final Arch DEFAULT_ARCH = Arch.x86;
+    public static final CpuArch DEFAULT_ARCH = CpuArch.x86_64;
 
     @Override
     protected Arch getArch(ILaunchConfiguration configuration, String mode) throws CoreException {
-        Arch arch = DEFAULT_ARCH;
+    	CpuArch arch = DEFAULT_ARCH;
         try {
-            arch = Arch.valueOf(configuration.getAttribute(ATTR_IOS_SIM_ARCH, DEFAULT_ARCH.toString()));
+            arch = CpuArch.valueOf(configuration.getAttribute(ATTR_IOS_SIM_ARCH, DEFAULT_ARCH.toString()));
         } catch (Throwable t) {
         }
-        return arch;
+        return new Arch(arch, Environment.Simulator);
     }
 
     @Override

--- a/plugins/eclipse/ui/src/org/robovm/eclipse/internal/IOSSimulatorLaunchConfigurationTabGroup.java
+++ b/plugins/eclipse/ui/src/org/robovm/eclipse/internal/IOSSimulatorLaunchConfigurationTabGroup.java
@@ -38,6 +38,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.robovm.compiler.config.Arch;
+import org.robovm.compiler.config.CpuArch;
 import org.robovm.compiler.target.ios.DeviceType;
 import org.robovm.eclipse.RoboVMPlugin;
 
@@ -60,7 +61,7 @@ public class IOSSimulatorLaunchConfigurationTabGroup extends AbstractLaunchConfi
     }
 
     public static class SimulatorTab extends RoboVMTab {
-        private static final Arch[] POSSIBLE_ARCH_VALUES = RoboVMPlugin.IOS_SIM_ARCH_VALUES;
+        private static final CpuArch[] POSSIBLE_ARCH_VALUES = RoboVMPlugin.IOS_SIM_ARCH_VALUES;
         private static final String[] POSSIBLE_ARCH_NAMES = RoboVMPlugin.IOS_SIM_ARCH_NAMES;
         
         private final boolean showProject;
@@ -142,11 +143,11 @@ public class IOSSimulatorLaunchConfigurationTabGroup extends AbstractLaunchConfi
             List<String> availableArchs = new ArrayList<String>();
             int prefArchIndex = 0;
             for(int i = 0; i < RoboVMPlugin.IOS_SIM_ARCH_VALUES.length; i++) {
-                Arch arch = RoboVMPlugin.IOS_SIM_ARCH_VALUES[i];
+                CpuArch arch = RoboVMPlugin.IOS_SIM_ARCH_VALUES[i];
                 for(Arch simArch: type.getArchs()) {
-                    if(arch == simArch) {
+                    if(arch == simArch.getCpuArch()) {
                         availableArchs.add(POSSIBLE_ARCH_NAMES[i]);
-                        if(simArch == IOSSimulatorLaunchConfigurationDelegate.DEFAULT_ARCH) {
+                        if(simArch.getCpuArch() == IOSSimulatorLaunchConfigurationDelegate.DEFAULT_ARCH) {
                             prefArchIndex = availableArchs.size() - 1;
                         }
                         break;
@@ -180,7 +181,7 @@ public class IOSSimulatorLaunchConfigurationTabGroup extends AbstractLaunchConfi
             }
             
             try {
-                Arch v = Arch.valueOf(config.getAttribute(IOSSimulatorLaunchConfigurationDelegate.ATTR_IOS_SIM_ARCH,
+                CpuArch v = CpuArch.valueOf(config.getAttribute(IOSSimulatorLaunchConfigurationDelegate.ATTR_IOS_SIM_ARCH,
                         IOSSimulatorLaunchConfigurationDelegate.DEFAULT_ARCH.toString()));
                 int idx = Arrays.asList(POSSIBLE_ARCH_VALUES).indexOf(v);
                 if (idx != -1) {
@@ -197,7 +198,7 @@ public class IOSSimulatorLaunchConfigurationTabGroup extends AbstractLaunchConfi
             super.performApply(wc);
             String selection = deviceTypeCombo.getItem(deviceTypeCombo.getSelectionIndex());
             wc.setAttribute(IOSSimulatorLaunchConfigurationDelegate.ATTR_IOS_SIM_DEVICE_TYPE, selection);
-            Arch arch = POSSIBLE_ARCH_VALUES[archCombo.getSelectionIndex()];
+            CpuArch arch = POSSIBLE_ARCH_VALUES[archCombo.getSelectionIndex()];
             wc.setAttribute(IOSSimulatorLaunchConfigurationDelegate.ATTR_IOS_SIM_ARCH, arch.toString());
         }
 

--- a/plugins/eclipse/ui/src/org/robovm/eclipse/internal/NewProjectWizard.java
+++ b/plugins/eclipse/ui/src/org/robovm/eclipse/internal/NewProjectWizard.java
@@ -187,15 +187,8 @@ public class NewProjectWizard extends Wizard implements INewWizard {
             };
         }
 
-        @Override
-        protected Control createJRESelectionControl(Composite composite) {
-            // Hide the JRE selection control
-            Label l = new Label(composite, NONE);
-            l.setSize(1, 1);
-            return l;
-        }
 
-        @Override
+		@Override
         protected Control createInfoControl(Composite composite) {
             addCustomControls(composite);
             return super.createInfoControl(composite);

--- a/plugins/eclipse/ui/src/org/robovm/eclipse/internal/actions/CreateIPAAction.java
+++ b/plugins/eclipse/ui/src/org/robovm/eclipse/internal/actions/CreateIPAAction.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
@@ -44,6 +45,8 @@ import org.eclipse.ui.IWorkbenchPart;
 import org.robovm.compiler.AppCompiler;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
+import org.robovm.compiler.config.CpuArch;
+import org.robovm.compiler.config.Environment;
 import org.robovm.compiler.config.OS;
 import org.robovm.compiler.target.ios.ProvisioningProfile;
 import org.robovm.compiler.target.ios.SigningIdentity;
@@ -83,7 +86,7 @@ public class CreateIPAAction implements IObjectActionDelegate {
         final String destDir = dialog.getDestinationDir();
         final String signingIdentity = dialog.getSigningIdentity();
         final String provisioningProfile = dialog.getProvisioningProfile();
-        final List<Arch> archs = dialog.getArchs();
+        final List<Arch> archs = dialog.getArchs().stream().map(a -> new Arch(a, Environment.Native)).collect(Collectors.toList());
 
         new Job("Package for App Store/Ad-Hoc distribution") {
 

--- a/plugins/eclipse/ui/src/org/robovm/eclipse/internal/actions/CreateIPADialog.java
+++ b/plugins/eclipse/ui/src/org/robovm/eclipse/internal/actions/CreateIPADialog.java
@@ -45,6 +45,7 @@ import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.robovm.compiler.config.Arch;
+import org.robovm.compiler.config.CpuArch;
 import org.robovm.compiler.target.ios.ProvisioningProfile;
 import org.robovm.compiler.target.ios.SigningIdentity;
 import org.robovm.eclipse.RoboVMPlugin;
@@ -54,16 +55,16 @@ import org.robovm.eclipse.RoboVMPlugin;
  */
 public class CreateIPADialog extends TitleAreaDialog {
 
-    private static final Arch[][] POSSIBLE_ARCH_VALUES;
+    private static final CpuArch[][] POSSIBLE_ARCH_VALUES;
     private static final String[] POSSIBLE_ARCH_NAMES;
 
     static {
-        POSSIBLE_ARCH_VALUES = new Arch[RoboVMPlugin.IOS_DEVICE_ARCH_VALUES.length + 1][];
+        POSSIBLE_ARCH_VALUES = new CpuArch[RoboVMPlugin.IOS_DEVICE_ARCH_VALUES.length + 1][];
         POSSIBLE_ARCH_NAMES = new String[RoboVMPlugin.IOS_DEVICE_ARCH_NAMES.length + 1];
         POSSIBLE_ARCH_VALUES[0] = RoboVMPlugin.IOS_DEVICE_ARCH_VALUES;
         POSSIBLE_ARCH_NAMES[0] = "All - " + join(RoboVMPlugin.IOS_DEVICE_ARCH_NAMES);
         for (int i = 0; i < RoboVMPlugin.IOS_DEVICE_ARCH_VALUES.length; i++) {
-            POSSIBLE_ARCH_VALUES[i + 1] = new Arch[] {RoboVMPlugin.IOS_DEVICE_ARCH_VALUES[i]}; 
+            POSSIBLE_ARCH_VALUES[i + 1] = new CpuArch[] {RoboVMPlugin.IOS_DEVICE_ARCH_VALUES[i]}; 
             POSSIBLE_ARCH_NAMES[i + 1] = RoboVMPlugin.IOS_DEVICE_ARCH_NAMES[i]; 
         }
     }
@@ -88,13 +89,13 @@ public class CreateIPADialog extends TitleAreaDialog {
     private String destinationDir;
     private String signingIdentity;
     private String provisioningProfile;
-    private List<Arch> archs;
+    private List<CpuArch> archs;
 
     private List<ProvisioningProfile> provisioningProfiles;
     
     public CreateIPADialog(Shell parentShell) {
         super(parentShell);
-        archs = new ArrayList<Arch>(Arrays.asList(RoboVMPlugin.IOS_DEVICE_ARCH_VALUES));
+        archs = new ArrayList<>(Arrays.asList(RoboVMPlugin.IOS_DEVICE_ARCH_VALUES));
     }
 
     @Override
@@ -280,7 +281,7 @@ public class CreateIPADialog extends TitleAreaDialog {
         return provisioningProfile;
     }
     
-    public List<Arch> getArchs() {
+    public List<CpuArch> getArchs() {
         return archs;
     }
     

--- a/plugins/eclipse/ui/src/org/robovm/eclipse/internal/junit/ConsoleJUnitLaunchConfigurationDelegate.java
+++ b/plugins/eclipse/ui/src/org/robovm/eclipse/internal/junit/ConsoleJUnitLaunchConfigurationDelegate.java
@@ -22,6 +22,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
+import org.robovm.compiler.config.Environment;
 import org.robovm.compiler.config.OS;
 import org.robovm.compiler.target.ConsoleTarget;
 import org.robovm.eclipse.RoboVMPlugin;
@@ -35,7 +36,7 @@ public class ConsoleJUnitLaunchConfigurationDelegate extends AbstractJUnitLaunch
 
     @Override
     protected Arch getArch(ILaunchConfiguration configuration, String mode) {
-        return RoboVMPlugin.getDefaultArch();
+        return new Arch(RoboVMPlugin.getDefaultArch(), Environment.Native);
     }
 
     @Override

--- a/plugins/eclipse/ui/src/org/robovm/eclipse/internal/junit/IOSSimulatorJUnitLaunchConfigurationDelegate.java
+++ b/plugins/eclipse/ui/src/org/robovm/eclipse/internal/junit/IOSSimulatorJUnitLaunchConfigurationDelegate.java
@@ -22,6 +22,8 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
+import org.robovm.compiler.config.CpuArch;
+import org.robovm.compiler.config.Environment;
 import org.robovm.compiler.config.OS;
 import org.robovm.compiler.target.LaunchParameters;
 import org.robovm.compiler.target.ios.DeviceType;
@@ -38,16 +40,16 @@ public class IOSSimulatorJUnitLaunchConfigurationDelegate extends AbstractJUnitL
     public static final String TYPE_NAME = "iOS Simulator JUnit Test";
     public static final String ATTR_IOS_SIM_DEVICE_TYPE = IOSSimulatorLaunchConfigurationDelegate.ATTR_IOS_SIM_DEVICE_TYPE;
     public static final String ATTR_IOS_SIM_ARCH = IOSSimulatorLaunchConfigurationDelegate.ATTR_IOS_SIM_ARCH;
-    public static final Arch DEFAULT_ARCH = IOSSimulatorLaunchConfigurationDelegate.DEFAULT_ARCH;
+    public static final CpuArch DEFAULT_ARCH = IOSSimulatorLaunchConfigurationDelegate.DEFAULT_ARCH;
 
     @Override
     protected Arch getArch(ILaunchConfiguration configuration, String mode) throws CoreException {
-        Arch arch = DEFAULT_ARCH;
+    	CpuArch arch = DEFAULT_ARCH;
         try {
-            arch = Arch.valueOf(configuration.getAttribute(ATTR_IOS_SIM_ARCH, DEFAULT_ARCH.toString()));
+            arch = CpuArch.valueOf(configuration.getAttribute(ATTR_IOS_SIM_ARCH, DEFAULT_ARCH.toString()));
         } catch (Throwable t) {
         }
-        return arch;
+        return new Arch(arch, Environment.Simulator);
     }
 
     @Override

--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractIOSSimulatorTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractIOSSimulatorTask.java
@@ -16,6 +16,8 @@
 package org.robovm.gradle.tasks;
 
 import org.robovm.compiler.config.Arch;
+import org.robovm.compiler.config.CpuArch;
+import org.robovm.compiler.config.Environment;
 import org.robovm.compiler.config.OS;
 import org.robovm.compiler.target.ios.DeviceType;
 import org.robovm.compiler.target.ios.IOSTarget;
@@ -37,16 +39,14 @@ public abstract class AbstractIOSSimulatorTask extends AbstractSimulatorTask {
     
     @Override
     protected Arch getArch() {
-        Arch arch = DeviceType.DEFAULT_HOST_ARCH;
+        CpuArch cpuArch = DeviceType.DEFAULT_HOST_ARCH;
         String extArchName = extension.getArch();
         if (extArchName != null) {
-            if (extArchName.equals(Arch.x86_64.toString()))
-                arch = Arch.x86_64;
-            else if (extArchName.equals(Arch.arm64.toString()))
-                arch = Arch.arm64;
-            else if (extArchName.equals(Arch.x86.toString()))
-                arch = Arch.x86;
+            Arch arch = Arch.parse(extArchName);
+            cpuArch = arch.getCpuArch();
+            if (cpuArch != CpuArch.arm64 && cpuArch != CpuArch.x86_64 && cpuArch != CpuArch.x86)
+                throw new IllegalArgumentException("Unsupported iOS Simulator arch " + extArchName);
         }
-        return arch;
+        return new Arch(cpuArch, Environment.Simulator);
     }
 }

--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMBuildTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMBuildTask.java
@@ -40,7 +40,7 @@ public abstract class AbstractRoboVMBuildTask extends AbstractRoboVMTask {
             if (extension.getArchs() != null) {
                 List<Arch> archs = new ArrayList<>();
                 for (String s : extension.getArchs().trim().split(":")) {
-                    archs.add(Arch.valueOf(s));
+                    archs.add(Arch.parse(s));
                 }
                 builder.archs(archs);
             }

--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMTask.java
@@ -87,13 +87,13 @@ abstract public class AbstractRoboVMTask extends DefaultTask {
         setGroup("MobiVM");
     }
 
-    public AppCompiler build(OS os, Arch arch, Environment env, String targetType) {
-        getLogger().info("Building RoboVM app for: " + os + " (" + arch + env.asLlvmSuffix("-")+ ")");
+    public AppCompiler build(OS os, Arch arch, String targetType) {
+        getLogger().info("Building RoboVM app for: " + os + " (" + arch + ")");
 
         Config.Builder builder;
         builder = new Config.Builder();
 
-        configure(builder).os(os).arch(arch).env(env).targetType(targetType);
+        configure(builder).os(os).arch(arch).targetType(targetType);
 
         // execute the RoboVM build
         Config config;

--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractSimulatorTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractSimulatorTask.java
@@ -34,7 +34,7 @@ public abstract class AbstractSimulatorTask extends AbstractRoboVMTask {
 
     protected void launch(DeviceType type) {
         try {
-            AppCompiler compiler = build(getOs(), getArch(), Environment.Simulator, getTargetType());
+            AppCompiler compiler = build(getOs(), getArch(), getTargetType());
 
             if (extension.isSkipLaunch()) {
                 return;

--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/ConsoleTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/ConsoleTask.java
@@ -34,10 +34,10 @@ public class ConsoleTask extends AbstractRoboVMTask {
         try {
             Arch arch = Arch.getDefaultArch();
             if (extension.getArch() != null) {
-                arch = Arch.valueOf(extension.getArch());
+                arch = Arch.parse(extension.getArch());
             }
 
-            AppCompiler compiler = build(OS.getDefaultOS(), arch, Environment.Native, ConsoleTarget.TYPE);
+            AppCompiler compiler = build(OS.getDefaultOS(), arch, ConsoleTarget.TYPE);
             Config config = compiler.getConfig();
             LaunchParameters launchParameters = config.getTarget().createLaunchParameters();
             compiler.launch(launchParameters);

--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/IOSDeviceTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/IOSDeviceTask.java
@@ -39,7 +39,7 @@ public class IOSDeviceTask extends AbstractRoboVMTask {
                 arch = Arch.thumbv7;
             }
 
-            AppCompiler compiler = build(OS.ios, arch, Environment.Native, IOSTarget.TYPE);
+            AppCompiler compiler = build(OS.ios, arch, IOSTarget.TYPE);
             if (extension.isSkipLaunch()) {
                 return;
             }

--- a/plugins/idea/src/main/java/org/robovm/idea/RoboVmPlugin.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/RoboVmPlugin.java
@@ -50,7 +50,6 @@ import org.jetbrains.annotations.NotNull;
 import org.robovm.compiler.Version;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
-import org.robovm.compiler.config.Environment;
 import org.robovm.compiler.config.Resource;
 import org.robovm.compiler.log.Logger;
 import org.robovm.idea.compilation.RoboVmCompileTask;
@@ -515,9 +514,8 @@ public class RoboVmPlugin {
         return buildDir;
     }
 
-    public static File getModuleBuildDir(Module module, String runConfigName, org.robovm.compiler.config.OS os, Arch arch, Environment env) {
-        File buildDir = new File(getModuleBaseDir(module), "robovm-build/tmp/" + runConfigName + "/" + os + "/" + arch +
-                env.asLlvmSuffix("-"));
+    public static File getModuleBuildDir(Module module, String runConfigName, org.robovm.compiler.config.OS os, Arch arch) {
+        File buildDir = new File(getModuleBaseDir(module), "robovm-build/tmp/" + runConfigName + "/" + os + "/" + arch);
         if (!buildDir.exists()) {
             if (!buildDir.mkdirs()) {
                 throw new RuntimeException("Couldn't create build dir '" + buildDir.getAbsolutePath() + "'");

--- a/plugins/idea/src/main/java/org/robovm/idea/RoboVmPlugin.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/RoboVmPlugin.java
@@ -71,6 +71,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.zip.GZIPInputStream;
 
 /**
@@ -421,10 +422,14 @@ public class RoboVmPlugin {
     }
 
     public static List<Module> getRoboVmModules(Project project) {
-        return getRoboVmModules(project, null);
+        return getRoboVmModules(project, (Predicate<String>)null);
     }
 
     public static List<Module> getRoboVmModules(Project project, String targetType) {
+        return getRoboVmModules(project, t -> t.equals(targetType));
+    }
+
+    public static List<Module> getRoboVmModules(Project project, Predicate<String> predicate) {
         List<Module> validModules = new ArrayList<>();
         for (Module module : ModuleManager.getInstance(project).getModules()) {
             if (!isRoboVmModule(module))
@@ -432,11 +437,11 @@ public class RoboVmPlugin {
 
             // dkimitsa: if target type is specified return only matching modules. E.g. don't allow to run Framework
             // target in Console runner
-            if (targetType != null) {
+            if (predicate != null) {
                 Config config = loadRawModuleConfig(module);
                 if (config == null)
                     continue;
-                if (!targetType.equals(config.getTargetType()))
+                if (!predicate.test(config.getTargetType()))
                     continue;
             }
             validModules.add(module);

--- a/plugins/idea/src/main/java/org/robovm/idea/actions/CreateFrameworkDialog.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/actions/CreateFrameworkDialog.java
@@ -58,7 +58,7 @@ public class CreateFrameworkDialog extends DialogWrapper {
         String configModule = properties.getValue(MODULE_NAME, "");
         String configDestDir = properties.getValue(DESTINATION_DIR, "");
 
-        for(Module module: RoboVmPlugin.getRoboVmModules(project, FrameworkTarget.TYPE)) {
+        for(Module module: RoboVmPlugin.getRoboVmModules(project, FrameworkTarget::matches)) {
             this.module.addItem(module.getName());
             if(module.getName().equals(configModule)) {
                 this.module.setSelectedIndex(this.module.getItemCount()-1);

--- a/plugins/idea/src/main/java/org/robovm/idea/compilation/RoboVmCompileTask.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/compilation/RoboVmCompileTask.java
@@ -208,21 +208,18 @@ public class RoboVmCompileTask {
             // set OS and arch
             OS os;
             Arch arch;
-            Environment env = Environment.Native;
             if (runConfig.getTargetType() == RoboVmRunConfiguration.TargetType.Device) {
                 os = OS.ios;
-                arch = runConfig.getDeviceArch();
+                arch = new Arch(runConfig.getDeviceArch());
             } else if (runConfig.getTargetType() == RoboVmRunConfiguration.TargetType.Simulator) {
                 os = OS.ios;
-                arch = runConfig.getSimulatorArch();
-                env = Environment.Simulator;
+                arch = new Arch(runConfig.getSimulatorArch(), Environment.Simulator);
             } else {
                 os = OS.getDefaultOS();
-                arch = runConfig.getDeviceArch();;
+                arch = new Arch(runConfig.getDeviceArch());
             }
             builder.os(os);
             builder.arch(arch);
-            builder.env(env);
 
             // set the plugin args
             List<String> args = splitArgs(runConfig.getArguments());
@@ -231,7 +228,7 @@ public class RoboVmCompileTask {
             // set build dir and install dir, pattern
             // module-basedir/robovm-build/tmp/module-name/runconfig-name/os/arch.
             // module-basedir/robovm-build/app/module-name/runconfig-name/os/arch.
-            File buildDir = RoboVmPlugin.getModuleBuildDir(module, runConfig.getName(), os, arch, env);
+            File buildDir = RoboVmPlugin.getModuleBuildDir(module, runConfig.getName(), os, arch);
             builder.tmpDir(buildDir);
             builder.skipInstall(true);
             RoboVmPlugin.logInfo(project, "Building executable in %s", buildDir.getAbsolutePath());

--- a/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmConsoleRunConfigurationSettingsEditor.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmConsoleRunConfigurationSettingsEditor.java
@@ -24,7 +24,7 @@ import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
-import org.robovm.compiler.config.Arch;
+import org.robovm.compiler.config.CpuArch;
 import org.robovm.compiler.target.ConsoleTarget;
 import org.robovm.compiler.target.ios.DeviceType;
 import org.robovm.idea.RoboVmPlugin;
@@ -39,7 +39,7 @@ public class RoboVmConsoleRunConfigurationSettingsEditor extends SettingsEditor<
     private JTextArea args;
     private JTextField workingDir;
     private JButton browseButton;
-    private JComboBox<Arch> deviceArch;
+    private JComboBox<CpuArch> deviceArch;
 
     @Override
     protected void resetEditorFrom(@NotNull RoboVmRunConfiguration config) {
@@ -53,7 +53,7 @@ public class RoboVmConsoleRunConfigurationSettingsEditor extends SettingsEditor<
         if (deviceArch.getSelectedItem() == null)
             throw buildConfigurationException("Device architecture is not specified!", () -> deviceArch.setSelectedItem(DeviceType.DEFAULT_HOST_ARCH));
         config.setModuleName(module.getSelectedItem().toString());
-        config.setDeviceArch((Arch)deviceArch.getSelectedItem());
+        config.setDeviceArch((CpuArch)deviceArch.getSelectedItem());
         config.setTargetType(RoboVmRunConfiguration.TargetType.Console);
         config.setArguments(args.getText());
         config.setWorkingDir(workingDir.getText());
@@ -79,10 +79,10 @@ public class RoboVmConsoleRunConfigurationSettingsEditor extends SettingsEditor<
 
         // populate arch
         deviceArch.removeAllItems();
-        if (DeviceType.DEFAULT_HOST_ARCH == Arch.arm64)
-            deviceArch.addItem(Arch.arm64);
-        deviceArch.addItem(Arch.x86_64);
-        if (config.getDeviceArch() == Arch.x86_64 || config.getDeviceArch() == DeviceType.DEFAULT_HOST_ARCH)
+        if (DeviceType.DEFAULT_HOST_ARCH == CpuArch.arm64)
+            deviceArch.addItem(CpuArch.arm64);
+        deviceArch.addItem(CpuArch.x86_64);
+        if (config.getDeviceArch() == CpuArch.x86_64 || config.getDeviceArch() == DeviceType.DEFAULT_HOST_ARCH)
             deviceArch.setSelectedItem(config.getDeviceArch());
 
         this.args.setText(config.getArguments());

--- a/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmIOSRunConfigurationSettingsEditor.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmIOSRunConfigurationSettingsEditor.java
@@ -22,6 +22,7 @@ import com.intellij.openapi.options.SettingsEditor;
 import org.jetbrains.annotations.NotNull;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
+import org.robovm.compiler.config.CpuArch;
 import org.robovm.compiler.target.ios.DeviceType;
 import org.robovm.compiler.target.ios.IOSTarget;
 import org.robovm.compiler.target.ios.ProvisioningProfile;
@@ -39,8 +40,8 @@ import static org.robovm.idea.running.RoboVmRunConfiguration.AUTO_PROVISIONING_P
 import static org.robovm.idea.running.RoboVmRunConfiguration.AUTO_SIGNING_IDENTITY;
 
 public class RoboVmIOSRunConfigurationSettingsEditor extends SettingsEditor<RoboVmRunConfiguration> {
-    private static final Arch[] DEVICE_ARCHS = {Arch.arm64, Arch.thumbv7};
-    private static final Arch[] SIMULATOR_ARCHS = {Arch.x86_64, Arch.x86, Arch.arm64};
+    private static final CpuArch[] DEVICE_ARCHS = {CpuArch.arm64, CpuArch.thumbv7};
+    private static final CpuArch[] SIMULATOR_ARCHS = {CpuArch.x86_64, CpuArch.x86, CpuArch.arm64};
 
     public static final String AUTO_SIMULATOR_IPHONE_TITLE = "Auto (prefers '" + DeviceType.PREFERRED_IPHONE_SIM_NAME + "')";
     public static final String AUTO_SIMULATOR_IPAD_TITLE = "Auto (prefers '" + DeviceType.PREFERRED_IPAD_SIM_NAME + "')";
@@ -54,8 +55,8 @@ public class RoboVmIOSRunConfigurationSettingsEditor extends SettingsEditor<Robo
     private JComboBox<SimTypeDecorator> simType;
     private JComboBox<SigningIdentityDecorator> signingIdentity;
     private JComboBox<ProvisioningProfileDecorator> provisioningProfile;
-    private JComboBox<Arch> simArch;
-    private JComboBox<Arch> deviceArch;
+    private JComboBox<CpuArch> simArch;
+    private JComboBox<CpuArch> deviceArch;
     private JTextArea args;
     private JCheckBox pairedWatch;
 
@@ -135,13 +136,13 @@ public class RoboVmIOSRunConfigurationSettingsEditor extends SettingsEditor<Robo
         config.setModuleName(Decorator.from(module).name);
         config.setTargetType(attachedDeviceRadioButton.isSelected() ? RoboVmRunConfiguration.TargetType.Device : RoboVmRunConfiguration.TargetType.Simulator);
         // device related
-        config.setDeviceArch((Arch) deviceArch.getSelectedItem());
+        config.setDeviceArch((CpuArch) deviceArch.getSelectedItem());
         config.setSigningIdentityType(Decorator.from(signingIdentity).entryType);
         config.setSigningIdentity(Decorator.from(signingIdentity).id);
         config.setProvisioningProfileType(Decorator.from(provisioningProfile).entryType);
         config.setProvisioningProfile(Decorator.from(provisioningProfile).id);
         // simulator related
-        config.setSimulatorArch((Arch) simArch.getSelectedItem());
+        config.setSimulatorArch((CpuArch) simArch.getSelectedItem());
         config.setSimulatorType(Decorator.from(simType).entryType);
         config.setSimulator(Decorator.from(simType).id);
         config.setSimulatorSdk(-1); // legacy, will not be used
@@ -149,8 +150,8 @@ public class RoboVmIOSRunConfigurationSettingsEditor extends SettingsEditor<Robo
         config.setSimulatorLaunchWatch(pairedWatch.isSelected());
     }
 
-    private Arch populateSimulatorArch(SimTypeDecorator simulator, Arch arch) {
-        Arch result = null;
+    private CpuArch populateSimulatorArch(SimTypeDecorator simulator, CpuArch arch) {
+        CpuArch result = null;
         simArch.removeAllItems();
         if (simulator != null) {
             if (simulator == simulatorAutoIPad || simulator == simulatorAutoIPhone){
@@ -159,7 +160,7 @@ public class RoboVmIOSRunConfigurationSettingsEditor extends SettingsEditor<Robo
                 result = DeviceType.DEFAULT_HOST_ARCH;
             } else {
                 Set<Arch> simArches = simulator.data.getArchs();
-                for (Arch a : SIMULATOR_ARCHS) {
+                for (CpuArch a : SIMULATOR_ARCHS) {
                     if (simArches.contains(a)) {
                         simArch.addItem(a);
                         if (a == arch)
@@ -174,7 +175,7 @@ public class RoboVmIOSRunConfigurationSettingsEditor extends SettingsEditor<Robo
 
     private void populateDeviceArch() {
         deviceArch.removeAllItems();
-        for (Arch arch : DEVICE_ARCHS)
+        for (CpuArch arch : DEVICE_ARCHS)
             deviceArch.addItem(arch);
     }
 
@@ -325,7 +326,7 @@ public class RoboVmIOSRunConfigurationSettingsEditor extends SettingsEditor<Robo
     }
 
     private void updateSimArchs(SimTypeDecorator simulator) {
-        Arch arch = populateSimulatorArch(simulator, (Arch) simArch.getSelectedItem());
+        CpuArch arch = populateSimulatorArch(simulator, (CpuArch) simArch.getSelectedItem());
         if (arch == null && simArch.getItemCount() > 0)
             arch = simArch.getItemAt(0);
         simArch.setSelectedItem(arch);

--- a/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmRunConfiguration.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmRunConfiguration.java
@@ -37,6 +37,7 @@ import org.jetbrains.annotations.Nullable;
 import org.robovm.compiler.AppCompiler;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
+import org.robovm.compiler.config.CpuArch;
 import org.robovm.compiler.target.ios.DeviceType;
 import org.robovm.idea.RoboVmPlugin;
 
@@ -63,12 +64,12 @@ public class RoboVmRunConfiguration extends ModuleBasedConfiguration<RoboVmRunCo
     }
 
     private TargetType targetType;
-    private Arch deviceArch;
+    private CpuArch deviceArch;
     private EntryType signingIdentityType;
     private String signingIdentity;
     private EntryType provisioningProfileType;
     private String provisioningProfile;
-    private Arch simulatorArch;
+    private CpuArch simulatorArch;
     private EntryType simulatorType;
     private String simulator;
     private int simulatorSdk;
@@ -95,7 +96,7 @@ public class RoboVmRunConfiguration extends ModuleBasedConfiguration<RoboVmRunCo
     private void setDefaultValues() {
         if (type instanceof RoboVmIOSConfigurationType) {
             targetType = TargetType.Device;
-            deviceArch = Arch.arm64;
+            deviceArch = CpuArch.arm64;
             signingIdentityType = EntryType.AUTO;
             provisioningProfileType = EntryType.AUTO;
             simulatorType = EntryType.AUTO;
@@ -133,14 +134,14 @@ public class RoboVmRunConfiguration extends ModuleBasedConfiguration<RoboVmRunCo
         super.readExternal(element);
 
         targetType = valueOf(TargetType.class, JDOMExternalizerUtil.readField(element, "targetType"));
-        deviceArch = valueOf(Arch.class, JDOMExternalizerUtil.readField(element, "deviceArch"));
+        deviceArch = valueOf(CpuArch.class, JDOMExternalizerUtil.readField(element, "deviceArch"));
         signingIdentityType = valueOf(EntryType.class, JDOMExternalizerUtil.readField(element, "signingIdentityType"));
         signingIdentity = JDOMExternalizerUtil.readField(element, "signingIdentity");
         provisioningProfileType = valueOf(EntryType.class, JDOMExternalizerUtil.readField(element, "provisioningProfileType"));
         provisioningProfile = JDOMExternalizerUtil.readField(element, "provisioningProfile");
         simulatorType = valueOf(EntryType.class, JDOMExternalizerUtil.readField(element, "simulatorType"));
         simulator = JDOMExternalizerUtil.readField(element, "simulatorName");
-        simulatorArch = valueOf(Arch.class, JDOMExternalizerUtil.readField(element, "simArch"));
+        simulatorArch = valueOf(CpuArch.class, JDOMExternalizerUtil.readField(element, "simArch"));
         simulatorSdk = parseInt(JDOMExternalizerUtil.readField(element, "simulatorSdk"), -1);
         simulatorLaunchWatch = parseInt(JDOMExternalizerUtil.readField(element, "simulatorLaunchPair"), -1)  > 0;
         arguments = JDOMExternalizerUtil.readField(element, "arguments", "");
@@ -168,11 +169,11 @@ public class RoboVmRunConfiguration extends ModuleBasedConfiguration<RoboVmRunCo
         JDOMExternalizerUtil.writeField(element, "workingDir", workingDir);
     }
 
-    public void setDeviceArch(Arch deviceArch) {
+    public void setDeviceArch(CpuArch deviceArch) {
         this.deviceArch = deviceArch;
     }
 
-    public Arch getDeviceArch() {
+    public CpuArch getDeviceArch() {
         return deviceArch;
     }
 
@@ -208,11 +209,11 @@ public class RoboVmRunConfiguration extends ModuleBasedConfiguration<RoboVmRunCo
         return provisioningProfile;
     }
 
-    public void setSimulatorArch(Arch simulatorArch) {
+    public void setSimulatorArch(CpuArch simulatorArch) {
         this.simulatorArch = simulatorArch;
     }
 
-    public Arch getSimulatorArch() {
+    public CpuArch getSimulatorArch() {
         return simulatorArch;
     }
 
@@ -332,7 +333,7 @@ public class RoboVmRunConfiguration extends ModuleBasedConfiguration<RoboVmRunCo
                 simulator = AUTO_SIGNING_IDENTITY;
         } else if (type instanceof RoboVmConsoleConfigurationType) {
             // MacOsX console target
-            if (deviceArch != Arch.x86_64 && deviceArch != DeviceType.DEFAULT_HOST_ARCH)
+            if (deviceArch != CpuArch.x86_64 && deviceArch != DeviceType.DEFAULT_HOST_ARCH)
                 deviceArch = DeviceType.DEFAULT_HOST_ARCH;
             targetType = TargetType.Console;
         }

--- a/plugins/junit/client/src/main/java/org/robovm/junit/client/TestClient.java
+++ b/plugins/junit/client/src/main/java/org/robovm/junit/client/TestClient.java
@@ -234,7 +234,7 @@ public class TestClient extends LaunchPlugin {
                 int port = serverPortReader.port;
 
                 try {
-                    if (config.getTarget() instanceof IOSTarget && IOSTarget.isDeviceArch(config.getArch(), config.getEnv())) {
+                    if (config.getTarget() instanceof IOSTarget && IOSTarget.isDeviceArch(config.getArch())) {
                         // iOS device launch. Use libimobiledevice to set up the
                         // connection.
                         IDevice device = ((IOSTarget) config.getTarget()).getDevice();

--- a/plugins/maven/plugin/src/main/java/org/robovm/maven/plugin/AbstractIOSSimulatorMojo.java
+++ b/plugins/maven/plugin/src/main/java/org/robovm/maven/plugin/AbstractIOSSimulatorMojo.java
@@ -52,17 +52,14 @@ public abstract class AbstractIOSSimulatorMojo extends AbstractRoboVMMojo {
 
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {
-            Arch arch = DeviceType.DEFAULT_HOST_ARCH;
+            Arch arch = new Arch(DeviceType.DEFAULT_HOST_ARCH, Environment.Simulator);
             if (super.arch != null) {
-                if (super.arch.equals(Arch.x86.toString()))
-                    arch = Arch.x86;
-                if (super.arch.equals(Arch.x86_64.toString()))
-                    arch = Arch.x86_64;
-                else if (super.arch.equals(Arch.arm64.toString()))
-                    arch = Arch.arm64;
+                arch = Arch.parse(super.arch).promoteTo(OS.ios);
+                if (arch.getEnv() != Environment.Simulator)
+                    throw new MojoExecutionException("Not simulator arch specified " + arch);
             }
 
-            AppCompiler compiler = build(OS.ios, arch, Environment.Simulator, IOSTarget.TYPE);
+            AppCompiler compiler = build(OS.ios, arch, IOSTarget.TYPE);
             Config config = compiler.getConfig();
             IOSSimulatorLaunchParameters launchParameters = (IOSSimulatorLaunchParameters)
                 config.getTarget().createLaunchParameters();

--- a/plugins/maven/plugin/src/main/java/org/robovm/maven/plugin/AbstractRoboVMBuildMojo.java
+++ b/plugins/maven/plugin/src/main/java/org/robovm/maven/plugin/AbstractRoboVMBuildMojo.java
@@ -57,7 +57,7 @@ public abstract class AbstractRoboVMBuildMojo extends AbstractRoboVMMojo {
             if (getArchs() != null) {
                 List<Arch> archs = new ArrayList<>();
                 for (String s : getArchs().trim().split(":")) {
-                    archs.add(Arch.valueOf(s));
+                    archs.add(Arch.parse(s));
                 }
                 builder.archs(archs);
             }

--- a/plugins/maven/plugin/src/main/java/org/robovm/maven/plugin/AbstractRoboVMMojo.java
+++ b/plugins/maven/plugin/src/main/java/org/robovm/maven/plugin/AbstractRoboVMMojo.java
@@ -337,15 +337,15 @@ public abstract class AbstractRoboVMMojo extends AbstractMojo {
         return builder;
     }
 
-    protected AppCompiler build(OS os, Arch arch, Environment env, String targetType)
+    protected AppCompiler build(OS os, Arch arch, String targetType)
             throws MojoExecutionException {
 
-        getLog().info("Building RoboVM app for: " + os + " (" + arch + env.asLlvmSuffix("-") + ")");
+        getLog().info("Building RoboVM app for: " + os + " (" + arch + ")");
 
         Config.Builder builder;
         builder = new Config.Builder();
 
-        configure(builder).os(os).arch(arch).env(env).targetType(targetType);
+        configure(builder).os(os).arch(arch).targetType(targetType);
 
         // execute the RoboVM build
 

--- a/plugins/maven/plugin/src/main/java/org/robovm/maven/plugin/ConsoleMojo.java
+++ b/plugins/maven/plugin/src/main/java/org/robovm/maven/plugin/ConsoleMojo.java
@@ -40,13 +40,12 @@ public class ConsoleMojo extends AbstractRoboVMMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
 
         try {
-
             Arch arch = Arch.getDefaultArch();
             if (super.arch != null) {
-                arch = Arch.valueOf(super.arch);
+                arch = Arch.parse(super.arch);
             }
 
-            AppCompiler compiler = build(OS.getDefaultOS(), arch, Environment.Native, ConsoleTarget.TYPE);
+            AppCompiler compiler = build(OS.getDefaultOS(), arch, ConsoleTarget.TYPE);
             Config config = compiler.getConfig();
             LaunchParameters launchParameters = config.getTarget()
                     .createLaunchParameters();

--- a/plugins/maven/plugin/src/main/java/org/robovm/maven/plugin/IOSDeviceMojo.java
+++ b/plugins/maven/plugin/src/main/java/org/robovm/maven/plugin/IOSDeviceMojo.java
@@ -45,7 +45,7 @@ public class IOSDeviceMojo extends AbstractRoboVMMojo {
                 arch = Arch.thumbv7;
             }
 
-            AppCompiler compiler = build(OS.ios, arch, Environment.Native, IOSTarget.TYPE);
+            AppCompiler compiler = build(OS.ios, arch, IOSTarget.TYPE);
             Config config = compiler.getConfig();
             LaunchParameters launchParameters = config.getTarget()
                     .createLaunchParameters();

--- a/plugins/maven/surefire/src/main/java/org/robovm/maven/surefire/RoboVMSurefireProvider.java
+++ b/plugins/maven/surefire/src/main/java/org/robovm/maven/surefire/RoboVMSurefireProvider.java
@@ -65,7 +65,6 @@ public class RoboVMSurefireProvider extends AbstractProvider {
     private final static String PROP_SERVER_DEBUG = "robovm.test.enableServerLogging";
     private final static String PROP_OS = "robovm.test.os";
     private final static String PROP_ARCH = "robovm.test.arch";
-    private final static String PROP_ENVIRONMENT = "robovm.test.environment";
     private final static String PROP_CONFIG_FILE = "robovm.test.configFile";
     private final static String PROP_PROPERTIES_FILE = "robovm.test.propertiesFile";
     private final static String PROP_IOS_SIGNING_IDENTITY = "robovm.test.iosSignIdentity";
@@ -163,7 +162,7 @@ public class RoboVMSurefireProvider extends AbstractProvider {
         Process process = null;
         try {
             Config config = testClient.configure(createConfig(consoleLogger), isIOS()).build();
-            config.getLogger().info("Building RoboVM tests for: %s (%s%s)", config.getOs(), config.getArch(), config.getEnv().asLlvmSuffix("-"));
+            config.getLogger().info("Building RoboVM tests for: %s (%s)", config.getOs(), config.getArch());
             config.getLogger().info("This could take a while, especially the first time round");
             AppCompiler appCompiler = new AppCompiler(config);
             appCompiler.build();
@@ -314,10 +313,7 @@ public class RoboVMSurefireProvider extends AbstractProvider {
             configBuilder.os(OS.valueOf(System.getProperty(PROP_OS)));
         }
         if (System.getProperty(PROP_ARCH) != null) {
-            configBuilder.arch(Arch.valueOf(System.getProperty(PROP_ARCH)));
-        }
-        if (System.getProperty(PROP_ENVIRONMENT) != null) {
-            configBuilder.env(Environment.valueOf(System.getProperty(PROP_ENVIRONMENT)));
+            configBuilder.arch(Arch.parse(System.getProperty(PROP_ARCH)));
         }
         if (Boolean.getBoolean(PROP_IOS_SKIP_SIGNING)) {
             configBuilder.iosSkipSigning(true);


### PR DESCRIPTION
## problem
1. it was not possible to generate `arm64-simulator` slice as only `<arch>arm64</arch>` was allowed;
2. once `arm64-simulator` is generated it is not possible to `lipo` both `arm64` and  `arm64-simulator` into single fat binary


## support for `<arch>arm64-simulator</arch>`
It was required to allow `arch` to contain both CPU arch and environment. To achieve this `Arch` enum was renamed into `CpuArch` and `Arch` value object is introduced that combines `CpuArch` and `Environment`. Code was refactored to work with new object (in future we might extend it with OS and have complete triple). 

## combining `arm64` and `arm64-simulator`
Lipo is unable to make fat binary for binaries of same CPU arch. And apple tells to produce xcframework instead. 
Changes were done to do following:
- combine CPU slices that belongs to same Environment (e.g. Simulator) into fat binaries; 
- create framework for these fat binaries (e.g. with own copy of assets/resource etc)
- produce `Info.plist` that describes xcframework structure

`robovm.xml` has to specify following target:
```xml
    <target>xcframework</target>
```

## eclipse plugin
can now run on m1 Mac and launch on arm64 sim

## other fixes 
CpuArch default arch was picked from `LLVM_HOST_TRIPLE` which specified host where LLVM lib was compiled, not actually host it is now running on.
As result it affected default arch selection for Console/Framework targets. Reworked to use `System.getProperty("os.arch")`