### PR TITLE
* fixed: debugger crash if method/field contains non ansi characters in name

### DIFF
--- a/plugins/debugger/src/main/java/org/robovm/debugger/debuginfo/DebuggerDebugObjectFileInfo.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/debuginfo/DebuggerDebugObjectFileInfo.java
@@ -245,9 +245,13 @@ public class DebuggerDebugObjectFileInfo {
 //    }
 
     private  static void putStringWithLen(DataOutputStream stream, String str) throws IOException {
-        stream.writeInt(str.length());
-        if (!str.isEmpty())
-            stream.write(str.getBytes());
+        if (!str.isEmpty()) {
+            byte[] bytes = str.getBytes();
+            stream.writeInt(bytes.length);
+            stream.write(bytes);
+        } else {
+            stream.writeInt(0);
+        }
     }
 
 }

--- a/plugins/debugger/src/main/java/org/robovm/debugger/utils/bytebuffer/CompositeDataBuffer.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/utils/bytebuffer/CompositeDataBuffer.java
@@ -138,7 +138,7 @@ public abstract class CompositeDataBuffer<T extends DataBufferReader> implements
 
     @Override
     public long readLong() {
-        return activeRegion.readInt32();
+        return activeRegion.readLong();
     }
 
     @Override


### PR DESCRIPTION
root case: str.length() != str.getBytes().length
also fixed CompositeDataBuffer readLong being wrongly proxied