### PR TITLE
* idea fixes #631, #630

### DIFF
--- a/plugins/idea/src/main/java/org/robovm/idea/RoboVmPlugin.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/RoboVmPlugin.java
@@ -457,7 +457,7 @@ public class RoboVmPlugin {
         }
 
         // check if there's any RoboVM RT libs in the classpath
-        OrderEnumerator classes = ModuleRootManager.getInstance(module).orderEntries().recursively().withoutSdk().compileOnly();
+        OrderEnumerator classes = ModuleRootManager.getInstance(module).orderEntries().withoutSdk().compileOnly();
         for (String path : classes.getPathsList().getPathList()) {
             if (isSdkLibrary(path)) {
                 return true;

--- a/plugins/idea/src/main/java/org/robovm/idea/components/RoboVmSdkUpdateComponent.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/components/RoboVmSdkUpdateComponent.java
@@ -63,7 +63,9 @@ public class RoboVmSdkUpdateComponent implements ModuleComponent {
         ApplicationManager.getApplication().invokeLater(() -> ApplicationManager.getApplication().runWriteAction(() -> {
             // module might already have been disposed, need to fetch it
             // by name
-            Module module = ModuleManager.getInstance(project).findModuleByName(moduleToUpdate.getName());
+            Module module = (!project.isDisposed() && !moduleToUpdate.isDisposed())
+                    ? ModuleManager.getInstance(project).findModuleByName(moduleToUpdate.getName())
+                    : null;
             if (module != null) {
                 ModuleRootManager manager = ModuleRootManager.getInstance(module);
                 ModifiableRootModel model = manager.getModifiableModel();


### PR DESCRIPTION
This is a workaround for issues:
#630 IDEA Plugin: Reopening Project give IDE Error
major fix for it was done in #604, but seems like projects with huge amount of modules might cause delayed execution at moment where project is disposed.
Its pure workaround as corresponding code has to be refactored as uses deprecated APIS

#631 IDEA Plugin: UI Freezes
Same conditions here: project with 100+ modules. Removing `recursive()` for dependencies evaluation. This should speed-up huge projects. But will affect modules where RoboVM dependencies are obtained transitively. Anyway we have to refactor this logic to use Facet to identify module as RoboVM one