### PR TITLE
* debugger - enhancement: proper thread status and suspend any thread

### DIFF
--- a/compiler/vm/core/include/robovm/hooks.h
+++ b/compiler/vm/core/include/robovm/hooks.h
@@ -30,6 +30,8 @@ void _rvmHookInstrumented(DebugEnv* debugEnv, jint lineNumber, jint lineNumberOf
 
 void rvmHookWaitForAttach(Options* options);
 void rvmHookDebuggerAttached(Options* options);
+jboolean _rvmHookAfterThreadStackCaptured(Env* env, void (*unlockFun)(void));
+
 static inline void rvmHookBeforeAppEntryPoint(Env* env, char* mainClass) {
     if (env->vm->options->enableHooks) {
         _rvmHookBeforeAppEntryPoint(env, mainClass);
@@ -88,6 +90,14 @@ static inline jboolean rvmHookHandshake(Options* options) {
 static inline void rvmHookInstrumented(DebugEnv* env, jint lineNumber, jint lineNumberOffset, jbyte* bptable, void* pc) {
     if (env->env.vm->options->enableHooks) {
         _rvmHookInstrumented(env, lineNumber, lineNumberOffset, bptable, pc);
+    }
+}
+
+static inline jboolean rvmHookAfterThreadStackCaptured(Env* env, void (*unlockFun)(void)) {
+    if(env->vm->options->enableHooks) {
+        return _rvmHookAfterThreadStackCaptured(env, unlockFun);
+    } else {
+        return FALSE;
     }
 }
 

--- a/compiler/vm/core/include/robovm/method.h
+++ b/compiler/vm/core/include/robovm/method.h
@@ -53,6 +53,7 @@ extern Method* rvmFindMethodAtAddress(Env* env, void* address);
 extern Method* rvmGetCallingMethod(Env* env);
 extern CallStack* rvmCaptureCallStack(Env* env);
 extern CallStack* rvmCaptureCallStackForThread(Env* env, Thread* thread);
+extern CallStack* rvmCaptureCallStackAndSuspendThread(Env* env, Thread* thread);
 extern CallStackFrame* rvmResolveCallStackFrame(Env* env, CallStackFrame* frame);
 extern ObjectArray* rvmCallStackToStackTraceElements(Env* env, CallStack* callStack, jint first);
 extern void rvmCallVoidInstanceMethod(Env* env, Object* obj, Method* method, ...);

--- a/compiler/vm/core/include/robovm/types.h
+++ b/compiler/vm/core/include/robovm/types.h
@@ -491,7 +491,7 @@ typedef struct {
     void* pchigh2;
     Mutex suspendMutex;
     pthread_cond_t suspendCond;
-    jboolean suspended;
+    volatile jbyte suspendStatus;
     jboolean stepping;
     jboolean ignoreExceptions;
 

--- a/compiler/vm/core/src/init.c
+++ b/compiler/vm/core/src/init.c
@@ -286,7 +286,7 @@ Env* rvmCreateEnv(VM* vm) {
     if(vm->options->enableHooks) {
         DebugEnv* debugEnv = (DebugEnv*)env;
         debugEnv->reqId = 0;
-        debugEnv->suspended = FALSE;
+        debugEnv->suspendStatus = 0;
         // dkimitsa: ignore VM initialization exception till app entry point as these exc wil will break wait_for_resume startup logic
         debugEnv->ignoreExceptions = TRUE;
     }

--- a/plugins/debugger/src/main/java/org/robovm/debugger/delegates/InstanceUtils.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/delegates/InstanceUtils.java
@@ -16,6 +16,7 @@
 package org.robovm.debugger.delegates;
 
 import org.robovm.debugger.DebuggerException;
+import org.robovm.debugger.hooks.HookConsts;
 import org.robovm.debugger.hooks.payloads.HooksCmdResponse;
 import org.robovm.debugger.jdwp.JdwpConsts;
 import org.robovm.debugger.runtime.ValueManipulator;
@@ -514,6 +515,8 @@ public class InstanceUtils {
         if (thread == null)
             throw new DebuggerException(JdwpConsts.Error.INVALID_THREAD);
         if (thread.suspendCount() == 0)
+            throw new DebuggerException(JdwpConsts.Error.THREAD_NOT_SUSPENDED);
+        if (thread.getHookSuspendStatus() != HookConsts.threadSuspendStatus.SUSPENDED_SOFT)
             throw new DebuggerException(JdwpConsts.Error.THREAD_NOT_SUSPENDED);
 
         // get method

--- a/plugins/debugger/src/main/java/org/robovm/debugger/hooks/HookConsts.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/hooks/HookConsts.java
@@ -27,27 +27,27 @@ public final class HookConsts {
         static final long ANSWER = 0x526f626f564d2121L; // RoboVM!!
     }
 
-    final static class commands {
+    public final static class commands {
         // memory operations
-        static final byte READ_MEMORY = 1;
-        static final byte READ_CSTRING = 2;
-        static final byte WRITE_MEMORY = 3;
-        static final byte WRITE_AND_BITS = 4;
-        static final byte WRITE_OR_BITS = 5;
-        static final byte ALLOCATE = 6;
-        static final byte FREE = 7;
+        public static final byte READ_MEMORY = 1;
+        public static final byte READ_CSTRING = 2;
+        public static final byte WRITE_MEMORY = 3;
+        public static final byte WRITE_AND_BITS = 4;
+        public static final byte WRITE_OR_BITS = 5;
+        public static final byte ALLOCATE = 6;
+        public static final byte FREE = 7;
 
         // thread operations
-        static final byte THREAD_SUSPEND = 50;
-        static final byte THREAD_RESUME = 51;
-        static final byte THREAD_STEP = 52;
-        static final byte THREAD_INVOKE = 53;
-        static final byte THREAD_NEWSTRING = 54;
-        static final byte THREAD_NEWARRAY = 55;
-        static final byte THREAD_NEWINSTANCE = 56;
+        public static final byte THREAD_SUSPEND = 50;
+        public static final byte THREAD_RESUME = 51;
+        public static final byte THREAD_STEP = 52;
+        public static final byte THREAD_INVOKE = 53;
+        public static final byte THREAD_NEWSTRING = 54;
+        public static final byte THREAD_NEWARRAY = 55;
+        public static final byte THREAD_NEWINSTANCE = 56;
 
         // class operations
-        static final byte CLASS_FILTER = 70;
+        public static final byte CLASS_FILTER = 70;
     }
 
     public final static class events {
@@ -61,6 +61,14 @@ public final class HookConsts {
         public static final byte THREAD_STEPPED = 106;
         public static final byte CLASS_LOAD = 107;
         public static final byte EXCEPTION = 108;
+    }
+
+    public final static class threadSuspendStatus {
+        // events
+        public static final byte RUNNING = 0;
+        public static final byte SUSPENDED_SOFT = 1;
+        public static final byte SUSPENDED_PENDING_HARD = 2;
+        public static final byte SUSPENDED_HARD = 3;
     }
 
     public static String commandToString(int cmd) {

--- a/plugins/debugger/src/main/java/org/robovm/debugger/hooks/IHooksApi.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/hooks/IHooksApi.java
@@ -33,7 +33,7 @@ public interface IHooksApi {
     long allocate(int numBytes);
     void free(long addr);
     void classFilter(boolean isSet, String className);
-    void threadSuspend(long thread);
+    HooksCmdResponse threadSuspend(long thread);
     void threadResume(long thread);
     void threadStep(long thread, long pcLow, long pcHigh, long pcLow2, long pcHigh2);
     HooksCmdResponse threadInvoke(long thread, long classOrObjectPtr, String methodName, String descriptor,

--- a/plugins/debugger/src/main/java/org/robovm/debugger/hooks/payloads/HooksSuspendThreadPayload.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/hooks/payloads/HooksSuspendThreadPayload.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Justin Shapcott.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.debugger.hooks.payloads;
+
+/**
+ * @author Demyan Kimitsa
+ * Suspend thread response payload
+ */
+public class HooksSuspendThreadPayload {
+    private final HooksCallStackEntry[] callStack;
+    // JVM state of the thread 
+    private final int jvmThreadState;
+    // HOOK debug environment thread state: running/soft suspended/forced suspended 
+    private final int suspendThreadStatus;
+
+    public HooksSuspendThreadPayload(HooksCallStackEntry[] callStack, int jvmThreadState, int suspendThreadStatus) {
+        this.callStack = callStack;
+        this.jvmThreadState = jvmThreadState;
+        this.suspendThreadStatus = suspendThreadStatus;
+    }
+
+    public HooksCallStackEntry[] getCallStack() {
+        return callStack;
+    }
+
+    public int getJvmThreadState() {
+        return jvmThreadState;
+    }
+
+    public int getSuspendThreadStatus() {
+        return suspendThreadStatus;
+    }
+}

--- a/plugins/debugger/src/main/java/org/robovm/debugger/hooks/payloads/HooksThreadStoppedEventPayload.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/hooks/payloads/HooksThreadStoppedEventPayload.java
@@ -25,24 +25,27 @@ public class HooksThreadStoppedEventPayload extends HooksEventPayload{
     private final long threadObj;
     private final long thread;
     private final long throwable;
+    private final int threadStatus;
     private final boolean isCaught;
     private final HooksCallStackEntry[] callStack;
 
-    public HooksThreadStoppedEventPayload(int eventId, long threadObj, long thread, HooksCallStackEntry[] callStack) {
+    public HooksThreadStoppedEventPayload(int eventId, long threadObj, long thread, int threadStatus, HooksCallStackEntry[] callStack) {
         super(eventId);
         this.threadObj = threadObj;
         this.thread = thread;
         this.throwable = 0;
         this.isCaught = false;
+        this.threadStatus = threadStatus;
         this.callStack = callStack;
     }
 
-    public HooksThreadStoppedEventPayload(int eventId, long threadObj, long thread, long throwable, boolean isCaught, HooksCallStackEntry[] callStack) {
+    public HooksThreadStoppedEventPayload(int eventId, long threadObj, long thread, long throwable, boolean isCaught, int threadStatus, HooksCallStackEntry[] callStack) {
         super(eventId);
         this.threadObj = threadObj;
         this.thread = thread;
         this.throwable = throwable;
         this.isCaught = isCaught;
+        this.threadStatus = threadStatus;
         this.callStack = callStack;
     }
 
@@ -60,6 +63,10 @@ public class HooksThreadStoppedEventPayload extends HooksEventPayload{
 
     public boolean isCaught() {
         return isCaught;
+    }
+
+    public int getThreadStatus() {
+        return threadStatus;
     }
 
     public HooksCallStackEntry[] callStack() {

--- a/plugins/debugger/src/main/java/org/robovm/debugger/jdwp/JdwpConsts.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/jdwp/JdwpConsts.java
@@ -144,6 +144,7 @@ public class JdwpConsts {
     }
 
     public static class SuspendStatus {
+        public static final int SUSPEND_STATUS_NOT_SUSPENDED = 0x0;
         public static final int SUSPEND_STATUS_SUSPENDED = 0x1;
     }
 

--- a/plugins/debugger/src/main/java/org/robovm/debugger/jdwp/handlers/thread/JdwpThreadStatusHandler.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/jdwp/handlers/thread/JdwpThreadStatusHandler.java
@@ -15,10 +15,12 @@
  */
 package org.robovm.debugger.jdwp.handlers.thread;
 
+import org.robovm.debugger.hooks.HookConsts;
 import org.robovm.debugger.jdwp.JdwpConsts;
 import org.robovm.debugger.jdwp.protocol.IJdwpRequestHandler;
 import org.robovm.debugger.state.VmDebuggerState;
 import org.robovm.debugger.state.instances.VmThread;
+import org.robovm.debugger.utils.Converter;
 import org.robovm.debugger.utils.bytebuffer.DataBufferReader;
 import org.robovm.debugger.utils.bytebuffer.DataBufferWriter;
 
@@ -51,8 +53,12 @@ public class JdwpThreadStatusHandler implements IJdwpRequestHandler {
                 return JdwpConsts.Error.INVALID_THREAD;
 
             // return running all time as for now, as status (wait/sleeping) is not available on object level 
-            output.writeInt32(JdwpConsts.ThreadStatus.RUNNING);
-            output.writeInt32(thread.suspendCount() > 0 ? JdwpConsts.SuspendStatus.SUSPEND_STATUS_SUSPENDED : 0);
+            output.writeInt32(Converter.jdwpThreadStatus(thread));
+            // suspended -- only if thread is running suspend cycle that can execute invoke command
+            output.writeInt32(thread.getHookSuspendStatus() == HookConsts.threadSuspendStatus.SUSPENDED_SOFT ||
+                    thread.getHookSuspendStatus() == HookConsts.threadSuspendStatus.SUSPENDED_HARD
+                    ? JdwpConsts.SuspendStatus.SUSPEND_STATUS_SUSPENDED 
+                    : JdwpConsts.SuspendStatus.SUSPEND_STATUS_NOT_SUSPENDED);
         }
 
         return JdwpConsts.Error.NONE;

--- a/plugins/debugger/src/main/java/org/robovm/debugger/state/instances/VmThread.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/state/instances/VmThread.java
@@ -15,6 +15,8 @@
  */
 package org.robovm.debugger.state.instances;
 
+import org.robovm.debugger.hooks.HookConsts;
+import org.robovm.debugger.jdwp.JdwpConsts;
 import org.robovm.debugger.state.classdata.ClassInfo;
 
 /**
@@ -22,11 +24,6 @@ import org.robovm.debugger.state.classdata.ClassInfo;
  * Represend thread object received from target
  */
 public class VmThread extends VmInstance {
-
-    public enum Status {
-        SUSPENDED,
-        RUNNING
-    }
 
     /** native (not java) thread object pointer */
     private long threadPtr;
@@ -37,7 +34,8 @@ public class VmThread extends VmInstance {
     /** thread group */
     private final VmThreadGroup threadGroup;
 
-    private Status status;
+    private int jdwpThreadStatus;
+    private int hookSuspendStatus;
     private int suspendCount;
     private VmStackTrace[] stack;
 
@@ -47,7 +45,8 @@ public class VmThread extends VmInstance {
         this.threadPtr = threadPtr;
         this.name = name;
         this.threadGroup = threadGroup;
-        status = Status.RUNNING;
+        jdwpThreadStatus = JdwpConsts.ThreadStatus.RUNNING;
+        hookSuspendStatus = HookConsts.threadSuspendStatus.RUNNING;
     }
 
     public int suspendCount() {
@@ -93,12 +92,20 @@ public class VmThread extends VmInstance {
         this.stack = stack;
     }
 
-    public Status status() {
-        return status;
+    public int getJdwpThreadStatus() {
+        return jdwpThreadStatus;
     }
 
-    public void setStatus(Status status) {
-        this.status = status;
+    public void setJdwpThreadStatus(int jdwpThreadStatus) {
+        this.jdwpThreadStatus = jdwpThreadStatus;
+    }
+
+    public int getHookSuspendStatus() {
+        return hookSuspendStatus;
+    }
+
+    public void setHookSuspendStatus(int hookSuspendStatus) {
+        this.hookSuspendStatus = hookSuspendStatus;
     }
 
     @Override

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/Converter.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/Converter.java
@@ -20,6 +20,7 @@ import org.robovm.debugger.state.classdata.ClassDataConsts;
 import org.robovm.debugger.state.classdata.ClassInfo;
 import org.robovm.debugger.state.classdata.ClassInfoImpl;
 import org.robovm.debugger.state.classdata.ClassInfoLoader;
+import org.robovm.debugger.state.instances.VmThread;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -217,6 +218,17 @@ public final class Converter {
         else
             tag = 'L';
         return tag;
+    }
+
+    /**
+     * returns JDWP thread status
+     */
+    public static int jdwpThreadStatus(VmThread thread) {
+        int status = thread.getJdwpThreadStatus();
+        if (status >= JdwpConsts.ThreadStatus.ZOMBIE && status <= JdwpConsts.ThreadStatus.WAIT)
+            return status;
+        else
+            return JdwpConsts.ThreadStatus.RUNNING;
     }
 
     private final Map<Long, Byte> classInfoToTagMap = new HashMap<>();

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/StackTraceConverter.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/StackTraceConverter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 Justin Shapcott.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.debugger.utils;
+
+import org.robovm.debugger.delegates.AllDelegates;
+import org.robovm.debugger.hooks.HookConsts;
+import org.robovm.debugger.hooks.payloads.HooksCallStackEntry;
+import org.robovm.debugger.state.classdata.ClassInfo;
+import org.robovm.debugger.state.classdata.MethodInfo;
+import org.robovm.debugger.state.instances.VmStackTrace;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Demyan Kimitsa
+ * Converts hooks stack traces into debugger one
+ */
+public final class StackTraceConverter {
+
+    public static VmStackTrace[] convertCallStack(int eventId, HooksCallStackEntry[] callStack, AllDelegates delegates, DbgLogger log) {
+        List<VmStackTrace> result = new ArrayList<>();
+        for (HooksCallStackEntry entry : callStack) {
+            VmStackTrace stackTrace = convertStackTrace(eventId, entry, delegates, log);
+            if (stackTrace != null)
+                result.add(stackTrace);
+        }
+
+        if (result.size() == 0)
+            log.error(HookConsts.commandToString(eventId) + ": Empty callstack!");
+
+        return result.toArray(new VmStackTrace[0]);
+    }
+
+    private static VmStackTrace convertStackTrace(int eventId, HooksCallStackEntry payload, AllDelegates delegates, DbgLogger log) {
+        String signature = "L" + payload.clazzName() + ";";
+        ClassInfo classInfo = delegates.state().classInfoLoader().classInfoBySignature(signature);
+        if (classInfo == null) {
+            log.error(HookConsts.commandToString(eventId) + ": Failed to get get stack entry. Class is not known " +
+                    payload.clazzName());
+            return null;
+        }
+
+        // find method
+        MethodInfo[] methods = delegates.state().classInfoLoader().classMethods(classInfo);
+        long implPtr = delegates.runtime().toMachOAddr(payload.impl());
+        MethodInfo methodInfo = null;
+        for (MethodInfo mi : methods) {
+            if (mi.implPtr() == implPtr) {
+                methodInfo = mi;
+                break;
+            }
+        }
+
+        if (methodInfo == null) {
+            log.error(HookConsts.commandToString(eventId) + ": Failed to get get stack entry. Method not found for impl " +
+                    Long.toHexString(payload.impl()) + " class " + payload.clazzName());
+            return null;
+        }
+
+        // skip synthetic methods from being visible to debugger
+        if (methodInfo.isBridge() || methodInfo.isBroCallback() || methodInfo.isBroBridge())
+            return null;
+
+        return new VmStackTrace(classInfo, methodInfo, payload.lineNumber(), payload.fp(), payload.pc() - payload.impl());
+    }
+
+}


### PR DESCRIPTION
## background 
debugger was able to suspend thread only when code was reaching software breakpoint -- hook callback. so hitting "pause" in debugger in general wasn't doing anything if there was no hook instrumented java code running (e.g. threads are waiting on lock/sleep or running native message loop).
Also debugger wasn't picking JDWP thread statuses like sleeping/monitor etc.
![debugger-wrong-thread-state](https://user-images.githubusercontent.com/24827357/154701939-20c8d5d9-c9ef-441e-99e5-eee47be401c3.png)

## thread status 
thread status was not propagated from VM (hooks) to JDWP and was solved by extending the protocol.
![debugger-proper-states](https://user-images.githubusercontent.com/24827357/154702348-60650dbf-8aa2-4251-92ac-aa54388a0df1.png)

## changes to suspend threads
interrupt any random thread is possible by sending a signal to it. There is already two signals dedicated to RoboVM and introducing another one would be wastefully.
Lucky for us one signal was used to capture thread stack trace. Last ones also good to have when you suspend the thread. So it was extended to provide a callback to hooks infrastructure and if thread was pending for suspend -- suspend loop was running there. Debugger code was updated to support these changes in debugger-hooks protocol.

![debugger-sleeping-with-stack-trace](https://user-images.githubusercontent.com/24827357/154702240-24d58b1c-db75-4c80-a43f-700b61efe9ef.png)
