### PR TITLE
* fixed: #641 java.lang.IllegalAccessError: Attempt to access protected method from Lambda

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/plugin/lambda/LambdaPlugin.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/plugin/lambda/LambdaPlugin.java
@@ -163,7 +163,6 @@ public class LambdaPlugin extends AbstractCompilerPlugin {
                                         samMethodType.getReturnType());
                                 for (SootMethod targetTypeMethod : targetType.getMethods()) {
                                     boolean isBridgeMethod = targetTypeMethod.getName().equals(invokedName);
-                                    isBridgeMethod &= targetTypeMethod.getName().equals(invokedName);
                                     isBridgeMethod &= targetTypeMethod.getParameterCount() == samMethodType.getParameterTypes().size();
                                     isBridgeMethod &= ((targetTypeMethod.getModifiers() & BRIDGE) != 0);
                                     isBridgeMethod &= ((targetTypeMethod.getModifiers() & SYNTHETIC) != 0);


### PR DESCRIPTION

Code to reproduce:
```
package a;
public class A {
    protected foo(){};
}

package b;
import a.A;
public class B extends A{
    public void test() {
        Runnable r = ::foo;
        r.run();
    }
}
```

Root case: labda for B class is located in `package b` and can access protected members of A class from there.

Fix: for such kind of lambda a trampoline method is generated in calling class (which has all access to destination member) and instead of directly invoking method target -- this trampoline is invoked:

```
public class B extends A{
    public void test() {
        Runnable r = lambda(this);
        r.run();
    }

    static private lambda$1$run(B thiz) {
       thiz.foo();
    }
}
public class lambda implements Runnable {
    private final B thiz;
    lambda(B thiz) { this.thiz = thiz; }
    public void run() {
        B.lambda$1$run(thiz);
    }
}
```