### PR TITLE
hot fix for recent Framework target changes

### DIFF
--- a/plugins/templates/ios-framework/src/main/resources/archetype-resources/headers/__appName__.h
+++ b/plugins/templates/ios-framework/src/main/resources/archetype-resources/headers/__appName__.h
@@ -10,7 +10,7 @@
 //
 // Calculator class
 //
-@interface Calculator
+@interface Calculator: NSObject
 -(id)init;
 -(id)initWithValue:(int)startValue;
 -(int)reset;
@@ -22,7 +22,7 @@
 //
 // ${appName}Demo class with basic API demonstration
 //
-@interface ${appName}Demo
+@interface ${appName}Demo: NSObject
 -(id)init;
 -(id)initWithText:(NSString*)text;
 +(void)hello;


### PR DESCRIPTION
Sadly, previous changes were not tested completely as result several use cases were not working -- like XCFramework creation when only one framework is specified (buildFat wasn't called in this case and framework wasn't picked).
Also second commit fixes Framework template for few projects by specifying NSObject superclass. Without it [ClassName alloc] is not available at native side.

Testing is ongoing but seems to be working 