### PR TITLE
changes in swiftSupport logic

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/AppCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/AppCompiler.java
@@ -43,8 +43,6 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
-import java.util.concurrent.*;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
@@ -53,9 +51,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
-import java.net.URL;
-import java.net.URLConnection;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -1043,7 +1038,7 @@ public class AppCompiler {
     }
 
     private static void printVersionAndExit() {
-        System.err.println(Version.getVersion());
+        System.err.println(Version.getCompilerVersion());
         System.exit(0);
     }
 
@@ -1283,7 +1278,7 @@ public class AppCompiler {
             String osVersion = System.getProperty("os.version", "Unknown");
             UpdateChecker t = new UpdateChecker("http://robovm.mobidevelop.com/version?"
                     + "uuid=" + URLEncoder.encode(uuid, "UTF-8") + "&"
-                    + "version=" + URLEncoder.encode(Version.getVersion(), "UTF-8") + "&"
+                    + "version=" + URLEncoder.encode(Version.getCompilerVersion(), "UTF-8") + "&"
                     + "osName=" + URLEncoder.encode(osName, "UTF-8") + "&"
                     + "osArch=" + URLEncoder.encode(osArch, "UTF-8") + "&"
                     + "osVersion=" + URLEncoder.encode(osVersion, "UTF-8"));
@@ -1292,9 +1287,9 @@ public class AppCompiler {
             JSONObject result = t.result;
             if (result != null) {
                 String version = (String) result.get("version");
-                if (version != null && Version.isOlderThan(version)) {
+                if (version != null && Version.isOlderThan(Version.getCompilerVersion(), version)) {
                     config.getLogger().info("A new version of RoboVM is available. "
-                            + "Current version: %s. New version: %s.", Version.getVersion(), version);
+                            + "Current version: %s. New version: %s.", Version.getCompilerVersion(), version);
                 }
             }
         } catch (Throwable t) {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/Version.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/Version.java
@@ -16,91 +16,178 @@
  */
 package org.robovm.compiler;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
-import org.apache.commons.io.IOUtils;
-
 /**
  * Reads the compiler version from auto generated <code>version.properties</code> file.
  */
-public class Version {
+public final class Version implements Comparable<Version>{
 
-    private static String version = null;
+    enum BuildType {
+        Snapshot("-SNAPSHOT"),
+        Alpha("-alpha-"),
+        Beta("-beta-"),
+        RC("-rc-"),
+        Release(null);
+
+        private final String suffix;
+
+        BuildType(String suffix) {
+            this.suffix = suffix;
+        }
+
+        String suffixWithBuild(int build) {
+            switch (this) {
+                case Snapshot: return this.suffix;
+                case Alpha:
+                case Beta:
+                case RC: return this.suffix + build;
+                default: return "";
+            }
+        }
+    }
+
+    // parts of version -- parsed dot separated values "1.2.3" -> [1,2,3]
+    public final int[] parts;
+    public final int build;
+    public final BuildType buildType;
+
+    public Version(BuildType buildType, int buildPart, int ...parts) {
+        this.buildType = buildType;
+        this.build = buildPart;
+        this.parts = parts;
+    }
+
+    public Version(int ...parts) {
+        this(BuildType.Release, 1, parts);
+    }
+
+    @Override
+    public int compareTo(Version other) {
+        // compare by type
+        int diff = buildType.compareTo(other.buildType);
+        if (diff != 0)
+            return diff;
+
+        // by common version numbers
+        int commonPart = Math.min(parts.length, other.parts.length);
+        for (int i = 0; i < commonPart; i++) {
+            diff = parts[i] - other.parts[i];
+            if (diff != 0)
+                return diff;
+        }
+
+        // common part is same
+        diff = parts.length - other.parts.length;
+        if (diff != 0) return diff;
+
+        return build - other.build;
+    }
+
+    public int[] getParts() {
+        return parts;
+    }
+
+    public BuildType getBuildType() {
+        return buildType;
+    }
+
+    public int getMajor() {
+        return parts[0];
+    }
+
+    public int getMinor() {
+        return parts.length > 1 ? parts[1] : 0;
+    }
+
+    public int getRevision() {
+        return parts.length > 2 ? parts[2] : 0;
+    }
+
+    public int getBuild() {
+        return build;
+    }
+
+    public static Version parse(String v) {
+        String buildPart = "";
+        BuildType buildType = BuildType.Release;
+        if (v.endsWith(BuildType.Snapshot.suffix)) {
+            buildPart = "";
+            v = v.substring(0, v.indexOf(BuildType.Snapshot.suffix));
+            buildType = BuildType.Snapshot;
+        } else if (v.contains(BuildType.Alpha.suffix)) {
+            buildPart = v.substring(v.lastIndexOf('-') + 1);
+            v = v.substring(0, v.indexOf(BuildType.Alpha.suffix));
+            buildType = BuildType.Alpha;
+        } else if (v.contains(BuildType.Beta.suffix)) {
+            buildPart = v.substring(v.lastIndexOf('-') + 1);
+            v = v.substring(0, v.indexOf(BuildType.Beta.suffix));
+            buildType = BuildType.Beta;
+        } else if (v.contains(BuildType.RC.suffix)) {
+            buildPart = v.substring(v.lastIndexOf('-') + 1);
+            v = v.substring(0, v.indexOf(BuildType.RC.suffix));
+            buildType = BuildType.RC;
+        }
+
+        String[] tokens = v.split("\\.");
+        int[] parts = new int[tokens.length];
+        for (int i = 0; i < tokens.length; i++)
+            parts[i] = Integer.parseInt(tokens[i]);
+
+        int build = buildPart.isEmpty() ? 0 : Integer.parseInt(buildPart);
+        return new Version(buildType, build, parts);
+    }
+
+    public static Version parseOrNull(String v) {
+        try {
+            return parse(v);
+        } catch (Exception ignored) {
+        }
+
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return StringUtils.join(parts, '.') + buildType.suffixWithBuild(build);
+    }
+
+    private static String versionString = null;
+    private static Version version = null;
     private static String PROPERTIES_RESOURCE = "/META-INF/robovm/version.properties";
-
     /**
      * Returns the version number of the compiler by reading the <code>version.properties</code>
      * file.
      * 
      * @return the version.
      */
-    public static String getVersion() {
-        if (version != null) {
-            return version;
+    public static String getCompilerVersion() {
+        if (versionString != null) {
+            return versionString;
         }
-        InputStream is = null;
-        try {
-            is = Version.class.getResourceAsStream(PROPERTIES_RESOURCE);
+        try(InputStream is = Version.class.getResourceAsStream(PROPERTIES_RESOURCE)) {
             Properties props = new Properties();
             props.load(is);
-            version = props.getProperty("version");
-            return version;
+            versionString = props.getProperty("version");
+            return versionString;
         } catch (IOException e) {
             throw new RuntimeException(e);
-        } finally {
-            IOUtils.closeQuietly(is);
         }
     }
-    
-    /**
-     * Converts a version string on the form x.y.z into an integer which can
-     * be compared to other versions converted into integers.
-     */
-    static long toLong(String v) {
-        String buildPart = "1";
-        long buildType = 700;
-        if (v.endsWith("-SNAPSHOT")) {
-            buildPart = "";
-            v = v.substring(0, v.indexOf("-SNAPSHOT"));
-            buildType = 0;
-        } else if (v.contains("-alpha-")) {
-            buildPart = v.substring(v.lastIndexOf('-') + 1);
-            v = v.substring(0, v.indexOf("-alpha-"));
-            buildType = 100;
-        } else if (v.contains("-beta-")) {
-            buildPart = v.substring(v.lastIndexOf('-') + 1);
-            v = v.substring(0, v.indexOf("-beta-"));
-            buildType = 300;
-        } else if (v.contains("-rc-")) {
-            buildPart = v.substring(v.lastIndexOf('-') + 1);
-            v = v.substring(0, v.indexOf("-rc-"));
-            buildType = 500;
-        }
-        
-        String[] parts = v.split("\\.");
-        if (parts.length > 3) {
-            throw new IllegalArgumentException("Illegal version number: " + v);
-        }
-        
-        long major = parts.length > 0 ? Long.parseLong(parts[0]) : 0;
-        long minor = parts.length > 1 ? Long.parseLong(parts[1]) : 0;
-        long rev = parts.length > 2 ? Long.parseLong(parts[2]) : 0;
-        long build = buildPart.isEmpty() ? 0 : Long.parseLong(buildPart);
-        long result = (((major * 1000 + minor) * 1000 + rev) * 1000) + build + buildType;
-        return result;
-    }
-    
+
     /**
      * Returns <code>true</code> if this version is less than the specified
      * version number.
      */
-    public static boolean isOlderThan(String otherVersion) {
-        return toLong(getVersion()) < toLong(otherVersion);
+    public static boolean isOlderThan(String version, String otherVersion) {
+        return parse(version).compareTo(parse(otherVersion)) < 0;
     }
     
     public static void main(String[] args) {
-        System.out.println(toLong("1.0.0-alpha-01"));
+        System.out.println(parse("1.0.0-alpha-01"));
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -1086,7 +1086,7 @@ public class Config {
             this.rtPath = rtPath;
             cacertsPath = new HashMap<>();
             cacertsPath.put(Cacerts.full, new File(devDir,
-                    "cacerts/full/target/robovm-cacerts-full-" + Version.getVersion() + ".jar"));
+                    "cacerts/full/target/robovm-cacerts-full-" + Version.getCompilerVersion() + ".jar"));
             this.dev = true;
         }
 
@@ -1178,7 +1178,7 @@ public class Config {
             // Compare the version of this compiler with the version of the
             // robovm-rt.jar in the home dir. They have to match.
             try {
-                String thisVersion = Version.getVersion();
+                String thisVersion = Version.getCompilerVersion();
                 String thatVersion = getImplementationVersion(rtJarFile);
                 if (thisVersion == null || !thisVersion.equals(thatVersion)) {
                     throw new IllegalArgumentException(error + "version mismatch (expected: "
@@ -1210,7 +1210,7 @@ public class Config {
                 throw new IllegalArgumentException(error + "bin/ missing or invalid");
             }
 
-            String rtJarName = "robovm-rt-" + Version.getVersion() + ".jar";
+            String rtJarName = "robovm-rt-" + Version.getCompilerVersion() + ".jar";
             File rtJar = new File(dir, "rt/target/" + rtJarName);
             File rtClasses = new File(dir, "rt/target/classes/");
             File rtSource = rtJar;

--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/SwiftSupport.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/SwiftSupport.java
@@ -19,8 +19,19 @@ public class SwiftSupport {
     @ElementList(required = false, entry = "path")
     private ArrayList<Config.QualifiedFile> swiftLibPaths;
 
+    /**
+     * specifies if swift runtime libraries to be copied
+     */
+    @Element(required = false)
+    private Boolean copySwiftLibs = true;
+
+
     public List<Config.QualifiedFile> getSwiftLibPaths() {
         return swiftLibPaths == null ? Collections.emptyList()
                 : Collections.unmodifiableList(swiftLibPaths);
+    }
+
+    public boolean shouldCopySwiftLibs() {
+        return copySwiftLibs != null ? copySwiftLibs : true;
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/debug/dwarf/DICompileUnit.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/debug/dwarf/DICompileUnit.java
@@ -46,7 +46,7 @@ public class DICompileUnit extends DIBaseItem {
                         //    i32,       ;; DWARF language identifier (ex. DW_LANG_C89)
                         .add(DwarfConst.SourceLanguage.LANG_Java)
                         //    mdstring,  ;; Producer (ex. "4.0.1 LLVM (LLVM research group)")
-                        .add("RoboVM " + Version.getVersion())
+                        .add("RoboVM " + Version.getCompilerVersion())
                         //    i1,        ;; True if this is optimized.
                         .add(false)
                         //    mdstring,  ;; Flags

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -310,10 +310,12 @@ public class IOSTarget extends AbstractTarget {
         libArgs.add(sdk.getVersion());
 
         // add runtime path to swift libs first to support swift-5 libs location
-        libArgs.add("-Xlinker");
-        libArgs.add("-rpath");
-        libArgs.add("-Xlinker");
-        libArgs.add("/usr/lib/swift");
+        if (config.hasSwiftSupport()) {
+            libArgs.add("-Xlinker");
+            libArgs.add("-rpath");
+            libArgs.add("-Xlinker");
+            libArgs.add("/usr/lib/swift");
+        }
         // specify dynamic library loading path
         libArgs.add("-Xlinker");
         libArgs.add("-rpath");
@@ -842,7 +844,7 @@ public class IOSTarget extends AbstractTarget {
                 .exec();
 
         File frameworksDir = new File(appDir, "Frameworks");
-        if (frameworksDir.exists()){
+        if (frameworksDir.exists() && config.hasSwiftSupport() && config.getSwiftSupport().shouldCopySwiftLibs()){
             String[] swiftLibs = frameworksDir.list(new AndFileFilter(
                     new PrefixFileFilter("libswift"),
                     new SuffixFileFilter(".dylib")));

--- a/compiler/compiler/src/test/java/org/robovm/compiler/VersionTest.java
+++ b/compiler/compiler/src/test/java/org/robovm/compiler/VersionTest.java
@@ -26,14 +26,36 @@ import org.junit.Test;
 public class VersionTest {
 
     @Test
-    public void testToInt() {
-        assertEquals(15701, Version.toLong("0.0.15"));
-        assertEquals(1001001701, Version.toLong("1.1.1"));
-        assertEquals(123456789701L, Version.toLong("123.456.789"));
-        assertEquals(1002003000, Version.toLong("1.2.3-SNAPSHOT"));
-        assertEquals(1002003101, Version.toLong("1.2.3-alpha-01"));
-        assertEquals(1002003323, Version.toLong("1.2.3-beta-23"));
-        assertEquals(1002003507, Version.toLong("1.2.3-rc-07"));
+    public void testVersion() {
+        Version version = Version.parse("1.2.15");
+        assertEquals(1, version.getMajor(), 1);
+        assertEquals(2, version.getMinor(), 2);
+        assertEquals(15, version.getRevision(), 15);
+        assertEquals(0, version.getBuild(), 0);
+        assertEquals(Version.BuildType.Release, version.getBuildType());
+
+        assertEquals(Version.BuildType.Snapshot, Version.parse("1.2.3-SNAPSHOT").getBuildType());
+        assertEquals(Version.BuildType.Alpha, Version.parse("1.2.3-alpha-01").getBuildType());
+        assertEquals(Version.BuildType.Beta, Version.parse("1.2.3-beta-23").getBuildType());
+        assertEquals(Version.BuildType.RC, Version.parse("1.2.3-rc-07").getBuildType());
+
+        assertCompareSmallerThan(Version.parse("1.2.3.4"), Version.parse("1.2.3.5"));
+        assertCompareSmallerThan(Version.parse("1.2.3.4"), Version.parse("1.2.3.4.5"));
+        assertCompareSmallerThan(Version.parse("1.2.3.4-rc-1"), Version.parse("1.2.3.4"));
+        assertCompareSmallerThan(Version.parse("1.2.3.4-beta-1"), Version.parse("1.2.3.4-rc-1"));
+        assertCompareSmallerThan(Version.parse("1.2.3.4-alpha-1"), Version.parse("1.2.3.4-beta-1"));
+        assertCompareSmallerThan(Version.parse("1.2.3.4-SNAPSHOT"), Version.parse("1.2.3.4-alpha-1"));
+
+        // basic to string
+        assertEquals("1.2.3-SNAPSHOT", Version.parse("1.2.3-SNAPSHOT").toString());
+        assertEquals("1.2.3-alpha-1", Version.parse("1.2.3-alpha-1").toString());
+        assertEquals("1.2.3-beta-23", Version.parse("1.2.3-beta-23").toString());
+        assertEquals("1.2.3-rc-7", Version.parse("1.2.3-rc-7").toString());
+        assertEquals("1.2.3", Version.parse("1.2.3").toString());
     }
 
+
+    static <T> void assertCompareSmallerThan(Comparable<T> a, T b) {
+        assertTrue(a.compareTo(b) < 0);
+    }
 }

--- a/plugins/eclipse/ui/src/org/robovm/eclipse/RoboVMPlugin.java
+++ b/plugins/eclipse/ui/src/org/robovm/eclipse/RoboVMPlugin.java
@@ -272,7 +272,7 @@ public class RoboVMPlugin extends AbstractUIPlugin implements IStartup {
             if (System.getenv("ROBOVM_DEV_ROOT") != null) {
                 roboVMHome = Config.Home.find();
             } else {
-                String version = Version.getVersion();
+                String version = Version.getCompilerVersion();
                 File homeDir = new File(getMetadataDir(), "robovm-" + version);
                 File distFile = new File(getMetadataDir(), "robovm-dist-" + version + ".tar.gz");
                 URL distUrl = RoboVMPlugin.class.getResource("/lib/robovm-dist.tar.gz");

--- a/plugins/gradle/src/main/java/org/robovm/gradle/RoboVMPlugin.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/RoboVMPlugin.java
@@ -41,7 +41,7 @@ public class RoboVMPlugin implements Plugin<Project> {
     private final ToolingModelBuilderRegistry registry;
 
     public static String getRoboVMVersion() {
-        return Version.getVersion();
+        return Version.getCompilerVersion();
     }
 
     @Inject

--- a/plugins/idea/src/main/java/org/robovm/idea/RoboVmPlugin.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/RoboVmPlugin.java
@@ -302,7 +302,7 @@ public class RoboVmPlugin {
     }
 
     public static File getSdkHome() {
-        return new File(getSdkHomeBase(), "robovm-" + Version.getVersion());
+        return new File(getSdkHomeBase(), "robovm-" + Version.getCompilerVersion());
     }
 
     public static File getSdkHomeBase() {
@@ -346,7 +346,7 @@ public class RoboVmPlugin {
                     filesWereUpdated = true;
                 }
             }
-            logInfo(null, "Installed RoboVM SDK %s to %s", Version.getVersion(), dest.getAbsolutePath());
+            logInfo(null, "Installed RoboVM SDK %s to %s", Version.getCompilerVersion(), dest.getAbsolutePath());
 
             if (filesWereUpdated) {
                 File cacheLog = new File(System.getProperty("user.home"), ".robovm/cache");
@@ -376,13 +376,13 @@ public class RoboVmPlugin {
         if (home.isDev()) {
             // ROBOVM_DEV_ROOT has been set (rtPath points to $ROBOVM_DEV_ROOT/rt/target/robovm-rt-<version>.jar).
             File rootDir = home.getRtPath().getParentFile().getParentFile().getParentFile();
-            libs.add(new File(rootDir, "objc/target/robovm-objc-" + Version.getVersion() + ".jar"));
-            libs.add(new File(rootDir, "objc/target/robovm-objc-" + Version.getVersion() + "-sources.jar"));
-            libs.add(new File(rootDir, "cocoatouch/target/robovm-cocoatouch-" + Version.getVersion() + ".jar"));
-            libs.add(new File(rootDir, "cocoatouch/target/robovm-cocoatouch-" + Version.getVersion() + "-sources.jar"));
-            libs.add(new File(rootDir, "rt/target/robovm-rt-" + Version.getVersion() + ".jar"));
-            libs.add(new File(rootDir, "rt/target/robovm-rt-" + Version.getVersion() + "-sources.jar"));
-            libs.add(new File(rootDir, "cacerts/full/target/robovm-cacerts-full-" + Version.getVersion() + ".jar"));
+            libs.add(new File(rootDir, "objc/target/robovm-objc-" + Version.getCompilerVersion() + ".jar"));
+            libs.add(new File(rootDir, "objc/target/robovm-objc-" + Version.getCompilerVersion() + "-sources.jar"));
+            libs.add(new File(rootDir, "cocoatouch/target/robovm-cocoatouch-" + Version.getCompilerVersion() + ".jar"));
+            libs.add(new File(rootDir, "cocoatouch/target/robovm-cocoatouch-" + Version.getCompilerVersion() + "-sources.jar"));
+            libs.add(new File(rootDir, "rt/target/robovm-rt-" + Version.getCompilerVersion() + ".jar"));
+            libs.add(new File(rootDir, "rt/target/robovm-rt-" + Version.getCompilerVersion() + "-sources.jar"));
+            libs.add(new File(rootDir, "cacerts/full/target/robovm-cacerts-full-" + Version.getCompilerVersion() + ".jar"));
         } else {
             // normal run
             File libsDir = new File(getSdkHome(), "lib");

--- a/plugins/idea/src/main/java/org/robovm/idea/builder/RoboVmModuleBuilder.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/builder/RoboVmModuleBuilder.java
@@ -33,7 +33,6 @@ import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ContentEntry;
 import com.intellij.openapi.roots.LanguageLevelModuleExtension;
-import com.intellij.openapi.roots.LanguageLevelModuleExtensionImpl;
 import com.intellij.openapi.roots.LanguageLevelProjectExtension;
 import com.intellij.openapi.roots.ModifiableRootModel;
 import com.intellij.openapi.roots.ProjectRootManager;
@@ -189,17 +188,17 @@ public class RoboVmModuleBuilder extends JavaModuleBuilder {
                 final File buildFile = new File(contentRoot + "/" + robovmDir + "/build.gradle");
                 if (buildFile.exists()) {
                     String template = FileUtils.readFileToString(buildFile, StandardCharsets.UTF_8.name());
-                    template = template.replaceAll(ROBOVM_VERSION_PLACEHOLDER, Version.getVersion());
+                    template = template.replaceAll(ROBOVM_VERSION_PLACEHOLDER, Version.getCompilerVersion());
                     FileUtils.write(buildFile, template, Charset.defaultCharset());
                 } else {
                     String template = IOUtils.toString(RoboVmModuleBuilder.class.getResource("/template_build.gradle"),
                             StandardCharsets.UTF_8);
-                    template = template.replaceAll(ROBOVM_VERSION_PLACEHOLDER, Version.getVersion());
+                    template = template.replaceAll(ROBOVM_VERSION_PLACEHOLDER, Version.getCompilerVersion());
                     FileUtils.write(buildFile, template, Charset.defaultCharset());
                 }
             } else if (buildSystem == BuildSystem.Maven) {
                 String template = IOUtils.toString(RoboVmModuleBuilder.class.getResource("/template_pom.xml"), StandardCharsets.UTF_8);
-                template = template.replaceAll(ROBOVM_VERSION_PLACEHOLDER, Version.getVersion());
+                template = template.replaceAll(ROBOVM_VERSION_PLACEHOLDER, Version.getCompilerVersion());
                 template = template.replaceAll(PACKAGE_NAME_PLACEHOLDER, packageName);
                 template = template.replaceAll(APP_NAME_PLACEHOLDER, appName);
                 File buildFile = new File(contentRoot + "/pom.xml");

--- a/plugins/idea/src/main/java/org/robovm/idea/sdk/RoboVmSdkType.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/sdk/RoboVmSdkType.java
@@ -33,7 +33,6 @@ import org.robovm.idea.RoboVmPlugin;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.projectRoots.*;
 import com.intellij.openapi.roots.OrderRootType;
-import com.intellij.openapi.vfs.JarFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 
 public class RoboVmSdkType extends SdkType implements JavaSdkType {
@@ -73,7 +72,7 @@ public class RoboVmSdkType extends SdkType implements JavaSdkType {
     @NotNull
     @Override
     public String suggestSdkName(String currentSdkName, String sdkHome) {
-        return SDK_NAME + " " + Version.getVersion();
+        return SDK_NAME + " " + Version.getCompilerVersion();
     }
 
     @Nullable

--- a/plugins/junit/client/src/test/java/org/robovm/junit/client/TestClientTest.java
+++ b/plugins/junit/client/src/test/java/org/robovm/junit/client/TestClientTest.java
@@ -85,7 +85,7 @@ public class TestClientTest {
 
     private Config.Builder createConfig() throws IOException, ClassNotFoundException {
         RoboVMResolver roboVMResolver = new RoboVMResolver();
-        Home home = new Home(roboVMResolver.resolveAndUnpackRoboVMDistArtifact(Version.getVersion()));
+        Home home = new Home(roboVMResolver.resolveAndUnpackRoboVMDistArtifact(Version.getCompilerVersion()));
 
         Config.Builder config = new Config.Builder();
 

--- a/plugins/maven/plugin/src/main/java/org/robovm/maven/plugin/AbstractRoboVMMojo.java
+++ b/plugins/maven/plugin/src/main/java/org/robovm/maven/plugin/AbstractRoboVMMojo.java
@@ -365,7 +365,7 @@ public abstract class AbstractRoboVMMojo extends AbstractMojo {
     }
 
     protected String getRoboVMVersion() {
-        return Version.getVersion();
+        return Version.getCompilerVersion();
     }
 
     protected File unpackRoboVMDist() throws MojoExecutionException {

--- a/plugins/maven/surefire/src/main/java/org/robovm/maven/surefire/RoboVMSurefireProvider.java
+++ b/plugins/maven/surefire/src/main/java/org/robovm/maven/surefire/RoboVMSurefireProvider.java
@@ -275,7 +275,7 @@ public class RoboVMSurefireProvider extends AbstractProvider {
             home = Home.find();
         } catch (Throwable t) {}
         if (home == null || !home.isDev()) {
-            home = new Home(roboVMResolver.resolveAndUnpackRoboVMDistArtifact(Version.getVersion()));
+            home = new Home(roboVMResolver.resolveAndUnpackRoboVMDistArtifact(Version.getCompilerVersion()));
         }
         configBuilder.home(home);
         if (home.isDev()) {
@@ -341,11 +341,11 @@ public class RoboVMSurefireProvider extends AbstractProvider {
         // Ignore any classpath entries in the loaded robovm.xml file.
         configBuilder.clearClasspathEntries();
         
-        configBuilder.addClasspathEntry(roboVMResolver.resolveArtifact("com.mobidevelop.robovm:robovm-junit-server:" + Version.getVersion()).asFile());
+        configBuilder.addClasspathEntry(roboVMResolver.resolveArtifact("com.mobidevelop.robovm:robovm-junit-server:" + Version.getCompilerVersion()).asFile());
         if(isIOS()) {
-            configBuilder.addClasspathEntry(roboVMResolver.resolveArtifact("com.mobidevelop.robovm:robovm-rt:" + Version.getVersion()).asFile());
-            configBuilder.addClasspathEntry(roboVMResolver.resolveArtifact("com.mobidevelop.robovm:robovm-objc:" + Version.getVersion()).asFile());
-            configBuilder.addClasspathEntry(roboVMResolver.resolveArtifact("com.mobidevelop.robovm:robovm-cocoatouch:" + Version.getVersion()).asFile());
+            configBuilder.addClasspathEntry(roboVMResolver.resolveArtifact("com.mobidevelop.robovm:robovm-rt:" + Version.getCompilerVersion()).asFile());
+            configBuilder.addClasspathEntry(roboVMResolver.resolveArtifact("com.mobidevelop.robovm:robovm-objc:" + Version.getCompilerVersion()).asFile());
+            configBuilder.addClasspathEntry(roboVMResolver.resolveArtifact("com.mobidevelop.robovm:robovm-cocoatouch:" + Version.getCompilerVersion()).asFile());
         }
         for (String p : System.getProperty("java.class.path").split(File.pathSeparator)) {
             configBuilder.addClasspathEntry(new File(p));


### PR DESCRIPTION
## Cause 
Swift library lookup was hardcoded to look for libs only in `swift-5.0` folder which is not completely valid today and causes failure to link with swift-based dependencies. 

## Changes
- fixed: manual provided path in swift support were extended with $platform suffix as result it was not possible to use SDK lib location (/usr/lib/swift) as it was extended with platform;
- updated swift library order lookup. there was TODO and only 5.0 folder was added now order of swift libraries is built as bellow:
  * `/usr/lib/swift`
  * version less `swift`
  * all versioned location like `swift-5.0` in reverse order (higher first)
- `swiftSupport` extended with `<copySwiftLibs>fals</copySwiftLibs>` option that controlls if swift runtime libraries are going to be copied or not.
- `swiftSupport` now must be added to config to enable all swift related logic. Before -- some part were enabled. some -- not.

## Other changes
- `Version.java` turned into utility class that can parse version strings.
-  Original `getVersion` renamed to `getCompilerVersion` ( it returns version of RoboVM itself). 
- Unit tests were updated