### PR TITLE
* Debugger: support for chained fixup 

### DIFF
--- a/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/ClassInfoLoader.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/ClassInfoLoader.java
@@ -75,7 +75,7 @@ public class ClassInfoLoader {
         dataInfos = Collections.unmodifiableList(new ArrayList<>(this.signatureToDataInfo.values()));
     }
 
-    private void parseHash( long hash) {
+    private void parseHash(long hash) {
         reader.setPosition(hash);
         long pointerSize = reader.pointerSize();
         int classInfoCount = reader.readInt32();

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/bytebuffer/CompositeDataBuffer.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/bytebuffer/CompositeDataBuffer.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2016 Justin Shapcott.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.debugger.utils.bytebuffer;
+
+import java.nio.ByteOrder;
+
+/**
+ * Wrapper around several mapped reader (regions) that simulates memory block access
+ * @author Demyan Kimitsa
+ */
+public abstract class CompositeDataBuffer<T extends DataBufferReader> implements DataBufferReader {
+    protected final T[] regions;
+    protected T activeRegion;
+
+    public CompositeDataBuffer(T[] regions) {
+        this.regions = regions;
+    }
+
+    @Override
+    public DataBufferReader setPosition(long addr) {
+        // check if address within the region
+        activeRegion = findRegion(addr);
+        if (activeRegion == null)
+            throw new IllegalArgumentException("there is no region for addr @" + Long.toHexString(addr));
+
+        activeRegion.setPosition(addr);
+        return this;
+    }
+
+    private T findRegion(long addr) {
+        if (activeRegion != null && addr >= activeRegion.bottomLimit() && addr < activeRegion.limit())
+            return activeRegion;
+
+        // use binary search
+        int left = 0;
+        int right = regions.length - 1;
+        while (right >= left) {
+            int middle = (left + right) / 2;
+            T r = regions[middle];
+            if (addr < r.bottomLimit()) {
+                right = middle - 1;
+            } else if (addr >= r.limit()) {
+                left = middle + 1;
+            } else {
+                return r;
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public long position() {
+        if (activeRegion == null)
+            throw new IllegalStateException("Address has not been set!");
+        return activeRegion.position();
+    }
+
+    /**
+     * it has no practical value as its expected to have gaps between regions
+     */
+    @Override
+    public long bottomLimit() {
+        return regions[0].bottomLimit();
+    }
+
+    /**
+     * it has no practical value as its expected to have gaps between regions
+     */
+    @Override
+    public long limit() {
+        return regions[regions.length - 1].limit();
+    }
+
+    @Override
+    public DataBuffer reset() {
+        activeRegion = regions[0];
+        activeRegion.reset();
+        return this;
+    }
+
+    @Override
+    public DataBuffer setByteOrder(ByteOrder order) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean is64bit() {
+        return regions[0].is64bit();
+    }
+
+    @Override
+    public int pointerSize() {
+        return is64bit() ? 8 : 4;
+    }
+
+    @Override
+    public int remaining() {
+        return activeRegion.remaining();
+    }
+
+    //
+    // Reader functionality
+    //
+
+    @Override
+    public long readPointer(boolean aligned) {
+        return activeRegion.readPointer(aligned);
+    }
+
+    @Override
+    public byte readByte() {
+        return activeRegion.readByte();
+    }
+
+    @Override
+    public short readInt16() {
+        return activeRegion.readInt16();
+    }
+
+    @Override
+    public int readInt32() {
+        return activeRegion.readInt32();
+    }
+
+    @Override
+    public long readLong() {
+        return activeRegion.readInt32();
+    }
+
+    @Override
+    public float readFloat() {
+        return activeRegion.readFloat();
+    }
+
+    @Override
+    public double readDouble() {
+        return activeRegion.readDouble();
+    }
+
+    @Override
+    public void readBytes(byte[] dst, int offset, int length) {
+        activeRegion.readBytes(dst, offset, length);
+    }
+
+}

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/bytebuffer/CompositeDataBufferReader.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/bytebuffer/CompositeDataBufferReader.java
@@ -19,154 +19,25 @@ import java.nio.ByteOrder;
 
 /**
  * Wrapper around several mapped reader (regions) that simulates memory block access
+ *
  * @author Demyan Kimitsa
  */
-public class CompositeDataBufferReader implements DataBufferReader {
-    private final DataBufferReader[] regions;
-    private DataBufferReader activeRegion;
+public class CompositeDataBufferReader extends CompositeDataBuffer<DataBufferReader> implements DataBufferReader {
 
     public CompositeDataBufferReader(DataBufferReader[] regions) {
-        this.regions = regions;
+        super(regions);
     }
 
     @Override
     public CompositeDataBufferReader setPosition(long addr) {
-        // check if address within the region
-        activeRegion = findRegion(addr);
-        if (activeRegion == null)
-            throw new IllegalArgumentException("there is no region to read addr @" + Long.toHexString(addr));
-
-        activeRegion.setPosition(addr);
+        super.setPosition(addr);
         return this;
-    }
-
-    private DataBufferReader findRegion(long addr) {
-        if (activeRegion != null && addr >= activeRegion.bottomLimit() && addr < activeRegion.limit())
-            return activeRegion;
-
-        // use binary search
-        int left = 0;
-        int right = regions.length - 1;
-        while (right >= left) {
-            int middle = (left + right) / 2;
-            DataBufferReader r = regions[middle];
-            if (addr < r.bottomLimit()) {
-                right = middle - 1;
-            } else if (addr >= r.limit()) {
-                left = middle + 1;
-            } else {
-                return r;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * sanity checks that there is enough data
-     * also checks against sections
-     */
-    @Override
-    public void expects(int bytes) {
-        // sanity
-        if (activeRegion == null)
-            throw new IllegalArgumentException("Address has not been set but read is performed!");
-        activeRegion.expects(bytes);
-    }
-
-    @Override
-    public long position() {
-        if (activeRegion == null)
-            throw new IllegalStateException("Address has not been set!");
-        return activeRegion.position();
-    }
-
-    /**
-     * it has no practical value as its expected to have gaps between regions
-     */
-    @Override
-    public long bottomLimit() {
-        return regions[0].bottomLimit();
-    }
-
-    /**
-     * it has no practical value as its expected to have gaps between regions
-     */
-    @Override
-    public long limit() {
-        return regions[regions.length - 1].limit();
     }
 
     @Override
     public CompositeDataBufferReader reset() {
-        activeRegion = regions[0];
-        activeRegion.reset();
+        super.reset();
         return this;
-    }
-
-    @Override
-    public CompositeDataBufferReader setByteOrder(ByteOrder order) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void skip(int bytesToSkip) {
-        activeRegion.skip(bytesToSkip);
-    }
-
-    @Override
-    public long readPointer(boolean aligned) {
-        return activeRegion.readPointer(aligned);
-    }
-
-    @Override
-    public boolean is64bit() {
-        return regions[0].is64bit();
-    }
-
-    @Override
-    public int pointerSize() {
-        return is64bit() ? 8 : 4;
-    }
-
-    @Override
-    public byte readByte() {
-        return activeRegion.readByte();
-    }
-
-    @Override
-    public short readInt16() {
-        return activeRegion.readInt16();
-    }
-
-    @Override
-    public int readInt32() {
-        return activeRegion.readInt32();
-    }
-
-    @Override
-    public long readLong() {
-        return activeRegion.readInt32();
-    }
-
-    @Override
-    public float readFloat() {
-        return activeRegion.readFloat();
-    }
-
-    @Override
-    public double readDouble() {
-        return activeRegion.readDouble();
-    }
-
-    @Override
-    public void readBytes(byte[] dst, int offset, int length) {
-        activeRegion.readBytes(dst, offset, length);
-    }
-
-    @Override
-    public int remaining() {
-        return activeRegion.remaining();
     }
 
     @Override

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/bytebuffer/CompositeDataBufferWriter.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/bytebuffer/CompositeDataBufferWriter.java
@@ -1,0 +1,69 @@
+package org.robovm.debugger.utils.bytebuffer;
+
+/**
+ * Wrapper around several mapped writers (regions) that simulates memory block access
+ * @author Demyan Kimitsa
+ */
+public class CompositeDataBufferWriter extends CompositeDataBuffer<DataBufferReaderWriter> implements DataBufferReaderWriter{
+
+    public CompositeDataBufferWriter(DataBufferReaderWriter[] regions) {
+        super(regions);
+    }
+
+    public CompositeDataBufferWriter setPosition(long position) {
+        super.setPosition(position);
+        return this;
+    }
+
+    @Override
+    public CompositeDataBufferWriter sliceAt(long pos, int size, long newBottomLimit, boolean as64bit) {
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public void wants(int size) {
+        activeRegion.wants(size);
+    }
+
+    @Override
+    public DataBufferReaderWriter writeByte(byte b) {
+        activeRegion.writeByte(b);
+        return this;
+    }
+
+    @Override
+    public DataBufferReaderWriter writeInt32(int i) {
+        activeRegion.writeInt32(i);
+        return this;
+    }
+
+    @Override
+    public DataBufferReaderWriter writeInt16(short i) {
+        activeRegion.writeInt16(i);
+        return this;
+    }
+
+    @Override
+    public DataBufferReaderWriter writeLong(long l) {
+        activeRegion.writeLong(l);
+        return this;
+    }
+
+    @Override
+    public DataBufferReaderWriter writeFloat(float f) {
+        activeRegion.writeFloat(f);
+        return this;
+    }
+
+    @Override
+    public DataBufferReaderWriter writeDouble(double d) {
+        activeRegion.writeDouble(d);
+        return this;
+    }
+
+    @Override
+    public DataBufferReaderWriter writeBytes(byte[] bytes, int offset, int count) {
+        activeRegion.writeBytes(bytes, offset, count);
+        return this;
+    }
+}

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/bytebuffer/DataBufferReaderWriter.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/bytebuffer/DataBufferReaderWriter.java
@@ -20,4 +20,37 @@ package org.robovm.debugger.utils.bytebuffer;
  * @author Demyan Kimitsa
  */
 public interface DataBufferReaderWriter extends DataBufferReader, DataBufferWriter {
+    //
+    // Overloaded api
+    //
+
+    DataBufferReaderWriter setPosition(long position);
+
+    /**
+     * makes a slice at specific position and specific size,
+     * new slices receives new bottom limit
+     */
+    DataBufferReaderWriter sliceAt(long pos, int size, long newBottomLimit, boolean as64bit);
+
+    default DataBufferReaderWriter sliceAt(long pos, int size, boolean as64bit) {
+        return sliceAt(pos, size, 0L, as64bit);
+    }
+
+    default DataBufferReaderWriter sliceAt(long pos, int size) {
+        return sliceAt(pos, size, is64bit());
+    }
+
+    /**
+     * makes a slice from current position and specific size
+     */
+    default DataBufferReaderWriter slice(int size) {
+        return sliceAt(position(), size);
+    }
+
+    /**
+     * slices all remain bytes
+     */
+    default DataBufferReaderWriter slice() {
+        return sliceAt(position(), remaining());
+    }
 }

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/bytebuffer/DataBufferWriter.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/bytebuffer/DataBufferWriter.java
@@ -34,7 +34,7 @@ public interface DataBufferWriter extends DataBuffer {
     DataBufferWriter writeInt32(int i);
 
     default DataBufferWriter writeUnsignedInt32(long l) {
-        int i = (int) (l & 0xFFFFFFFF);
+        int i = (int) (l & 0xFFFFFFFFL);
         return writeInt32(i);
     }
 
@@ -127,11 +127,40 @@ public interface DataBufferWriter extends DataBuffer {
         return this;
     }
 
+    //
+    // Overloadable API
+    //
+
     /**
-     * resets writer part, in case both reader and writer are implemented
+     * sets new position of buffer
      */
-    default DataBufferWriter resetWriter() {
-        reset();
-        return this;
+    DataBufferWriter setPosition(long position);
+
+    /**
+     * makes a slice at specific position and specific size,
+     * new slices receives new bottom limit
+     */
+    DataBufferWriter sliceAt(long pos, int size, long newBottomLimit, boolean as64bit);
+
+    default DataBufferWriter sliceAt(long pos, int size, boolean as64bit) {
+        return sliceAt(pos, size, 0L, as64bit);
+    }
+
+    default DataBufferWriter sliceAt(long pos, int size) {
+        return sliceAt(pos, size, is64bit());
+    }
+
+    /**
+     * makes a slice from current position and specific size
+     */
+    default DataBufferWriter slice(int size) {
+        return sliceAt(position(), size);
+    }
+
+    /**
+     * slices all remain bytes
+     */
+    default DataBufferWriter slice() {
+        return sliceAt(position(), remaining());
     }
 }

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/bytebuffer/DataByteBufferReader.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/bytebuffer/DataByteBufferReader.java
@@ -165,4 +165,9 @@ public class DataByteBufferReader implements DataBufferReader {
         byteBuffer.order(order);
         return this;
     }
+
+    @Override
+    public String toString() {
+        return "DataByteBufferReader{" +  Long.toHexString(bottomLimit) + " ... " + Long.toHexString(limit() - 1) + '}';
+    }
 }

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/bytebuffer/DataByteBufferWriter.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/bytebuffer/DataByteBufferWriter.java
@@ -28,6 +28,10 @@ public class DataByteBufferWriter extends DataByteBufferReader implements DataBu
         this(DEFAULT_CAPACITY, false);
     }
 
+    public DataByteBufferWriter(ByteBuffer bb) {
+        super(bb);
+    }
+
     public DataByteBufferWriter(boolean is64Bit) {
         this(DEFAULT_CAPACITY, is64Bit);
     }
@@ -35,6 +39,10 @@ public class DataByteBufferWriter extends DataByteBufferReader implements DataBu
     public DataByteBufferWriter(int capacity, boolean is64Bit) {
         super(ByteBuffer.allocate(capacity), is64Bit);
         reset();
+    }
+
+    public DataByteBufferWriter(ByteBuffer sliced, long newBottomLimit, boolean as64bit) {
+        super(sliced, newBottomLimit, as64bit);
     }
 
     @Override
@@ -123,6 +131,25 @@ public class DataByteBufferWriter extends DataByteBufferReader implements DataBu
     public DataByteBufferWriter writeBytes(byte[] bytes, int offset, int length) {
         wants(length);
         byteBuffer.put(bytes, offset, length);
+        return this;
+    }
+
+    @Override
+    public DataByteBufferWriter sliceAt(long pos, int size, long newBottomLimit, boolean as64bit) {
+        long savedPosition = position();
+        setPosition(pos);
+        expects(size);
+        ByteBuffer sliced = byteBuffer.slice();
+        sliced.limit(size);
+        sliced.order(byteBuffer.order());
+        setPosition(savedPosition);
+
+        return new DataByteBufferWriter(sliced, newBottomLimit, as64bit);
+    }
+
+    @Override
+    public DataByteBufferWriter setPosition(long position) {
+        super.setPosition(position);
         return this;
     }
 }

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/bytebuffer/NullDataBufferReader.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/bytebuffer/NullDataBufferReader.java
@@ -109,4 +109,9 @@ public class NullDataBufferReader implements DataBufferReader {
         expectAndAdvance(length);
         Arrays.fill(dst, offset, offset + length, (byte) 0);
     }
+
+    @Override
+    public String toString() {
+        return "NullDataBufferReader{" +  Long.toHexString(bottomLimit) + " ... " + Long.toHexString(limit() - 1) + '}';
+    }
 }

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/MachOConsts.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/MachOConsts.java
@@ -49,9 +49,11 @@ public final class MachOConsts {
         public static final int LC_SEGMENT_64 = 0x19;
         public static final int LC_SYMTAB = 0x2;
         public static final int LC_DYSYMTAB = 0xb;
+        public static final int LC_DYLD_EXPORTS_TRIE = 0x80000033;
+        public static final int LC_DYLD_CHAINED_FIXUPS = 0x80000034;
     }
 
-    public static class nlist {
+    public static final class nlist {
         public static final int N_STAB = 0xe0;  // if any of these bits set, a symbolic debugging entry
         public static final int N_PEXT = 0x10;  // private external symbol bit
         public static final int N_TYPE = 0x0e;  // mask for the type bits
@@ -64,7 +66,7 @@ public final class MachOConsts {
         public static final int N_TYPE_INDR = 0xa;  // indirect
     }
 
-    public static class stab {
+    public static final class stab {
         public static final int N_GSYM = 0x20;   // global symbol: name,,NO_SECT,type,0
         public static final int N_FNAME = 0x22;  // procedure name (f77 kludge): name,,NO_SECT,0,0
         public static final int N_FUN = 0x24;    // procedure: name,,n_sect,linenumber,address
@@ -95,5 +97,43 @@ public final class MachOConsts {
         public static final int N_ECOMM = 0xe4;  // end common: name,,n_sect,0,0
         public static final int N_ECOML = 0xe8;  // end common (local name): 0,,n_sect,0,address
         public static final int N_LENG = 0xfe;   // second stab entry with length information
+    }
+
+    public static final class ExportSymbolFlags {
+        public static final int KIND_MASK = 0x03;
+        public static final int WEAK_DEFINITION = 0x04;
+        public static final int REEXPORT = 0x08;
+        public static final int STUB_AND_RESOLVER = 0x10;
+    }
+
+    public enum ExportSymbolKind {
+        REGULAR, THREAD_LOCAL, ABSOLUTE
+    }
+
+    public static final class BindSpecialDylib {
+        public static final int SELF = 0;
+        public static final int MAIN_EXECUTABLE = -1;
+        public static final int FLAT_LOOKUP = -2;
+        public static final int WEAK_LOOKUP = -3;
+    }
+
+    public static final class dyld {
+        public static final short DYLD_CHAINED_PTR_START_NONE   = (short) 0xFFFF; // denote a page with no fixups
+        public static final int DYLD_CHAINED_PTR_START_MULTI  = 0x8000; // denote a page which has multiple starts
+        public static final int DYLD_CHAINED_PTR_START_LAST   = 0x8000; // to denote last start in list for page
+
+        public static final int DYLD_CHAINED_PTR_ARM64E              =  1;    // stride 8, unauth target is vmaddr
+        public static final int DYLD_CHAINED_PTR_64                  =  2;    // target is vmaddr
+        public static final int DYLD_CHAINED_PTR_32                  =  3;
+        public static final int DYLD_CHAINED_PTR_32_CACHE            =  4;
+        public static final int DYLD_CHAINED_PTR_32_FIRMWARE         =  5;
+        public static final int DYLD_CHAINED_PTR_64_OFFSET           =  6;    // target is vm offset
+        public static final int DYLD_CHAINED_PTR_ARM64E_OFFSET       =  7;    // old name
+        public static final int DYLD_CHAINED_PTR_ARM64E_KERNEL       =  7;    // stride 4, unauth target is vm offset
+        public static final int DYLD_CHAINED_PTR_64_KERNEL_CACHE     =  8;
+        public static final int DYLD_CHAINED_PTR_ARM64E_USERLAND     =  9;    // stride 8, unauth target is vm offset
+        public static final int DYLD_CHAINED_PTR_ARM64E_FIRMWARE     = 10;   // stride 4, unauth target is vmaddr
+        public static final int DYLD_CHAINED_PTR_X86_64_KERNEL_CACHE = 11;   // stride 1, x86_64 kernel caches
+        public static final int DYLD_CHAINED_PTR_ARM64E_USERLAND24   = 12;   // stride 8, unauth target is vm offset, 24-bit bind
     }
 }

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/cmds/LinkeditDataCommand.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/cmds/LinkeditDataCommand.java
@@ -1,0 +1,25 @@
+package org.robovm.debugger.utils.macho.cmds;
+
+import org.robovm.debugger.utils.bytebuffer.DataBufferReader;
+
+/**
+ * The linkedit_data_command contains the offsets and sizes of a blob
+ * of data in the __LINKEDIT segment.
+ */
+public class LinkeditDataCommand {
+    private final long dataoff; // file offset of data in __LINKEDIT segment
+    private final int datasize; // file size of data in __LINKEDIT segment
+
+    public LinkeditDataCommand(DataBufferReader reader) {
+        dataoff = reader.readUnsignedInt32();
+        datasize = reader.readInt32();
+    }
+
+    public long getDataoff() {
+        return dataoff;
+    }
+
+    public int getDatasize() {
+        return datasize;
+    }
+}

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/cmds/SegmentCommand.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/cmds/SegmentCommand.java
@@ -162,4 +162,12 @@ public class SegmentCommand {
     public boolean is64b() {
         return is64b;
     }
+
+    @Override
+    public String toString() {
+        return "SegmentCommand{" +
+                "segname='" + segname + '\'' +
+                (vmaddr != 0L ? (", vmaddr=" + Long.toHexString(vmaddr) + "..." + Long.toHexString(vmaddr + vmsize - 1)) : "") +
+                '}';
+    }
 }

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/structs/DyLdChainedFixups.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/structs/DyLdChainedFixups.java
@@ -1,0 +1,471 @@
+package org.robovm.debugger.utils.macho.structs;
+
+import org.robovm.debugger.utils.bytebuffer.DataBufferReader;
+import org.robovm.debugger.utils.macho.MachOConsts;
+import org.robovm.debugger.utils.macho.tools.Bits64;
+import org.robovm.debugger.utils.macho.tools.ExportedSymbolsParser.ResolvedSymbol;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.robovm.debugger.utils.macho.MachOConsts.dyld.*;
+
+public class DyLdChainedFixups {
+    static final int DYLD_CHAINED_IMPORT = 1;
+    static final int DYLD_CHAINED_IMPORT_ADDEND = 2;
+    static final int DYLD_CHAINED_IMPORT_ADDEND64 = 3;
+
+    // header of the LC_DYLD_CHAINED_FIXUPS payload
+    // dyld_chained_fixups_header
+    public static class Header {
+        public final StartsInSegment[] startsInSegment;
+        public final Long[] imports;
+
+        public Header(DataBufferReader reader, Map<String, ResolvedSymbol> knownSymbols) {
+            long start = reader.position();
+
+            // uint32_t    fixups_version;    // 0
+            int fixups_version = reader.readInt32();
+            // uint32_t    starts_offset;     // offset of dyld_chained_starts_in_image in chain_data
+            long starts_offset = reader.readUnsignedInt32();
+            // uint32_t    imports_offset;    // offset of imports table in chain_data
+            long imports_offset = reader.readUnsignedInt32();
+            // uint32_t    symbols_offset;    // offset of symbol strings in chain_data
+            long symbols_offset = reader.readUnsignedInt32();
+            // uint32_t    imports_count;     // number of imported symbol names
+            int imports_count = reader.readInt32();
+            // uint32_t    imports_format;    // DYLD_CHAINED_IMPORT*
+            int imports_format = reader.readInt32();
+            // uint32_t    symbols_format;    // 0 => uncompressed, 1 => zlib compressed
+            boolean symbolsCompressed = reader.readInt32() == 1;
+            if (symbolsCompressed)
+                throw new UnsupportedOperationException("Compressed symbols not supported at moment");
+
+            // parse starts
+            startsInSegment = parseChainedStartsInImage(reader.setPosition(starts_offset));
+
+            // parse imports
+            DataBufferReader stringReader = reader.setPosition(start + symbols_offset).slice();
+            imports = parseImports(imports_format, reader.setPosition(start + imports_offset),
+                    stringReader, imports_count, knownSymbols);
+        }
+
+        private StartsInSegment[] parseChainedStartsInImage(DataBufferReader reader) {
+            long start = reader.position();
+
+            // uint32_t    seg_count;
+            // uint32_t    seg_info_offset[1];  // each entry is offset into this struct for that segment
+            // followed by pool of dyld_chain_starts_in_segment data
+            int seg_count = reader.readInt32();
+            List<StartsInSegment> chainedStars = new ArrayList<>(seg_count);
+            for (int i = 0; i < seg_count; i++) {
+                int offset = reader.readInt32();
+                if (offset != 0) {
+                    long savedPos = reader.position();
+                    reader.setPosition(start + offset);
+                    chainedStars.add(new StartsInSegment(reader));
+                    reader.setPosition(savedPos);
+                }
+            }
+
+            return chainedStars.toArray(new StartsInSegment[0]);
+        }
+
+        private Long[] parseImports(int format, DataBufferReader reader, DataBufferReader stringReader, int count,
+                                      Map<String, ResolvedSymbol> knownSymbols) {
+            Long[] imports = new Long[count];
+
+            for (int i = 0; i < count; i++)
+                imports[i] = parseSingleImport(format, reader, stringReader, knownSymbols);
+            return imports;
+        }
+
+        private Long parseSingleImport(int format, DataBufferReader reader, DataBufferReader stringReader,
+                                       Map<String, ResolvedSymbol> knownSymbols) {
+            long v;
+            int lib_ordinal;
+            boolean weak_import;
+            String symbolName;
+            long addend;
+            switch (format) {
+                case DYLD_CHAINED_IMPORT: {
+                    // uint32_t lib_ordinal :  8,
+                    //          weak_import :  1,
+                    //          name_offset : 23;
+                    v = reader.readUnsignedInt32();
+                    lib_ordinal = (int) (v & 0xff);
+                    weak_import = ((v >> 8) & 1) == 1;
+                    long name_offset = (v >> 9 & 0x7fffff);
+                    symbolName = stringReader.setPosition(name_offset).readStringZ();
+                    addend = 0;
+                    break;
+                }
+
+                case DYLD_CHAINED_IMPORT_ADDEND: {
+                    // uint32_t lib_ordinal :  8,
+                    //          weak_import :  1,
+                    //          name_offset : 23;
+                    // int32_t  addend;
+                    v = reader.readUnsignedInt32();
+                    lib_ordinal = (int) (v & 0xff);
+                    weak_import = ((v >> 8) & 1) == 1;
+                    long name_offset = (v >> 9 & 0x7fffff);
+                    symbolName = stringReader.setPosition(name_offset).readStringZ();
+                    addend = reader.readUnsignedInt32();
+                    break;
+                }
+
+                case DYLD_CHAINED_IMPORT_ADDEND64: {
+                    // uint64_t lib_ordinal : 16,
+                    //          weak_import :  1,
+                    //          reserved    : 15,
+                    //          name_offset : 32;
+                    // uint64_t addend;
+                    v = reader.readUnsignedInt32();
+                    lib_ordinal = (int) (v & 0xff);
+                    weak_import = ((v >> 8) & 1) == 1;
+                    long name_offset = (v >> 9 & 0x7fffff);
+                    symbolName = stringReader.setPosition(name_offset).readStringZ();
+                    addend = reader.readLong();
+                    break;
+                }
+
+                default:
+                    // throw new IllegalArgumentException("Unsupported import format: " + format);
+                    return null;
+            }
+
+            // capture only symbols debugger will be used for -- own ones
+            if (lib_ordinal == MachOConsts.BindSpecialDylib.SELF && !weak_import) {
+                ResolvedSymbol resolvedSymbol = knownSymbols.get(symbolName);
+                if (resolvedSymbol != null) {
+                    switch (resolvedSymbol.kind) {
+                        case REGULAR:
+                        case ABSOLUTE:
+                            return resolvedSymbol.target + addend;
+
+                        case THREAD_LOCAL:
+                            // no type checking that client expected TLV yet
+                            return resolvedSymbol.target;
+                    }
+                }
+            }
+
+            // import bind debugger doesn't bother about
+            return null;
+        }
+    }
+
+
+    public static class StartsInSegment {
+        public final short page_size;
+        public final short pointer_format;
+        public final long segment_offset;
+        public final long max_valid_pointer;
+        public final short[] page_starts;
+        // or DYLD_CHAINED_PTR_START_NONE if no fixups on page
+        // uint16_t    chain_starts[1];    // some 32-bit formats may require multiple starts per page.
+
+        public StartsInSegment(DataBufferReader reader) {
+            // uint32_t    size;               // size of this (amount kernel needs to copy)
+            int size = reader.readInt32();
+            // uint16_t    page_size;          // 0x1000 or 0x4000
+            page_size = reader.readInt16();
+            // uint16_t    pointer_format;     // DYLD_CHAINED_PTR_*
+            pointer_format = reader.readInt16();
+            // uint64_t    segment_offset;     // offset in memory to start of segment
+            segment_offset = reader.readLong();
+            // uint32_t    max_valid_pointer;  // for 32-bit OS, any value beyond this is not a pointer
+            max_valid_pointer = reader.readInt32();
+            // uint16_t    page_count;         // how many pages are in array
+            short page_count = reader.readInt16();
+            // uint16_t    page_start[1];      // each entry is offset in each page of first element in chain
+            // or DYLD_CHAINED_PTR_START_NONE if no fixups on page
+            page_starts = new short[page_count];
+            for (int i = 0; i < page_count; i++)
+                page_starts[i] = reader.readInt16();
+        }
+    }
+
+    /**
+     * represent fixup pointer structures
+     */
+    public static class PointerOnDisk extends Bits64 {
+        public final long addr;
+
+        public final Arm64e arm64e = new Arm64e();
+        public final Generic64 generic64 = new Generic64();
+
+        public PointerOnDisk(long addr, long val) {
+            super(val);
+            this.addr = addr;
+        }
+
+        public class Arm64e {
+            public final AuthRebase authRebase = new AuthRebase();
+            public final AuthBind authBind = new AuthBind();
+            public final Rebase rebase = new Rebase();
+            public final Bind bind = new Bind();
+
+            public long signPointer(PointerOnDisk loc, long target) {
+                assert (authBind.auth());
+                return target;
+            }
+
+            public long signExtendedAddend() {
+                assert (authBind.bind());
+                assert (!authBind.auth());
+                long addend19 = bind.addend();
+                if ((addend19 & 0x40000) != 0)
+                    return addend19 | 0xFFFFFFFFFFFC0000L;
+                else
+                    return addend19;
+            }
+
+            public long unpackTarget() {
+                assert (!authBind.bind());
+                assert (!authBind.auth());
+                return (rebase.high8() << 56) | (this.rebase.target());
+            }
+
+            public class Rebase {
+                // uint64_t    target   : 43,    // vmaddr
+                //    high8    :  8,
+                //    next     : 11,    // 8-byte stide
+                //    bind     :  1,    // == 0
+                //    auth     :  1;    // == 0
+                public long target() {
+                    return getLongBits(43);
+                }
+
+                public long high8() {
+                    return getLongBits(8, 43);
+                }
+
+                public long next() {
+                    return getLongBits(11, 43 + 8);
+                }
+
+                public boolean bind() {
+                    return getBooleanBit(43 + 8 + 11);
+                }
+
+                public boolean auth() {
+                    return getBooleanBit(43 + 8 + 11 + 1);
+                }
+            }
+
+            public class Bind {
+                // uint64_t    ordinal   : 16,
+                //    zero      : 16,
+                //    addend    : 19,
+                //    next      : 11,    // 8-byte stide
+                //    bind      :  1,    // == 1
+                //    auth      :  1;    // == 0
+                public int ordinal() {
+                    return getIntBits(16);
+                }
+
+                public long addend() {
+                    return getLongBits(19, 16 + 16);
+                }
+
+                public long next() {
+                    return getLongBits(11, 16 + 16 + 19);
+                }
+
+                public boolean bind() {
+                    return getBooleanBit(16 + 16 + 19 + 11);
+                }
+
+                public boolean auth() {
+                    return getBooleanBit(16 + 16 + 19 + 11 + 1);
+                }
+            }
+
+            public class AuthRebase {
+                // uint64_t    target    : 32,   // runtimeOffset
+                //    diversity : 16,
+                //    addrDiv   :  1,
+                //    key       :  2,
+                //    next      : 11,    // 8-byte stide
+                //    bind      :  1,    // == 0
+                //    auth      :  1;    // == 1
+
+                public long target() {
+                    return getLongBits(32);
+                }
+
+                public int diversity() {
+                    return getIntBits(16, 32);
+                }
+
+                public boolean addrDiv() {
+                    return getBooleanBit(32 + 16);
+                }
+
+                public int key() {
+                    return getIntBits(2, 32 + 16 + 1);
+                }
+
+                public long next() {
+                    return getIntBits(11, 32 + 16 + 1 + 2);
+                }
+
+                public boolean bind() {
+                    return getBooleanBit(32 + 16 + 1 + 2 + 11);
+                }
+
+                public boolean auth() {
+                    return getBooleanBit(32 + 16 + 1 + 2 + 11 + 1);
+                }
+            }
+
+            public class AuthBind {
+                //uint64_t ordinal   :16,
+                //    zero      :16,
+                //    diversity :16,
+                //    addrDiv   :1,
+                //    key       :2,
+                //    next      :11,    // 8-byte stide
+                //    bind      :1,    // == 1
+                //    auth      :1;    // == 1
+                public int ordinal() {
+                    return getIntBits(16);
+                }
+
+                public int diversity() {
+                    return getIntBits(16, 16 + 16);
+                }
+
+                public boolean addrDiv() {
+                    return getBooleanBit(16 + 16 + 16);
+                }
+
+                public int key() {
+                    return getIntBits(2, 16 + 16 + 16 + 1);
+                }
+
+                public long next() {
+                    return getIntBits(11, 16 + 16 + 16 + 1 + 2);
+                }
+
+                public boolean bind() {
+                    return getBooleanBit(16 + 16 + 16 + 1 + 2 + 11);
+                }
+
+                public boolean auth() {
+                    return getBooleanBit(16 + 16 + 16 + 1 + 2 + 11 + 1);
+                }
+            }
+        }
+
+        public class Generic64 {
+            public final Rebase rebase = new Rebase();
+            public final Bind bind = new Bind();
+
+            public long signExtendedAddend() {
+                long addend27 = bind.addend();
+                long top8Bits = addend27 & 0x00007F80000L;
+                long bottom19Bits = addend27 & 0x0000007FFFFL;
+                return (top8Bits << 13) | (((bottom19Bits << 37) >> 37) & 0x00FFFFFFFFFFFFFFL);
+            }
+
+            public long unpackedTarget() {
+                return (rebase.high8() << 56) | rebase.target();
+            }
+
+            public class Rebase {
+                // uint64_t    target    : 36,    // vmaddr, 64GB max image size
+                //    high8     :  8,    // top 8 bits set to this after slide added
+                //    reserved  :  7,    // all zeros
+                //    next      : 12,    // 4-byte stride
+                //    bind      :  1;    // == 0
+                public long target() {
+                    return getLongBits(36);
+                }
+
+                public long high8() {
+                    return getLongBits(8, 36);
+                }
+
+                public long next() {
+                    return getLongBits(12, 36 + 8 + 7);
+                }
+
+                public boolean bind() {
+                    return getBooleanBit(36 + 8 + 7 + 12);
+                }
+
+                @Override
+                public String toString() {
+                    return "Rebase: " +
+                            "target=" + Long.toHexString(target()) +
+                            ", hig8h=" + Long.toHexString(high8()) +
+                            ", next=" + Long.toHexString(next()) +
+                            ", bind=" + bind();
+                }
+            }
+
+            // DYLD_CHAINED_PTR_64
+            public class Bind {
+                // uint64_t    ordinal   : 24,
+                //    addend    :  8,   // 0 thru 255
+                //    reserved  : 19,   // all zeros
+                //    next      : 12,   // 4-byte stride
+                //    bind      :  1;   // == 1
+                public int ordinal() {
+                    return getIntBits(24);
+                }
+
+                public long addend() {
+                    return getLongBits(8, 24);
+                }
+
+                public long next() {
+                    return getLongBits(12, 24 + 8 + 19);
+                }
+
+                public boolean bind() {
+                    return getBooleanBit(24 + 8 + 19 + 12);
+                }
+
+                public String toString() {
+                    return "Bind: " +
+                            "ordinal=" + Long.toHexString(ordinal()) +
+                            ", addend=" + Long.toHexString(addend()) +
+                            ", next=" + Long.toHexString(next()) +
+                            ", bind=" + bind();
+                }
+            }
+
+            @Override
+            public String toString() {
+                return "Generic64: raw=" + Long.toHexString(raw);
+            }
+        }
+
+        public static int strideSize(short pointerFormat) {
+            switch (pointerFormat) {
+                case DYLD_CHAINED_PTR_ARM64E:
+                case DYLD_CHAINED_PTR_ARM64E_USERLAND:
+                case DYLD_CHAINED_PTR_ARM64E_USERLAND24:
+                    return 8;
+                case DYLD_CHAINED_PTR_ARM64E_KERNEL:
+                case DYLD_CHAINED_PTR_ARM64E_FIRMWARE:
+                case DYLD_CHAINED_PTR_32_FIRMWARE:
+                case DYLD_CHAINED_PTR_64:
+                case DYLD_CHAINED_PTR_64_OFFSET:
+                case DYLD_CHAINED_PTR_32:
+                case DYLD_CHAINED_PTR_32_CACHE:
+                case DYLD_CHAINED_PTR_64_KERNEL_CACHE:
+                    return 4;
+                case DYLD_CHAINED_PTR_X86_64_KERNEL_CACHE:
+                    return 1;
+            }
+
+            throw new IllegalArgumentException("unsupported pointer chain format " + pointerFormat);
+        }
+    }
+}

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/structs/Section.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/structs/Section.java
@@ -150,4 +150,9 @@ public class Section {
         return is64b ? (16 + 16 + 8 + 8 + 4 * 8) : (16 + 16 + 4 * 9);
     }
 
+    @Override
+    public String toString() {
+        return "Section{" + segname + ',' + sectname +
+                Long.toHexString(addr) + "..." + Long.toHexString(addr + size - 1) + " }";
+    }
 }

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/tools/Bits64.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/tools/Bits64.java
@@ -1,0 +1,33 @@
+package org.robovm.debugger.utils.macho.tools;
+
+/**
+ * Utility class that helps with bit manipulations
+ */
+public class Bits64 {
+    public final long raw;
+
+    public Bits64(long raw) {
+        this.raw = raw;
+    }
+
+    protected long getLongBits(int bitWidth, int bitOffs) {
+        return (raw >> bitOffs) & ((1L << bitWidth) - 1);
+    }
+
+    protected long getLongBits(int bitWidth) {
+        return raw & ((1L << bitWidth) - 1);
+    }
+
+    protected int getIntBits(int bitWidth, int bitOffs) {
+        return (int) getLongBits(bitWidth, bitOffs);
+    }
+
+    protected int getIntBits(int bitWidth) {
+        return (int) getLongBits(bitWidth);
+    }
+
+
+    protected boolean getBooleanBit(int bitOffs) {
+        return (raw & (1L << bitOffs)) != 0;
+    }
+}

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/tools/ChainedFixup.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/tools/ChainedFixup.java
@@ -1,0 +1,145 @@
+package org.robovm.debugger.utils.macho.tools;
+
+import org.robovm.debugger.utils.bytebuffer.DataBufferReaderWriter;
+import org.robovm.debugger.utils.macho.structs.DyLdChainedFixups;
+import org.robovm.debugger.utils.macho.structs.DyLdChainedFixups.PointerOnDisk;
+
+import static org.robovm.debugger.utils.macho.MachOConsts.dyld.*;
+
+/**
+ * Mostly port of DYLD code that performs chained pointer fixup
+ */
+public class ChainedFixup {
+
+    private final DataBufferReaderWriter readerWriter;
+    private final long imageBaseAddress;
+
+    public ChainedFixup(long imageBaseAddress, DataBufferReaderWriter readerWriter) {
+        this.imageBaseAddress = imageBaseAddress;
+        this.readerWriter = readerWriter;
+    }
+
+    private PointerOnDisk getFixupPointerAt(long addr) {
+        long val = readerWriter.setPosition(addr).readPointer();
+        return new PointerOnDisk(addr, val);
+    }
+
+    private void applyFixup(PointerOnDisk ptr, long value) {
+        if (ptr.raw != value)
+            readerWriter.setPosition(ptr.addr).writePointer(value);
+    }
+
+    public void fixupAllChainedFixups(DyLdChainedFixups.StartsInSegment[] starts, long slide, Long[] bindTargets) {
+        for (DyLdChainedFixups.StartsInSegment segInfo : starts) {
+            for (int pageIndex = 0; pageIndex < segInfo.page_starts.length; ++pageIndex) {
+                short offsetInPage = segInfo.page_starts[pageIndex];
+                if (offsetInPage == DYLD_CHAINED_PTR_START_NONE)
+                    continue;
+                if ((offsetInPage & DYLD_CHAINED_PTR_START_MULTI) != 0) {
+                    // 32-bit chains which may need multiple starts per page
+                    // not supported !
+                    throw new IllegalArgumentException("32bit DYLD_CHAINED_PTR_START_MULTI are not supported!");
+                } else {
+                    // one chain per page
+                    long pageContentStart = imageBaseAddress + segInfo.segment_offset + ((long) pageIndex * segInfo.page_size);
+                    PointerOnDisk chain = getFixupPointerAt(pageContentStart + offsetInPage);
+
+                    walkChain(chain, segInfo.pointer_format, bindTargets, slide);
+                }
+            }
+        }
+    }
+
+    private void walkChain(PointerOnDisk chain, short pointer_format, Long[] bindTargets, long slide) {
+        int stride = PointerOnDisk.strideSize(pointer_format);
+        boolean chainEnd = false;
+        while (!chainEnd) {
+            handleFixupLocation(chain, pointer_format, bindTargets, slide);
+            switch (pointer_format) {
+                case DYLD_CHAINED_PTR_ARM64E:
+                case DYLD_CHAINED_PTR_ARM64E_KERNEL:
+                case DYLD_CHAINED_PTR_ARM64E_USERLAND:
+                case DYLD_CHAINED_PTR_ARM64E_USERLAND24:
+                case DYLD_CHAINED_PTR_ARM64E_FIRMWARE:
+                    if (chain.arm64e.rebase.next() == 0)
+                        chainEnd = true;
+                    else
+                        chain = getFixupPointerAt(chain.addr + chain.arm64e.rebase.next() * stride);
+                    break;
+                case DYLD_CHAINED_PTR_64:
+                case DYLD_CHAINED_PTR_64_OFFSET:
+                    if (chain.generic64.rebase.next() == 0)
+                        chainEnd = true;
+                    else
+                        chain = getFixupPointerAt(chain.addr + chain.generic64.rebase.next() * stride);
+                    break;
+                default:
+                    throw new Error("unknown pointer format " + pointer_format);
+            }
+        }
+    }
+
+    private void handleFixupLocation(PointerOnDisk fixupLoc, short pointer_format, Long[] bindTargets,
+                                     long slide) {
+        long newValue;
+        switch (pointer_format) {
+            case DYLD_CHAINED_PTR_ARM64E:
+            case DYLD_CHAINED_PTR_ARM64E_KERNEL:
+            case DYLD_CHAINED_PTR_ARM64E_USERLAND:
+                if (fixupLoc.arm64e.authRebase.auth()) {
+                    if (fixupLoc.arm64e.authBind.bind()) {
+                        // authenticated bind
+                        Long bindTarget = bindTargets[fixupLoc.arm64e.authBind.ordinal()];
+                        if (bindTarget == null)
+                            return;
+                        newValue = bindTarget;
+                        if (newValue != 0)  // Don't sign missing weak imports
+                            newValue = fixupLoc.arm64e.signPointer(fixupLoc, newValue);
+                    } else {
+                        // authenticated rebase
+                        newValue = fixupLoc.arm64e.signPointer(fixupLoc, imageBaseAddress + fixupLoc.arm64e.authRebase.target());
+                    }
+                } else {
+                    if (fixupLoc.arm64e.bind.bind()) {
+                        // plain bind
+                        Long bindTarget = bindTargets[fixupLoc.arm64e.bind.ordinal()];
+                        if (bindTarget == null)
+                            return;
+                        newValue = bindTarget + fixupLoc.arm64e.signExtendedAddend();
+                    } else {
+                        // plain rebase (old format target is vmaddr, new format target is offset)
+                        if (pointer_format == DYLD_CHAINED_PTR_ARM64E)
+                            newValue = fixupLoc.arm64e.unpackTarget() + slide;
+                        else
+                            newValue = imageBaseAddress + fixupLoc.arm64e.unpackTarget();
+                    }
+                }
+
+                // fixup pointer in memory
+                applyFixup(fixupLoc, newValue);
+                break;
+
+            case DYLD_CHAINED_PTR_64:
+            case DYLD_CHAINED_PTR_64_OFFSET:
+                if (fixupLoc.generic64.bind.bind()) {
+                    Long bindTarget = bindTargets[fixupLoc.generic64.bind.ordinal()];
+                    if (bindTarget == null)
+                        return;
+                    newValue = bindTarget + fixupLoc.generic64.signExtendedAddend();
+                } else {
+                    // plain rebase (old format target is vmaddr, new format target is offset)
+                    if (pointer_format == DYLD_CHAINED_PTR_64)
+                        newValue = fixupLoc.generic64.unpackedTarget() + slide;
+                    else
+                        newValue = imageBaseAddress + fixupLoc.generic64.unpackedTarget();
+                }
+
+                // fixup pointer in memory
+                applyFixup(fixupLoc, newValue);
+                break;
+
+            default:
+                throw new IllegalArgumentException("unsupported pointer chain format: " + pointer_format);
+        }
+    }
+}

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/tools/ExportedSymbolsParser.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/tools/ExportedSymbolsParser.java
@@ -1,0 +1,97 @@
+package org.robovm.debugger.utils.macho.tools;
+
+import org.robovm.debugger.utils.bytebuffer.DataBufferArrayReader;
+import org.robovm.debugger.utils.bytebuffer.DataBufferReader;
+import org.robovm.debugger.utils.macho.MachOConsts.ExportSymbolFlags;
+import org.robovm.debugger.utils.macho.MachOConsts.ExportSymbolKind;
+import org.robovm.debugger.utils.macho.cmds.SymtabCommand;
+import org.robovm.debugger.utils.macho.structs.NList;
+
+import java.util.Map;
+
+final public class ExportedSymbolsParser {
+
+    public static class ResolvedSymbol {
+        public final String symbolName;
+        public final ExportSymbolKind kind;
+        public final long target;
+
+        public ResolvedSymbol(String symbolName, ExportSymbolKind kind, long target) {
+            this.symbolName = symbolName;
+            this.kind = kind;
+            this.target = target;
+        }
+    }
+
+    public static void parseSymtabCommand(Map<String, ResolvedSymbol> dest, DataBufferReader reader,
+                                          SymtabCommand symtabCommand, boolean is64b) {
+        DataBufferReader stringReader;
+        if (symtabCommand.strsize < 8 * 1024 * 1024) {
+            // read entire data to byte array and wrap to byte buffer
+            // to enable array based optimizations
+            byte[] symtabBytes = reader.setPosition(symtabCommand.stroff).readBytes((int) symtabCommand.strsize);
+            stringReader = DataBufferReader.wrap(symtabBytes);
+        } else {
+            stringReader = reader.sliceAt(symtabCommand.stroff, (int) symtabCommand.strsize);
+        }
+        DataBufferReader nlistReader = reader.sliceAt(symtabCommand.symoff, (int) (symtabCommand.nsyms * NList.ITEM_SIZE(is64b)));
+        DataBufferArrayReader<NList> arrayReader = new DataBufferArrayReader<>(nlistReader,
+                NList.ITEM_SIZE(is64b), NList.OBJECT_READER(is64b));
+        for (NList nlist : arrayReader) {
+            if (nlist.isTypeStab()) {
+                if (!nlist.isTypeStabGlobalSymb())
+                    continue;
+            } else {
+                // do some filtering
+                if (nlist.isTypeUndfined())
+                    continue;
+                if (nlist.isTypePreboundUndefined())
+                    continue;
+            }
+            if (nlist.n_sect() == 0)
+                continue;
+
+            // save offset to NList as there is too much of symbols
+            String sym = stringReader.readStringZ(nlist.n_strx());
+            if (isUsableDebuggerSym(sym)) {
+                ExportSymbolKind kind = ExportSymbolKind.ABSOLUTE;
+                long target = nlist.n_value();
+                ResolvedSymbol resolved = new ResolvedSymbol(sym, kind, target);
+                dest.put(sym, resolved);
+            }
+        }
+    }
+
+    public static void parseExportTrie(Map<String, ResolvedSymbol> dest, DataBufferReader trie) {
+
+        Trie.forEach(trie, (symbolName, data, size) -> {
+            // capture only usable symbols
+            if (isUsableDebuggerSym(symbolName)) {
+                DataBufferReader symbolData = data.slice(size);
+                int flags = (int) symbolData.readUleb128();
+                ExportSymbolKind kind = ExportSymbolKind.values()[flags & ExportSymbolFlags.KIND_MASK];
+
+                // proceed only if symbol: not reexport, not weekm and not stub and resolver
+                boolean accept = (flags & ExportSymbolFlags.REEXPORT) == 0 &&
+                        (flags & ExportSymbolFlags.WEAK_DEFINITION) == 0 &&
+                        (flags & ExportSymbolFlags.STUB_AND_RESOLVER) != 0;
+
+                if (accept) {
+                    long target = symbolData.readUleb128();
+                    ResolvedSymbol resolved = new ResolvedSymbol(symbolName, kind, target);
+                    dest.put(symbolName, resolved);
+                }
+            }
+            return true;
+        });
+    }
+
+    private static boolean isUsableDebuggerSym(String sym) {
+        return sym.endsWith("[debuginfo]") ||
+                sym.endsWith("[bptable]") ||
+                sym.startsWith("_prim_") ||
+                sym.equals("__bcBootClassesHash") ||
+                sym.equals("__bcClassesHash") ||
+                sym.equals("_robovmBaseSymbol");
+    }
+}

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/tools/RegionSquasher.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/tools/RegionSquasher.java
@@ -1,0 +1,32 @@
+package org.robovm.debugger.utils.macho.tools;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.BiPredicate;
+
+/**
+ * Squashes list of memory regions if these goes in sequence
+ */
+final public class RegionSquasher {
+    public static <T> void squash(List<T> items, BiPredicate<T, T> isSequence, BiConsumer<T, T> squash) {
+        T first = null;
+        T last = null;
+        for (T s : items) {
+            if (last != null) {
+                if (isSequence.test(last, s)) {
+                    // sequence continue to be uninterruptible
+                    last = s;
+                } else {
+                    // there is a gap, squash and start new region
+                    squash.accept(first, last);
+                    first = last = s;
+                }
+            } else {
+                first = last = s;
+            }
+        }
+        // squash last ones
+        if (first != null)
+            squash.accept(first, last);
+    }
+}

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/tools/Trie.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/macho/tools/Trie.java
@@ -1,0 +1,78 @@
+package org.robovm.debugger.utils.macho.tools;
+
+import org.robovm.debugger.utils.bytebuffer.DataBufferReader;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * trie structures walker, such as export symbol tries
+ */
+public final class Trie {
+    public interface TrieIterator {
+        // called for trie final node, should return true to continue walk
+        boolean handle(String name, DataBufferReader data, int size);
+    }
+
+    public interface Mapper<T> {
+        // mapper for find interface to map data buffer into expected data
+        T map(DataBufferReader data, int size);
+    }
+
+
+    /**
+     * walks through all children of node
+     */
+    private static boolean walkNode(DataBufferReader trie,
+                                    Set<Long> visitedNodeOffsets,
+                                    String nodeName,
+                                    Predicate<String> shouldContinueToChild,
+                                    TrieIterator iterator) {
+        visitedNodeOffsets.add(trie.position());
+        long terminalSize = trie.readUleb128();
+        if (terminalSize != 0) {
+            // pointing to symbol data
+            long savedPos = trie.position();
+            if (!iterator.handle(nodeName, trie, (int) terminalSize))
+                return false;
+            trie.setPosition(savedPos + terminalSize);
+        }
+
+        byte childrenCount = trie.readByte();
+        for (; childrenCount > 0; childrenCount--) {
+            String childSuffix = trie.readStringZ();
+            String childName = nodeName + childSuffix;
+            long nodeOffset = trie.readUleb128();
+            if (shouldContinueToChild.test(childName)) {
+                long savedPos = trie.position();
+                trie.setPosition(nodeOffset);
+                if (!walkNode(trie, visitedNodeOffsets, childName, shouldContinueToChild, iterator))
+                    return false;
+                trie.setPosition(savedPos);
+            }
+        }
+
+        return true;
+    }
+
+    public static void forEach(DataBufferReader trie, TrieIterator iterator) {
+        Set<Long> visitedNodeOffsets = new HashSet<>();
+        walkNode(trie, visitedNodeOffsets, "", (name) -> true, iterator);
+    }
+
+    public static <T> T find(DataBufferReader trie, String key, Mapper<T> mapper) {
+        Set<Long> visitedNodeOffsets = new HashSet<>();
+        final Object[] result = new Object[]{null};
+        walkNode(trie, visitedNodeOffsets, "", key::startsWith, (name, data, size) -> {
+            if (name.equals(key)) {
+                result[0] = mapper.map(data, size);
+                // don't continue
+                return false;
+            } else return true;
+        });
+
+        //noinspection unchecked
+        return (T) result[0];
+    }
+}


### PR DESCRIPTION
Starting from Xcode13 and for ios15 target Apple have changed a binary and its address references are mixed with meta data that doesn't allow debugger to parse RoboVM structures. 
This results in debugger crash on startup:
>[ERROR] Couldn't start application
>java.lang.IllegalArgumentException: there is no region for addr @10000101effaa0
>	at org.robovm.debugger.utils.bytebuffer.CompositeDataBuffer.setPosition(CompositeDataBuffer.java:37)

this PR adds support for chained fixup based on DYLD sources. It includes:
- parsed LC_DYLD_CHAINED_FIXUPS, pointer being fixed up to fixups organized in chains. Code based on [dyld](https://opensource.apple.com/tarballs/dyld/) code, mostly its a port of
`MachOLoaded::fixupAllChainedFixups` method;
- support for LC_DYLD_EXPORTS_TRIE -- another way how exports organized in tries.
- byte readers/writers extended a bit to support changes;
- all data that is available in binary is accessible to debugger now through composite reader. There seems to be changes as const data is being put to new segments.