### PR TITLE
* CocoaTouch: NSObjectProtocol reverted in sake of NSObject

### DIFF
--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/contacts/CNContact.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/contacts/CNContact.java
@@ -139,7 +139,7 @@ import org.robovm.apple.foundation.*;
     @Method(selector = "comparatorForNameSortOrder:")
     public static native @Block Block2<String, String, NSComparisonResult> getNameComparator(CNContactSortOrder sortOrder);
     @Method(selector = "descriptorForAllComparatorKeys")
-    public static native NSObjectProtocol getDescriptorForAllComparatorKeys();
+    public static native NSObject getDescriptorForAllComparatorKeys();
     @Method(selector = "predicateForContactsMatchingName:")
     public static native NSPredicate getPredicateForContacts(String name);
     /**

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/contacts/CNContactFormatter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/contacts/CNContactFormatter.java
@@ -53,9 +53,9 @@ import org.robovm.apple.coretext.CTAttributedStringAttributes;
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "descriptorForRequiredKeysForNameOrder")
-    public static native NSObjectProtocol getDescriptorForRequiredKeysForNameOrder();
+    public static native NSObject getDescriptorForRequiredKeysForNameOrder();
     @Property(selector = "descriptorForRequiredKeysForDelimiter")
-    public static native NSObjectProtocol getDescriptorForRequiredKeysForDelimiter();
+    public static native NSObject getDescriptorForRequiredKeysForDelimiter();
     @Property(selector = "style")
     public native CNContactFormatterStyle getStyle();
     @Property(selector = "setStyle:")
@@ -91,7 +91,7 @@ import org.robovm.apple.coretext.CTAttributedStringAttributes;
     @Method(selector = "attributedStringFromContact:defaultAttributes:")
     public native NSAttributedString format(CNContact contact, NSDictionary<?, ?> attributes);
     @Method(selector = "descriptorForRequiredKeysForStyle:")
-    public static native NSObjectProtocol getDescriptorForRequiredKeys(CNContactFormatterStyle style);
+    public static native NSObject getDescriptorForRequiredKeys(CNContactFormatterStyle style);
     @Method(selector = "stringFromContact:style:")
     public static native String format(CNContact contact, CNContactFormatterStyle style);
     @Method(selector = "attributedStringFromContact:style:defaultAttributes:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/contacts/CNContactVCardSerialization.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/contacts/CNContactVCardSerialization.java
@@ -54,7 +54,7 @@ import org.robovm.apple.foundation.*;
     /*<members>*//*</members>*/
     /*<methods>*/
     @Method(selector = "descriptorForRequiredKeys")
