### PR TITLE
* removed Log4jLoggerFactory as it seems to be not available in latest EAP

### DIFF
--- a/plugins/idea/src/main/java/org/robovm/idea/components/RoboVmBuildProcessParametersProvider.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/components/RoboVmBuildProcessParametersProvider.java
@@ -4,8 +4,6 @@ import com.intellij.compiler.server.BuildProcessParametersProvider;
 import com.intellij.util.PathUtil;
 import groovy.lang.GroovyObject;
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.impl.Log4jLoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,8 +14,6 @@ public class RoboVmBuildProcessParametersProvider extends BuildProcessParameters
     public List<String> getClassPath() {
         List<String> classpath = new ArrayList<>();
         classpath.add(PathUtil.getJarPathForClass(GroovyObject.class));
-        classpath.add(PathUtil.getJarPathForClass(Logger.class));
-        classpath.add(PathUtil.getJarPathForClass(Log4jLoggerFactory.class));
         return classpath;
     }
 }


### PR DESCRIPTION

`org.jetbrains.intellij` uses LATEST_EAP when building plugin. Seems like this class is removed that causes compilation failure.
 (removal of this class has no affect for me, its old code from 2014)