### PR TITLE
* Fixed: `rvmCreateVM SIGABRT` during concurrent class load

### DIFF
--- a/compiler/vm/core/src/class.c
+++ b/compiler/vm/core/src/class.c
@@ -792,8 +792,11 @@ Class* rvmFindClassUsingLoader(Env* env, const char* className, Object* classLoa
 }
 
 Class* rvmFindLoadedClass(Env* env, const char* className, Object* classLoader) {
+    obtainClassLock();
     Class* clazz = getLoadedClass(env, className);
+    releaseClassLock();
     if (rvmExceptionOccurred(env)) return NULL;
+    if (clazz && !CLASS_IS_STATE_INITIALIZED(clazz)) return NULL;
     return clazz;
 }
 


### PR DESCRIPTION
Crash log looks like bellow:
```
Crashed: Thread
0  libsystem_kernel.dylib         0x1d5219414 __pthread_kill + 8
1  libsystem_pthread.dylib        0x1f2d74b50 pthread_kill + 272
2  libsystem_c.dylib              0x1b06f7b74 abort + 104
3  RoboVMMobile                   0x1060a77b0 rvmCreateVM + 4386699184
4  RoboVMMobile                   0x1060a51ec rvmInitialize + 4386689516
5  RoboVMMobile                   0x10609d9a8 _bcInitializeClass + 4386658728
```

Root case:
`rvmFindLoadedClass` was doing not synchronized access to loaded class map