-    public static native NSObjectProtocol getDescriptorForRequiredKeys();
+    public static native NSObject getDescriptorForRequiredKeys();
     public static NSData convertContactsToData(NSArray<CNContact> contacts) throws NSErrorException {
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
        NSData result = convertContactsToData(contacts, ptr);

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/contacts/CNMutableContact.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/contacts/CNMutableContact.java
@@ -171,7 +171,7 @@ import org.robovm.apple.foundation.*;
     @Method(selector = "comparatorForNameSortOrder:")
     public static native @Block Block2<String, String, NSComparisonResult> getNameComparator(CNContactSortOrder sortOrder);
     @Method(selector = "descriptorForAllComparatorKeys")
-    public static native NSObjectProtocol getDescriptorForAllComparatorKeys();
+    public static native NSObject getDescriptorForAllComparatorKeys();
     public static CNMutableContact createProviderDataObject(NSData data, String typeIdentifier) throws NSErrorException {
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
        CNMutableContact result = createProviderDataObject(data, typeIdentifier, ptr);

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/contactsui/CNContactViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/contactsui/CNContactViewController.java
@@ -103,7 +103,7 @@ import org.robovm.apple.uikit.*;
     @Method(selector = "highlightPropertyWithKey:identifier:")
     public native void highlightProperty(CNContactPropertyKey key, String identifier);
     @Method(selector = "descriptorForRequiredKeys")
-    public static native NSObjectProtocol getDescriptorForRequiredKeys();
+    public static native NSObject getDescriptorForRequiredKeys();
     @Method(selector = "viewControllerForContact:")
     public static native CNContactViewController createForContact(CNContact contact);
     @Method(selector = "viewControllerForUnknownContact:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/cryptotokenkit/TKTokenDriverConfiguration.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/cryptotokenkit/TKTokenDriverConfiguration.java
@@ -51,7 +51,7 @@ import org.robovm.apple.security.*;
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "driverConfigurations")
-    public static native NSDictionary<?, ?> getDriverConfigurations();
+    public static native NSDictionary<NSString, TKTokenDriverConfiguration> getDriverConfigurations();
     @Property(selector = "classID")
     public native String getClassID();
     @Property(selector = "tokenConfigurations")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSNotificationCenter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSNotificationCenter.java
@@ -103,6 +103,6 @@ import org.robovm.apple.dispatch.*;
     @Method(selector = "removeObserver:name:object:")
     public native void removeObserver(NSObject observer, NSString name, NSObject anObject);
     @Method(selector = "addObserverForName:object:queue:usingBlock:")
-    public native NSObjectProtocol addObserver(NSString name, NSObject obj, NSOperationQueue queue, @Block VoidBlock1<NSNotification> block);
+    public native NSObject addObserver(NSString name, NSObject obj, NSOperationQueue queue, @Block VoidBlock1<NSNotification> block);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSProcessInfo.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSProcessInfo.java
@@ -145,9 +145,9 @@ import org.robovm.apple.dispatch.*;
     @Method(selector = "isOperatingSystemAtLeastVersion:")
     public native boolean isOperatingSystemAtLeastVersion(@ByVal NSOperatingSystemVersion version);
     @Method(selector = "beginActivityWithOptions:reason:")
-    public native NSObjectProtocol beginActivity(NSActivityOptions options, String reason);
+    public native NSObject beginActivity(NSActivityOptions options, String reason);
     @Method(selector = "endActivity:")
-    public native void endActivity(NSObjectProtocol activity);
+    public native void endActivity(NSObject activity);
     @Method(selector = "performActivityWithOptions:reason:usingBlock:")
     public native void performActivity(NSActivityOptions options, String reason, @Block Runnable block);
     /**

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/gameplaykit/GKDecisionNode.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/gameplaykit/GKDecisionNode.java
@@ -57,10 +57,10 @@ import org.robovm.apple.uikit.*;
     /*<members>*//*</members>*/
     /*<methods>*/
     @Method(selector = "createBranchWithValue:attribute:")
-    public native GKDecisionNode createBranch(NSNumber value, NSObjectProtocol attribute);
+    public native GKDecisionNode createBranch(NSNumber value, NSObject attribute);
     @Method(selector = "createBranchWithPredicate:attribute:")
-    public native GKDecisionNode createBranch(NSPredicate predicate, NSObjectProtocol attribute);
+    public native GKDecisionNode createBranch(NSPredicate predicate, NSObject attribute);
     @Method(selector = "createBranchWithWeight:attribute:")
-    public native GKDecisionNode createBranch(@MachineSizedSInt long weight, NSObjectProtocol attribute);
+    public native GKDecisionNode createBranch(@MachineSizedSInt long weight, NSObject attribute);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/gameplaykit/GKDecisionTree.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/gameplaykit/GKDecisionTree.java
@@ -51,7 +51,7 @@ import org.robovm.apple.uikit.*;
     protected GKDecisionTree(Handle h, long handle) { super(h, handle); }
     protected GKDecisionTree(SkipInit skipInit) { super(skipInit); }
     @Method(selector = "initWithAttribute:")
-    public GKDecisionTree(NSObjectProtocol attribute) { super((SkipInit) null); initObject(init(attribute)); }
+    public GKDecisionTree(NSObject attribute) { super((SkipInit) null); initObject(init(attribute)); }
     @Method(selector = "initWithExamples:actions:attributes:")
     public GKDecisionTree(NSArray<?> examples, NSArray<?> actions, NSArray<?> attributes) { super((SkipInit) null); initObject(init(examples, actions, attributes)); }
     @Method(selector = "initWithURL:error:")
@@ -72,7 +72,7 @@ import org.robovm.apple.uikit.*;
     /*<members>*//*</members>*/
     /*<methods>*/
     @Method(selector = "initWithAttribute:")
-    protected native @Pointer long init(NSObjectProtocol attribute);
+    protected native @Pointer long init(NSObject attribute);
     @Method(selector = "initWithExamples:actions:attributes:")
     protected native @Pointer long init(NSArray<?> examples, NSArray<?> actions, NSArray<?> attributes);
     @Method(selector = "initWithURL:error:")
@@ -80,7 +80,7 @@ import org.robovm.apple.uikit.*;
     @Method(selector = "exportToURL:error:")
     public native boolean exportToURL(NSURL url, NSError error);
     @Method(selector = "findActionForAnswers:")
-    public native NSObjectProtocol findActionForAnswers(NSDictionary<?, ?> answers);
+    public native NSObject findActionForAnswers(NSDictionary<?, ?> answers);
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder coder);
     @Method(selector = "initWithCoder:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/gameplaykit/GKNSPredicateRule.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/gameplaykit/GKNSPredicateRule.java
@@ -64,8 +64,8 @@ import org.robovm.apple.uikit.*;
     @Method(selector = "evaluatePredicateWithSystem:")
     public native boolean evaluatePredicate(GKRuleSystem system);
     @Method(selector = "ruleWithPredicate:assertingFact:grade:")
-    public static native GKNSPredicateRule createAssertingFact(NSPredicate predicate, NSObjectProtocol fact, float grade);
+    public static native GKNSPredicateRule createAssertingFact(NSPredicate predicate, NSObject fact, float grade);
     @Method(selector = "ruleWithPredicate:retractingFact:grade:")
-    public static native GKNSPredicateRule createRetractingFact(NSPredicate predicate, NSObjectProtocol fact, float grade);
+    public static native GKNSPredicateRule createRetractingFact(NSPredicate predicate, NSObject fact, float grade);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/gameplaykit/GKRule.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/gameplaykit/GKRule.java
@@ -65,9 +65,9 @@ import org.robovm.apple.uikit.*;
     @Method(selector = "performActionWithSystem:")
     public native void performAction(GKRuleSystem system);
     @Method(selector = "ruleWithPredicate:assertingFact:grade:")
-    public static native GKRule createAssertingFact(NSPredicate predicate, NSObjectProtocol fact, float grade);
+    public static native GKRule createAssertingFact(NSPredicate predicate, NSObject fact, float grade);
     @Method(selector = "ruleWithPredicate:retractingFact:grade:")
-    public static native GKRule createRetractingFact(NSPredicate predicate, NSObjectProtocol fact, float grade);
+    public static native GKRule createRetractingFact(NSPredicate predicate, NSObject fact, float grade);
     @Method(selector = "ruleWithBlockPredicate:action:")
     protected static native @Pointer long create(@Block Block1<GKRuleSystem, Boolean> predicate, @Block VoidBlock1<GKRuleSystem> action);
     /*</methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/gameplaykit/GKRuleSystem.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/gameplaykit/GKRuleSystem.java
@@ -74,19 +74,19 @@ import org.robovm.apple.uikit.*;
     @Method(selector = "removeAllRules")
     public native void removeAllRules();
     @Method(selector = "gradeForFact:")
-    public native float getGradeForFact(NSObjectProtocol fact);
+    public native float getGradeForFact(NSObject fact);
     @Method(selector = "minimumGradeForFacts:")
     public native float getMinimumGradeForFacts(NSArray<?> facts);
     @Method(selector = "maximumGradeForFacts:")
     public native float getMaximumGradeForFacts(NSArray<?> facts);
     @Method(selector = "assertFact:")
-    public native void assertFact(NSObjectProtocol fact);
+    public native void assertFact(NSObject fact);
     @Method(selector = "assertFact:grade:")
-    public native void assertFact(NSObjectProtocol fact, float grade);
+    public native void assertFact(NSObject fact, float grade);
     @Method(selector = "retractFact:")
-    public native void retractFact(NSObjectProtocol fact);
+    public native void retractFact(NSObject fact);
     @Method(selector = "retractFact:grade:")
-    public native void retractFact(NSObjectProtocol fact, float grade);
+    public native void retractFact(NSObject fact, float grade);
     @Method(selector = "reset")
     public native void reset();
     /*</methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/scenekit/SCNTechnique.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/scenekit/SCNTechnique.java
@@ -88,7 +88,7 @@ import org.robovm.apple.avfoundation.*;
      * @since Available in iOS 9.0 and later.
      */
     @Method(selector = "setObject:forKeyedSubscript:")
-    public native void setObjectForKeyedSubscript(NSObject obj, NSObjectProtocol key);
+    public native void setObjectForKeyedSubscript(NSObject obj, NSObject key);
     @Method(selector = "techniqueWithDictionary:")
     public static native SCNTechnique create(NSDictionary<NSString, ?> dictionary);
     @Method(selector = "techniqueBySequencingTechniques:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/soundanalysis/SNClassificationResult.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/soundanalysis/SNClassificationResult.java
@@ -53,7 +53,7 @@ import org.robovm.apple.coreml.*;
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "classifications")
-    public native NSArray<?> getClassifications();
+    public native NSArray<SNClassification> getClassifications();
     @Property(selector = "timeRange")
     public native @ByVal CMTimeRange getTimeRange();
     /*</properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityCustomRotorItemResult.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityCustomRotorItemResult.java
@@ -59,13 +59,13 @@ import org.robovm.apple.linkpresentation.*;
     protected UIAccessibilityCustomRotorItemResult(Handle h, long handle) { super(h, handle); }
     protected UIAccessibilityCustomRotorItemResult(SkipInit skipInit) { super(skipInit); }
     @Method(selector = "initWithTargetElement:targetRange:")
-    public UIAccessibilityCustomRotorItemResult(NSObjectProtocol targetElement, UITextRange targetRange) { super((SkipInit) null); initObject(init(targetElement, targetRange)); }
+    public UIAccessibilityCustomRotorItemResult(NSObject targetElement, UITextRange targetRange) { super((SkipInit) null); initObject(init(targetElement, targetRange)); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "targetElement")
-    public native NSObjectProtocol getTargetElement();
+    public native NSObject getTargetElement();
     @Property(selector = "setTargetElement:", strongRef = true)
-    public native void setTargetElement(NSObjectProtocol v);
+    public native void setTargetElement(NSObject v);
     @Property(selector = "targetRange")
     public native UITextRange getTargetRange();
     @Property(selector = "setTargetRange:")
@@ -74,6 +74,6 @@ import org.robovm.apple.linkpresentation.*;
     /*<members>*//*</members>*/
     /*<methods>*/
     @Method(selector = "initWithTargetElement:targetRange:")
-    protected native @Pointer long init(NSObjectProtocol targetElement, UITextRange targetRange);
+    protected native @Pointer long init(NSObject targetElement, UITextRange targetRange);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollisionBehavior.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollisionBehavior.java
@@ -88,13 +88,13 @@ import org.robovm.apple.linkpresentation.*;
     @Method(selector = "setTranslatesReferenceBoundsIntoBoundaryWithInsets:")
     public native void setTranslatesReferenceBoundsIntoBoundary(@ByVal UIEdgeInsets insets);
     @Method(selector = "addBoundaryWithIdentifier:forPath:")
-    public native void addBoundary(NSObjectProtocol identifier, UIBezierPath bezierPath);
+    public native void addBoundary(NSObject identifier, UIBezierPath bezierPath);
     @Method(selector = "addBoundaryWithIdentifier:fromPoint:toPoint:")
-    public native void addBoundary(NSObjectProtocol identifier, @ByVal CGPoint p1, @ByVal CGPoint p2);
+    public native void addBoundary(NSObject identifier, @ByVal CGPoint p1, @ByVal CGPoint p2);
     @Method(selector = "boundaryWithIdentifier:")
-    public native UIBezierPath getBoundary(NSObjectProtocol identifier);
+    public native UIBezierPath getBoundary(NSObject identifier);
     @Method(selector = "removeBoundaryWithIdentifier:")
-    public native void removeBoundary(NSObjectProtocol identifier);
+    public native void removeBoundary(NSObject identifier);
     @Method(selector = "removeAllBoundaries")
     public native void removeAllBoundaries();
     /*</methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollisionBehaviorDelegate.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollisionBehaviorDelegate.java
@@ -62,9 +62,9 @@ import org.robovm.apple.linkpresentation.*;
     @Method(selector = "collisionBehavior:endedContactForItem:withItem:")
     void endedContact(UICollisionBehavior behavior, UIDynamicItem item1, UIDynamicItem item2);
     @Method(selector = "collisionBehavior:beganContactForItem:withBoundaryIdentifier:atPoint:")
-    void beganBoundaryContact(UICollisionBehavior behavior, UIDynamicItem item, NSObjectProtocol identifier, @ByVal CGPoint p);
+    void beganBoundaryContact(UICollisionBehavior behavior, UIDynamicItem item, NSObject identifier, @ByVal CGPoint p);
     @Method(selector = "collisionBehavior:endedContactForItem:withBoundaryIdentifier:")
-    void endedBoundaryContact(UICollisionBehavior behavior, UIDynamicItem item, NSObjectProtocol identifier);
+    void endedBoundaryContact(UICollisionBehavior behavior, UIDynamicItem item, NSObject identifier);
     /*</methods>*/
     /*<adapter>*/
     /*</adapter>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollisionBehaviorDelegateAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollisionBehaviorDelegateAdapter.java
@@ -64,8 +64,8 @@ import org.robovm.apple.linkpresentation.*;
     @NotImplemented("collisionBehavior:endedContactForItem:withItem:")
     public void endedContact(UICollisionBehavior behavior, UIDynamicItem item1, UIDynamicItem item2) {}
     @NotImplemented("collisionBehavior:beganContactForItem:withBoundaryIdentifier:atPoint:")
-    public void beganBoundaryContact(UICollisionBehavior behavior, UIDynamicItem item, NSObjectProtocol identifier, @ByVal CGPoint p) {}
+    public void beganBoundaryContact(UICollisionBehavior behavior, UIDynamicItem item, NSObject identifier, @ByVal CGPoint p) {}
     @NotImplemented("collisionBehavior:endedContactForItem:withBoundaryIdentifier:")
-    public void endedBoundaryContact(UICollisionBehavior behavior, UIDynamicItem item, NSObjectProtocol identifier) {}
+    public void endedBoundaryContact(UICollisionBehavior behavior, UIDynamicItem item, NSObject identifier) {}
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIContextMenuConfiguration.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIContextMenuConfiguration.java
@@ -58,15 +58,15 @@ import org.robovm.apple.linkpresentation.*;
     public UIContextMenuConfiguration() {}
     protected UIContextMenuConfiguration(Handle h, long handle) { super(h, handle); }
     protected UIContextMenuConfiguration(SkipInit skipInit) { super(skipInit); }
-    public UIContextMenuConfiguration(NSObjectProtocol identifier, @Block Block0<UIViewController> previewProvider, @Block Block1<NSArray<UIMenuElement>, UIMenu> actionProvider) { super((Handle) null, create(identifier, previewProvider, actionProvider)); retain(getHandle()); }
+    public UIContextMenuConfiguration(NSObject identifier, @Block Block0<UIViewController> previewProvider, @Block Block1<NSArray<UIMenuElement>, UIMenu> actionProvider) { super((Handle) null, create(identifier, previewProvider, actionProvider)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "identifier")
-    public native NSObjectProtocol getIdentifier();
+    public native NSObject getIdentifier();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
     @Method(selector = "configurationWithIdentifier:previewProvider:actionProvider:")
-    protected static native @Pointer long create(NSObjectProtocol identifier, @Block Block0<UIViewController> previewProvider, @Block Block1<NSArray<UIMenuElement>, UIMenu> actionProvider);
+    protected static native @Pointer long create(NSObject identifier, @Block Block0<UIViewController> previewProvider, @Block Block1<NSArray<UIMenuElement>, UIMenu> actionProvider);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPointerRegion.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPointerRegion.java
@@ -58,13 +58,13 @@ import org.robovm.apple.linkpresentation.*;
     protected UIPointerRegion() {}
     protected UIPointerRegion(Handle h, long handle) { super(h, handle); }
     protected UIPointerRegion(SkipInit skipInit) { super(skipInit); }
-    public UIPointerRegion(@ByVal CGRect rect, NSObjectProtocol identifier) { super((Handle) null, create(rect, identifier)); retain(getHandle()); }
+    public UIPointerRegion(@ByVal CGRect rect, NSObject identifier) { super((Handle) null, create(rect, identifier)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "rect")
     public native @ByVal CGRect getRect();
     @Property(selector = "identifier")
-    public native NSObjectProtocol getIdentifier();
+    public native NSObject getIdentifier();
     @Property(selector = "latchingAxes")
     public native UIAxis getLatchingAxes();
     @Property(selector = "setLatchingAxes:")
@@ -73,6 +73,6 @@ import org.robovm.apple.linkpresentation.*;
     /*<members>*//*</members>*/
     /*<methods>*/
     @Method(selector = "regionWithRect:identifier:")
-    protected static native @Pointer long create(@ByVal CGRect rect, NSObjectProtocol identifier);
+    protected static native @Pointer long create(@ByVal CGRect rect, NSObject identifier);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/vision/VNClassifyImageRequest.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/vision/VNClassifyImageRequest.java
@@ -90,9 +90,9 @@ import org.robovm.apple.imageio.*;
      * @deprecated Deprecated in iOS 15.0. Use -supportedIdentifiersAndReturnError:
      */
     @Deprecated
-    public static NSArray<?> getKnownClassificationsForRevision(@MachineSizedUInt long requestRevision) throws NSErrorException {
+    public static NSArray<VNClassificationObservation> getKnownClassificationsForRevision(@MachineSizedUInt long requestRevision) throws NSErrorException {
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
-       NSArray<?> result = getKnownClassificationsForRevision(requestRevision, ptr);
+       NSArray<VNClassificationObservation> result = getKnownClassificationsForRevision(requestRevision, ptr);
        if (ptr.get() != null) { throw new NSErrorException(ptr.get()); }
        return result;
     }
@@ -102,6 +102,6 @@ import org.robovm.apple.imageio.*;
      */
     @Deprecated
     @Method(selector = "knownClassificationsForRevision:error:")
-    private static native NSArray<?> getKnownClassificationsForRevision(@MachineSizedUInt long requestRevision, NSError.NSErrorPtr error);
+    private static native NSArray<VNClassificationObservation> getKnownClassificationsForRevision(@MachineSizedUInt long requestRevision, NSError.NSErrorPtr error);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/vision/VNRecognizedObjectObservation.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/vision/VNRecognizedObjectObservation.java
@@ -57,7 +57,7 @@ import org.robovm.apple.imageio.*;
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "labels")
-    public native NSArray<?> getLabels();
+    public native NSArray<VNClassificationObservation> getLabels();
     @Property(selector = "supportsSecureCoding")
     public static native boolean supportsSecureCoding();
     /*</properties>*/


### PR DESCRIPTION
fix for https://github.com/MobiVM/robovm/issues/629

Root case(s):
1. some apis return id<nsobject> and accept back id.
In case of RoboVM 2.3.16 bind these types as following:
* id<nsobject> -> NSObjectProtocol
* id -> NSObject

2. there is significant moment: CocoaTouch defines all NSObject apis in NSObject protocol and keeps NSObject class empty. While RoboVM has opposite implementation: NSObjectProtocol is empty

3. RoboVM handle retain/release for NSObject subclasses and there is might be issues with NSObjectProtocol