### PR TITLE
Add ability to configure classpathEntries from gradle.

### DIFF
--- a/plugins/gradle/src/main/java/org/robovm/gradle/RoboVMPluginExtension.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/RoboVMPluginExtension.java
@@ -46,6 +46,8 @@ public class RoboVMPluginExtension {
     private String keychainPassword;
     private String keychainPasswordFile;
     private boolean dumpIntermediates = false;
+    private String configurationName;
+    private boolean skipDefaultClasspathEntries = false;
 
     public RoboVMPluginExtension(Project project) {
         this.project = project;
@@ -251,4 +253,22 @@ public class RoboVMPluginExtension {
 	public void setDumpIntermediates(boolean dumpIntermediates) {
 		this.dumpIntermediates = dumpIntermediates;
 	}
+
+    public String getConfigurationName() {
+        return project.hasProperty("robovm.configurationName") ? project.getProperties().get("robovm.configurationName").toString() : configurationName;
+    }
+
+    public void setConfigurationName(String configurationName) {
+        this.configurationName = configurationName;
+    }
+
+    public boolean isSkipDefaultClasspathEntries() {
+        return project.hasProperty("robovm.skipDefaultClasspathEntries")
+                ? Boolean.parseBoolean(project.getProperties().get("robovm.skipDefaultClasspathEntries").toString())
+                : skipDefaultClasspathEntries;
+    }
+
+    public void setSkipDefaultClasspathEntries(boolean skipDefaultClasspathEntries) {
+        this.skipDefaultClasspathEntries = skipDefaultClasspathEntries;
+    }
 }

--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMTask.java
@@ -227,13 +227,21 @@ abstract public class AbstractRoboVMTask extends DefaultTask {
         builder.clearClasspathEntries();
 
         // configure the runtime classpath
-        Set<File> classpathEntries = project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).getFiles();
-        classpathEntries.add(new File(project.getBuildDir(), "classes/main"));
-        classpathEntries.add(new File(project.getBuildDir(), "classes/java/main"));
-        classpathEntries.add(new File(project.getBuildDir(), "classes/groovy/main"));
-        classpathEntries.add(new File(project.getBuildDir(), "classes/scala/main"));
-        classpathEntries.add(new File(project.getBuildDir(), "classes/kotlin/main"));
-        classpathEntries.add(new File(project.getBuildDir(), "resources/main"));
+        Set<File> classpathEntries;
+        if(extension.getConfigurationName() != null) {
+            classpathEntries = project.getConfigurations().getByName(extension.getConfigurationName()).getFiles();
+        } else {
+            classpathEntries = project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).getFiles();
+        }
+
+        if(!extension.isSkipDefaultClasspathEntries()) {
+            classpathEntries.add(new File(project.getBuildDir(), "classes/main"));
+            classpathEntries.add(new File(project.getBuildDir(), "classes/java/main"));
+            classpathEntries.add(new File(project.getBuildDir(), "classes/groovy/main"));
+            classpathEntries.add(new File(project.getBuildDir(), "classes/scala/main"));
+            classpathEntries.add(new File(project.getBuildDir(), "classes/kotlin/main"));
+            classpathEntries.add(new File(project.getBuildDir(), "resources/main"));
+        }
 
         if (project.hasProperty("output.classesDir")) {
             classpathEntries.add((File) project.property("output.classesDir"));


### PR DESCRIPTION
This should allow building an alternative configuration other than the default runtimeClasspath. This can be used to build a more finely controlled classpath, including prebuilt jars while keeping the quality of life of the gradle plugin.

```
configurations { custom }

dependencies {
    custom "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-ios"
    custom "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-ios"
    custom files('local_jar.jar')
}

robovm {
    configurationName custom
    skipDefaultClasspathEntries true
}
```

This PR is untested, but I believe it should compile/function as intended.