### PR TITLE
* fix for `ld: unaligned pointer(s) for architecture arm64`

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/AttributesEncoder.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/AttributesEncoder.java
@@ -33,8 +33,8 @@ import org.robovm.compiler.llvm.FloatingPointConstant;
 import org.robovm.compiler.llvm.Global;
 import org.robovm.compiler.llvm.IntegerConstant;
 import org.robovm.compiler.llvm.Linkage;
-import org.robovm.compiler.llvm.PackedStructureConstant;
-import org.robovm.compiler.llvm.PackedStructureType;
+import org.robovm.compiler.llvm.StructureConstant;
+import org.robovm.compiler.llvm.StructureType;
 import org.robovm.compiler.llvm.StructureConstant;
 import org.robovm.compiler.llvm.Type;
 import org.robovm.compiler.llvm.Value;
@@ -92,10 +92,10 @@ public class AttributesEncoder {
     
     public void encode(ModuleBuilder mb, SootClass sootClass) {
         this.mb = mb;
-        dependencies = new HashSet<String>();
+        dependencies = new HashSet<>();
         classAttributes = null;
-        fieldAttributes = new HashMap<SootField, Global>();
-        methodAttributes = new HashMap<SootMethod, Global>();
+        fieldAttributes = new HashMap<>();
+        methodAttributes = new HashMap<>();
         
         encodeAttributes(sootClass);
         Constant classAttributes = encodeAttributes(sootClass);
@@ -152,21 +152,21 @@ public class AttributesEncoder {
         return methodAttributes.get(m);
     }
     
-    private PackedStructureType getAnnotationElementType(AnnotationElem ae) {
+    private StructureType getAnnotationElementType(AnnotationElem ae) {
         if (ae instanceof AnnotationIntElem) {
-            return new PackedStructureType(I8, I32);
+            return new StructureType(I8, I32);
         } else if (ae instanceof AnnotationLongElem) {
-            return new PackedStructureType(I8, I64);            
+            return new StructureType(I8, I64);            
         } else if (ae instanceof AnnotationFloatElem) {
-            return new PackedStructureType(I8, FLOAT);            
+            return new StructureType(I8, FLOAT);            
         } else if (ae instanceof AnnotationDoubleElem) {
-            return new PackedStructureType(I8, DOUBLE);            
+            return new StructureType(I8, DOUBLE);            
         } else if (ae instanceof AnnotationStringElem) {
-            return new PackedStructureType(I8, I8_PTR);            
+            return new StructureType(I8, I8_PTR);            
         } else if (ae instanceof AnnotationClassElem) {
-            return new PackedStructureType(I8, I8_PTR);            
+            return new StructureType(I8, I8_PTR);            
         } else if (ae instanceof AnnotationEnumElem) {
-            return new PackedStructureType(I8, I8_PTR, I8_PTR);            
+            return new StructureType(I8, I8_PTR, I8_PTR);            
         } else if (ae instanceof AnnotationArrayElem) {
             AnnotationArrayElem aae = (AnnotationArrayElem) ae;
             Type[] types = new Type[aae.getNumValues() + 2];
@@ -175,46 +175,46 @@ public class AttributesEncoder {
             for (int i = 0; i < aae.getNumValues(); i++) {
                 types[i + 2] = getAnnotationElementType(aae.getValueAt(i));
             }
-            return new PackedStructureType(types);            
+            return new StructureType(types);            
         } else if (ae instanceof AnnotationAnnotationElem) {
             AnnotationAnnotationElem aae = (AnnotationAnnotationElem) ae;
-            return new PackedStructureType(I8, getAnnotationTagType(aae.getValue()));            
+            return new StructureType(I8, getAnnotationTagType(aae.getValue()));            
         }
         throw new IllegalArgumentException("Unknown AnnotationElem type: " + ae.getClass());
     }
     
-    private PackedStructureConstant encodeAnnotationElementValue(AnnotationElem ae) {
-        PackedStructureType type = getAnnotationElementType(ae);
+    private StructureConstant encodeAnnotationElementValue(AnnotationElem ae) {
+        StructureType type = getAnnotationElementType(ae);
         Value kind = new IntegerConstant((byte) ae.getKind());
         if (ae instanceof AnnotationIntElem) {
             AnnotationIntElem aie = (AnnotationIntElem) ae;
-            return new PackedStructureConstant(type, kind,
+            return new StructureConstant(type, kind,
                     new IntegerConstant(aie.getValue()));
         } else if (ae instanceof AnnotationLongElem) {
             AnnotationLongElem ale = (AnnotationLongElem) ae;
-            return new PackedStructureConstant(type, kind,
+            return new StructureConstant(type, kind,
                     new IntegerConstant(ale.getValue()));            
         } else if (ae instanceof AnnotationFloatElem) {
             AnnotationFloatElem afe = (AnnotationFloatElem) ae;
-            return new PackedStructureConstant(type, kind,
+            return new StructureConstant(type, kind,
                     new FloatingPointConstant(afe.getValue()));            
         } else if (ae instanceof AnnotationDoubleElem) {
             AnnotationDoubleElem ade = (AnnotationDoubleElem) ae;
-            return new PackedStructureConstant(type, kind,
+            return new StructureConstant(type, kind,
                     new FloatingPointConstant(ade.getValue()));            
         } else if (ae instanceof AnnotationStringElem) {
             AnnotationStringElem ase = (AnnotationStringElem) ae;
-            return new PackedStructureConstant(type, kind,
+            return new StructureConstant(type, kind,
                     getStringOrNull(ase.getValue()));            
         } else if (ae instanceof AnnotationClassElem) {
             AnnotationClassElem ace = (AnnotationClassElem) ae;
             addDependencyIfNeeded(ace.getDesc());
-            return new PackedStructureConstant(type, kind,
+            return new StructureConstant(type, kind,
                     getStringOrNull(ace.getDesc()));            
         } else if (ae instanceof AnnotationEnumElem) {
             AnnotationEnumElem aee = (AnnotationEnumElem) ae;
             addDependencyIfNeeded(aee.getTypeName());
-            return new PackedStructureConstant(type, kind,
+            return new StructureConstant(type, kind,
                     getStringOrNull(aee.getTypeName()),            
                     getStringOrNull(aee.getConstantName()));            
         } else if (ae instanceof AnnotationArrayElem) {
@@ -225,15 +225,15 @@ public class AttributesEncoder {
             for (int i = 0; i < aae.getNumValues(); i++) {
                 values[i + 2] = encodeAnnotationElementValue(aae.getValueAt(i));
             }
-            return new PackedStructureConstant(type, values);
+            return new StructureConstant(type, values);
         } else if (ae instanceof AnnotationAnnotationElem) {
             AnnotationAnnotationElem aae = (AnnotationAnnotationElem) ae;
-            return new PackedStructureConstant(type, kind, encodeAnnotationTagValue(aae.getValue()));            
+            return new StructureConstant(type, kind, encodeAnnotationTagValue(aae.getValue()));            
         }
         throw new IllegalArgumentException("Unknown AnnotationElem type: " + ae.getClass());
     }
     
-    private PackedStructureType getAnnotationTagType(AnnotationTag tag) {
+    private StructureType getAnnotationTagType(AnnotationTag tag) {
         Type[] types = new Type[tag.getNumElems() * 2 + 2];
         types[0] = I8_PTR;
         types[1] = I32;
@@ -241,10 +241,10 @@ public class AttributesEncoder {
             types[i * 2 + 2] = I8_PTR;
             types[i * 2 + 2 + 1] = getAnnotationElementType(tag.getElemAt(i));
         }
-        return new PackedStructureType(types);            
+        return new StructureType(types);            
     }
     
-    private PackedStructureConstant encodeAnnotationTagValue(AnnotationTag tag) {
+    private StructureConstant encodeAnnotationTagValue(AnnotationTag tag) {
         Value[] values = new Value[tag.getNumElems() * 2 + 2];
         values[0] = getString(tag.getType());
         addDependencyIfNeeded(tag.getType());
@@ -253,27 +253,27 @@ public class AttributesEncoder {
             values[i * 2 + 2] = getString(tag.getElemAt(i).getName());
             values[i * 2 + 2 + 1] = encodeAnnotationElementValue(tag.getElemAt(i));
         }
-        return new PackedStructureConstant(getAnnotationTagType(tag), values);
+        return new StructureConstant(getAnnotationTagType(tag), values);
     }
     
     private Constant encodeAttributes(Host host) {
-        List<Value> attributes = new ArrayList<Value>();
+        List<Value> attributes = new ArrayList<>();
         for (Tag tag : host.getTags()) {
             if (tag instanceof SourceFileTag) {
                 // Skip. We don't need this at this time.
                 Value sourceFile = getString(((SourceFileTag) tag).getSourceFile());
-                attributes.add(new PackedStructureConstant(new PackedStructureType(I8, I8_PTR), 
+                attributes.add(new StructureConstant(new StructureType(I8, I8_PTR), 
                         new IntegerConstant(SOURCE_FILE), sourceFile));
             } else if (tag instanceof EnclosingMethodTag) {
                 EnclosingMethodTag emt = (EnclosingMethodTag) tag;
                 Value eClass = getString(emt.getEnclosingClass());
                 Value eMethod = getStringOrNull(emt.getEnclosingMethod());
                 Value eDesc = getStringOrNull(emt.getEnclosingMethodSig());
-                attributes.add(new PackedStructureConstant(new PackedStructureType(I8, I8_PTR, I8_PTR, I8_PTR), 
+                attributes.add(new StructureConstant(new StructureType(I8, I8_PTR, I8_PTR, I8_PTR), 
                         new IntegerConstant(ENCLOSING_METHOD), eClass, eMethod, eDesc));
             } else if (tag instanceof SignatureTag) {
                 Value signature = getString(((SignatureTag) tag).getSignature());
-                attributes.add(new PackedStructureConstant(new PackedStructureType(I8, I8_PTR), 
+                attributes.add(new StructureConstant(new StructureType(I8, I8_PTR), 
                         new IntegerConstant(SIGNATURE), signature));
             } else if (tag instanceof InnerClassTag) {
                 InnerClassTag ict = (InnerClassTag) tag;
@@ -281,11 +281,11 @@ public class AttributesEncoder {
                 Value outerClass = getStringOrNull(ict.getOuterClass());
                 Value innerName = getStringOrNull(ict.getShortName());
                 Value innerClassAccess = new IntegerConstant(ict.getAccessFlags());
-                attributes.add(new PackedStructureConstant(new PackedStructureType(I8, I8_PTR, I8_PTR, I8_PTR, I32), 
+                attributes.add(new StructureConstant(new StructureType(I8, I8_PTR, I8_PTR, I8_PTR, I32), 
                         new IntegerConstant(INNER_CLASS), innerClass, outerClass, innerName, innerClassAccess));
             } else if (tag instanceof AnnotationDefaultTag) {
                 StructureConstant value = encodeAnnotationElementValue(((AnnotationDefaultTag) tag).getDefaultVal());
-                attributes.add(new PackedStructureConstant(new PackedStructureType(I8, value.getType()), 
+                attributes.add(new StructureConstant(new StructureType(I8, value.getType()), 
                         new IntegerConstant(ANNOTATION_DEFAULT), value));
             } else if (tag instanceof VisibilityAnnotationTag) {
                 VisibilityAnnotationTag vat = (VisibilityAnnotationTag) tag;
@@ -298,14 +298,14 @@ public class AttributesEncoder {
                         types[i] = values[i].getType();
                         i++;
                     }
-                    attributes.add(new PackedStructureConstant(new PackedStructureType(I8, I32, new PackedStructureType(types)),
+                    attributes.add(new StructureConstant(new StructureType(I8, I32, new StructureType(types)),
                             new IntegerConstant(RUNTIME_VISIBLE_ANNOTATIONS), new IntegerConstant(vat.getAnnotations().size()),
-                            new PackedStructureConstant(new PackedStructureType(types), values)));
+                            new StructureConstant(new StructureType(types), values)));
                 }
             } else if (tag instanceof VisibilityParameterAnnotationTag) {
                 VisibilityParameterAnnotationTag vpat = (VisibilityParameterAnnotationTag) tag;
-                List<Type> typesList = new ArrayList<Type>();
-                List<Value> valuesList = new ArrayList<Value>();
+                List<Type> typesList = new ArrayList<>();
+                List<Value> valuesList = new ArrayList<>();
                 boolean hasRuntimeVisible = false;
                 for (VisibilityAnnotationTag vat : vpat.getVisibilityAnnotations()) {
                     typesList.add(I32);
@@ -315,19 +315,20 @@ public class AttributesEncoder {
                         hasRuntimeVisible = true;
                         valuesList.add(new IntegerConstant(vat.getAnnotations().size()));
                         for (AnnotationTag at : vat.getAnnotations()) {
-                            valuesList.add(encodeAnnotationTagValue(at));
-                            typesList.add(valuesList.get(valuesList.size() - 1).getType());
+                            StructureConstant value = encodeAnnotationTagValue(at);
+                            valuesList.add(value);
+                            typesList.add(value.getType());
                         }
                     } else {
                         valuesList.add(new IntegerConstant(0));                        
                     }
                 }
                 if (hasRuntimeVisible) {
-                    Type[] types = typesList.toArray(new Type[typesList.size()]);
-                    Value[] values = valuesList.toArray(new Value[valuesList.size()]);
-                    attributes.add(new PackedStructureConstant(new PackedStructureType(I8, I32, new PackedStructureType(types)),
+                    Type[] types = typesList.toArray(new Type[0]);
+                    Value[] values = valuesList.toArray(new Value[0]);
+                    attributes.add(new StructureConstant(new StructureType(I8, I32, new StructureType(types)),
                             new IntegerConstant(RUNTIME_VISIBLE_PARAMETER_ANNOTATIONS), new IntegerConstant(vpat.getVisibilityAnnotations().size()),
-                            new PackedStructureConstant(new PackedStructureType(types), values)));
+                            new StructureConstant(new StructureType(types), values)));
                 }
             }
         }
@@ -340,7 +341,7 @@ public class AttributesEncoder {
                     values[i] = getString(exName);
                     addDependency(exName);
                 }
-                attributes.add(new PackedStructureConstant(new PackedStructureType(I8, I32, new ArrayType(exceptions.size(), I8_PTR)), 
+                attributes.add(new StructureConstant(new StructureType(I8, I32, new ArrayType(exceptions.size(), I8_PTR)), 
                         new IntegerConstant(EXCEPTIONS), new IntegerConstant(exceptions.size()), 
                         new ArrayConstant(new ArrayType(exceptions.size(), I8_PTR), values)));
             }
@@ -356,7 +357,7 @@ public class AttributesEncoder {
         for (int i = 0; i < types.length; i++) {
             types[i] = attributes.get(i).getType();
         }
-        return new PackedStructureConstant(new PackedStructureType(types), attributes.toArray(new Value[0]));
+        return new StructureConstant(new StructureType(types), attributes.toArray(new Value[0])).flatten();
     }
     
     private Constant getString(String string) {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/ClassCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/ClassCompiler.java
@@ -52,7 +52,6 @@ import org.robovm.compiler.llvm.Linkage;
 import org.robovm.compiler.llvm.Load;
 import org.robovm.compiler.llvm.NullConstant;
 import org.robovm.compiler.llvm.Ordering;
-import org.robovm.compiler.llvm.PackedStructureConstantBuilder;
 import org.robovm.compiler.llvm.PointerType;
 import org.robovm.compiler.llvm.Ret;
 import org.robovm.compiler.llvm.Store;
@@ -1304,7 +1303,7 @@ public class ClassCompiler {
         header.add(new IntegerConstant((short) countReferences(classFields)));
         header.add(new IntegerConstant((short) countReferences(instanceFields)));
 
-        PackedStructureConstantBuilder body = new PackedStructureConstantBuilder();
+        StructureConstantBuilder body = new StructureConstantBuilder();
         body.add(new IntegerConstant((short) sootClass.getInterfaceCount()));
         body.add(new IntegerConstant((short) sootClass.getFieldCount()));
         body.add(new IntegerConstant((short) sootClass.getMethodCount()));

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/StructureConstant.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/StructureConstant.java
@@ -16,6 +16,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  *
  * @version $Id$
@@ -32,6 +35,31 @@ public class StructureConstant extends Constant {
     @Override
     public StructureType getType() {
         return type;
+    }
+
+
+
+    // flatten all contained structs in way removing struct and inserting struct members
+    private static void flattenInto(List<Value> dest, StructureConstant struct) {
+        for (Value v: struct.values) {
+            if (v instanceof StructureConstant)
+                flattenInto(dest, (StructureConstant)v);
+            else
+                dest.add(v);
+        }
+    }
+
+    public StructureConstant flatten() {
+        List<Value> flattenValues = new ArrayList<>();
+        flattenInto(flattenValues, this);
+
+        Type[] types = new Type[flattenValues.size()];
+        int i = 0;
+        for (Value v : flattenValues) {
+            types[i++] = v.getType();
+        }
+
+        return new StructureConstant(new StructureType(types), flattenValues.toArray(new Value[0]));
     }
 
     @Override

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -288,26 +288,17 @@ public class IOSTarget extends AbstractTarget {
         ccArgs.add("--target=" + config.getClangTriple(getMinimumOSVersion()));
 
         if (isDeviceArch(arch)) {
-            if (config.isDebug()) {
-                ccArgs.add("-Wl,-no_pie");
-            }
             if (config.isEnableBitcode()) {
                 // tells clang to keep bitcode while linking
                 ccArgs.add("-fembed-bitcode");
             }
         } else {
-            if (config.getArch().getCpuArch() == CpuArch.x86 || config.isDebug()) {
+            if (config.getArch().getCpuArch() == CpuArch.x86) {
                 ccArgs.add("-Wl,-no_pie");
             }
         }
         ccArgs.add("-isysroot");
         ccArgs.add(sdk.getRoot().getAbsolutePath());
-
-        // specify sdk version for linker
-        libArgs.add("-Xlinker");
-        libArgs.add("-sdk_version");
-        libArgs.add("-Xlinker");
-        libArgs.add(sdk.getVersion());
 
         // add runtime path to swift libs first to support swift-5 libs location
         libArgs.add("-Xlinker");

--- a/compiler/compiler/src/main/java/org/robovm/compiler/util/ToolchainUtil.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/util/ToolchainUtil.java
@@ -393,11 +393,6 @@ public class ToolchainUtil {
             for (File objectsFile : objectsFiles) {
                 opts.add("-Wl,-filelist," + objectsFile.getAbsolutePath());
             }
-            /*
-             * See #123, ignore ld: warning: pointer not aligned at address [infostruct] message with Xcode 8.3
-             * unless we find a better solution
-             */
-            opts.add("-w");
         } else {
             opts.add(config.getArch().is32Bit() ? "-m32" : "-m64");
             for (File objectsFile : objectsFiles) {

--- a/compiler/vm/bc/src/aligned.h
+++ b/compiler/vm/bc/src/aligned.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2012 RoboVM AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef ALIGNED_H
+#define ALIGNED_H
+
+#include <robovm.h>
+
+#define ALIGN(pp, t) (void*)(((uintptr_t) (pp) + sizeof(t) - 1) & ~(sizeof(t) - 1))
+
+static inline jbyte readByte(void** p) {
+    jbyte v = *(jbyte*) *p;
+    *p += sizeof(jbyte);
+    return v;
+}
+
+static inline jchar readChar(void** p) {
+    *p = ALIGN(*p, jchar);
+    jchar v = *(jchar*) *p;
+    *p += sizeof(jchar);
+    return v;
+}
+
+static inline jshort readShort(void** p) {
+    *p = ALIGN(*p, jshort);
+    jshort v = *(jshort*) *p;
+    *p += sizeof(jshort);
+    return v;
+}
+
+static inline jint readInt(void** p) {
+    *p = ALIGN(*p, jint);
+    jint v = *(jint*) *p;
+    *p += sizeof(jint);
+    return v;
+}
+
+static inline char* readString(void** p) {
+    *p = ALIGN(*p, char*);
+    char* v = *(char**) *p;
+    *p += sizeof(char*);
+    return v;
+}
+
+static inline void* readPtr(void** p) {
+    *p = ALIGN(*p, void*);
+    void* v = *(void**) *p;
+    *p += sizeof(void*);
+    return v;
+}
+
+static inline void writeInt(void** p, jint v) {
+    *p = ALIGN(*p, jint);
+    *(jint*) *p = v;
+    *p += sizeof(jint);
+}
+
+#endif
+

--- a/compiler/vm/bc/src/classinfo.c
+++ b/compiler/vm/bc/src/classinfo.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include <string.h>
-#include "packed.h"
+#include "aligned.h"
 #include "classinfo.h"
 
 #define FI_ACCESS_MASK 0x3

--- a/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/ClassInfoImpl.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/ClassInfoImpl.java
@@ -119,10 +119,10 @@ public class ClassInfoImpl extends ClassInfo {
         // save position to continue once loadData is called
         endOfHeaderPos = reader.position();
 
-        // read little bit more to get super class name
+        // read a bit more to get super class name
         if (!isInterface()) {
             reader.skip(2 + 2 + 2); // interfaceCount +  fieldCount +  methodCount
-            long superNamePtr = reader.readPointer();
+            long superNamePtr = reader.readPointer(true);
             if (superNamePtr != 0) {
                 superclassName = reader.readStringZ(superNamePtr);
                 superclassSignature = "L" + superclassName + ";";
@@ -151,18 +151,18 @@ public class ClassInfoImpl extends ClassInfo {
 
         if (!isInterface()) {
             // skip super name as already has been read
-            reader.skip(reader.pointerSize());
+            reader.readPointer(true);
         }
 
         if ((flags & ClassDataConsts.classinfo.ATTRIBUTES) != 0) {
             // TODO: skip attributes for now
-            reader.skip(reader.pointerSize());
+            reader.readPointer(true);
         }
 
         // reading interfaces
         interfaces = new ClassInfo[interfaceCount];
         for (int idx = 0; idx < interfaceCount; idx++) {
-            long ptr = reader.readPointer();
+            long ptr = reader.readPointer(true);
             String interfaceSignature = "L" + reader.readStringZ(ptr) + ";";
             interfaces[idx] = loader.classInfoBySignature(interfaceSignature);
             if (interfaces[idx] == null)

--- a/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/ClassInfoLoader.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/ClassInfoLoader.java
@@ -75,7 +75,7 @@ public class ClassInfoLoader {
         dataInfos = Collections.unmodifiableList(new ArrayList<>(this.signatureToDataInfo.values()));
     }
 
-    private void parseHash( long hash) {
+    private void parseHash(long hash) {
         reader.setPosition(hash);
         long pointerSize = reader.pointerSize();
         int classInfoCount = reader.readInt32();

--- a/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/FieldInfo.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/FieldInfo.java
@@ -49,7 +49,7 @@ public class FieldInfo extends BaseModifiersInfo {
     public void readFieldInfo(DataBufferReader reader) {
         flags = reader.readInt16();
 
-        name = reader.readStringZ(reader.readPointer());
+        name = reader.readStringZ(reader.readPointer(true));
 
         if ((flags >> 12) != 0) {
             switch ((flags >> 12) & 0xf) {
@@ -63,14 +63,14 @@ public class FieldInfo extends BaseModifiersInfo {
                 case ClassDataConsts.desc.Z: signature = "Z"; break;
             }
         } else {
-            signature = reader.readStringZ(reader.readPointer());
+            signature = reader.readStringZ(reader.readPointer(true));
         }
 
-        offset = reader.readInt32();
+        offset = reader.readInt32(true);
 
         if ((flags & ClassDataConsts.fieldinfo.ATTRIBUTES) != 0) {
             // TODO: skip attributes for now
-            reader.skip(reader.pointerSize());
+            reader.readPointer(true);
         }
     }
 

--- a/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/FieldInfo.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/FieldInfo.java
@@ -47,7 +47,7 @@ public class FieldInfo extends BaseModifiersInfo {
     }
 
     public void readFieldInfo(DataBufferReader reader) {
-        flags = reader.readInt16();
+        flags = reader.readInt16(true);
 
         name = reader.readStringZ(reader.readPointer(true));
 

--- a/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/MethodInfo.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/MethodInfo.java
@@ -54,9 +54,9 @@ public class MethodInfo extends BaseModifiersInfo {
     private CallSpec callspec;
 
     public void readMethodInfo(DataBufferReader reader) {
-        flags = reader.readInt16();
+        flags = reader.readInt16(true);
 
-        int vtableIndex = reader.readInt16();
+        int vtableIndex = reader.readInt16(true);
         name = reader.readStringZ(reader.readPointer(true));
 
         if ((flags & ClassDataConsts.methodinfo.COMPACT_DESC) != 0) {

--- a/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/MethodInfo.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/MethodInfo.java
@@ -57,7 +57,7 @@ public class MethodInfo extends BaseModifiersInfo {
         flags = reader.readInt16();
 
         int vtableIndex = reader.readInt16();
-        name = reader.readStringZ(reader.readPointer());
+        name = reader.readStringZ(reader.readPointer(true));
 
         if ((flags & ClassDataConsts.methodinfo.COMPACT_DESC) != 0) {
             switch (reader.readByte()) {
@@ -90,31 +90,31 @@ public class MethodInfo extends BaseModifiersInfo {
                     break;
             }
         } else {
-            desc = reader.readStringZ(reader.readPointer());
+            desc = reader.readStringZ(reader.readPointer(true));
         }
 
         if ((flags & ClassDataConsts.methodinfo.ATTRIBUTES) != 0) {
             // TODO: skip attributes
-            reader.skip(reader.pointerSize());
+            reader.readPointer(true);
         }
 
         long synchronizedImpl = 0;
         long linetable = 0;
         if (!isAbstract()) {
-            implPtr = reader.readPointer();
-            methodCodeSize = reader.readInt32();
+            implPtr = reader.readPointer(true);
+            methodCodeSize = reader.readInt32(true);
             if (isSynchronized())
-                synchronizedImpl = reader.readPointer();
+                synchronizedImpl = reader.readPointer(true);
             if (!isNative()) {
-                linetable = reader.readPointer();
+                linetable = reader.readPointer(true);
             }
         }
         long targetFnPtr = 0;
         if (isBroBridge())
-            targetFnPtr = reader.readPointer();
+            targetFnPtr = reader.readPointer(true);
         long callbackImpl = 0;
         if (isBroCallback())
-            callbackImpl = reader.readPointer();
+            callbackImpl = reader.readPointer(true);
     }
 
     public String name() {

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/bytebuffer/DataBufferReader.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/bytebuffer/DataBufferReader.java
@@ -66,6 +66,16 @@ public interface DataBufferReader extends DataBuffer {
 
     int readInt32();
 
+    default int readInt32(boolean aligned) {
+        if (aligned) {
+            long savedPosition = position();
+            long alignedPosition = DataUtils.align(savedPosition, 4);
+            if (savedPosition != alignedPosition)
+                setPosition(alignedPosition);
+        }
+        return readInt32();
+    }
+
     default long readUnsignedInt32() {
         return Integer.toUnsignedLong(readInt32());
     }


### PR DESCRIPTION
## Changes 
1. attribute/class info structs: these are now generated to be not packed (will consume a bit more ram)
2. VM code updated to new structure layouts
3. Debugger code updated to new structure layouts

## Memory footprint affected
as information structures are not packed it will increase memory requirement to keep these.
On sample project it increases size of structs from `5525197` to `6935824` bytes or by `25%`

## removed linker flags 
- `-w` that was suppressing all warnings 
- `-no_pie` -- as it is not supported for arm targets (and debugger can handle it) 
- `-sdk_version` as linker picks one from `platform_version`