### PR TITLE
* Memory usage optimization (1/2): release not required data asap

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/AppCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/AppCompiler.java
@@ -28,10 +28,7 @@ import org.robovm.compiler.config.*;
 import org.robovm.compiler.config.Config.TreeShakerMode;
 import org.robovm.compiler.config.StripArchivesConfig.StripArchivesBuilder;
 import org.robovm.compiler.log.ConsoleLogger;
-import org.robovm.compiler.plugin.LaunchPlugin;
-import org.robovm.compiler.plugin.Plugin;
-import org.robovm.compiler.plugin.PluginArgument;
-import org.robovm.compiler.plugin.TargetPlugin;
+import org.robovm.compiler.plugin.*;
 import org.robovm.compiler.target.ConsoleTarget;
 import org.robovm.compiler.target.LaunchParameters;
 import org.robovm.compiler.target.ios.*;
@@ -439,9 +436,10 @@ public class AppCompiler {
                     dependencyGraph.add(clazz, rootClasses.contains(clazz), forceLinkMethods);
                     linkClasses.add(clazz);
 
-                    // at this moment this class is processed and all dependency information not required anymore
-                    // can be dropped to reduce memory usage
-                    clazz.getClazzInfo().dropDependencyData();
+                    // notify plugins
+                    for (CompilerPlugin plugin : config.getCompilerPlugins()) {
+                        plugin.afterClassDependenciesResolved(config, clazz);
+                    }
 
                     if (compileDependencies) {
                         addMetaInfImplementations(config.getClazzes(), clazz, linkClasses, compileQueue);
@@ -493,10 +491,6 @@ public class AppCompiler {
             long duration = System.currentTimeMillis() - start;
             config.getLogger().info("Compiled %d classes in %.2f seconds", compiledCount, duration / 1000.0);
         }
-
-        // reset anything that can be retained by Soot library. As it keeps structures that are not required
-        // any more
-        config.getClazzes().disposeSoot();
 
         return linkClasses;
     }
@@ -974,14 +968,9 @@ public class AppCompiler {
                         this.config.addResourcesPath(path);
                     }
                 }
-
-                // dispose compilation data that is not required anymore (clazzes, dependency trie etc)
-                sliceConfig.disposeBuildData();
             }
             this.config.getTarget().buildFat(slices);
         }
-        // dispose compilation data that is not required anymore (clazzes, dependency trie etc)
-        this.config.disposeBuildData();
     }
 
     /**

--- a/compiler/compiler/src/main/java/org/robovm/compiler/AppCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/AppCompiler.java
@@ -439,6 +439,10 @@ public class AppCompiler {
                     dependencyGraph.add(clazz, rootClasses.contains(clazz), forceLinkMethods);
                     linkClasses.add(clazz);
 
+                    // at this moment this class is processed and all dependency information not required anymore
+                    // can be dropped to reduce memory usage
+                    clazz.getClazzInfo().dropDependencyData();
+
                     if (compileDependencies) {
                         addMetaInfImplementations(config.getClazzes(), clazz, linkClasses, compileQueue);
                     }
@@ -489,6 +493,10 @@ public class AppCompiler {
             long duration = System.currentTimeMillis() - start;
             config.getLogger().info("Compiled %d classes in %.2f seconds", compiledCount, duration / 1000.0);
         }
+
+        // reset anything that can be retained by Soot library. As it keeps structures that are not required
+        // any more
+        config.getClazzes().disposeSoot();
 
         return linkClasses;
     }
@@ -966,9 +974,14 @@ public class AppCompiler {
                         this.config.addResourcesPath(path);
                     }
                 }
+
+                // dispose compilation data that is not required anymore (clazzes, dependency trie etc)
+                sliceConfig.disposeBuildData();
             }
             this.config.getTarget().buildFat(slices);
         }
+        // dispose compilation data that is not required anymore (clazzes, dependency trie etc)
+        this.config.disposeBuildData();
     }
 
     /**

--- a/compiler/compiler/src/main/java/org/robovm/compiler/ClassCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/ClassCompiler.java
@@ -25,7 +25,6 @@ import org.robovm.compiler.clazz.Dependency;
 import org.robovm.compiler.clazz.MethodInfo;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
-import org.robovm.compiler.config.Environment;
 import org.robovm.compiler.config.OS;
 import org.robovm.compiler.llvm.Alias;
 import org.robovm.compiler.llvm.AliasRef;
@@ -330,6 +329,10 @@ public class ClassCompiler {
                 } catch (Throwable t) {
                     listener.failure(clazz, t);
                 }
+
+                // remove all soot structures that are not
+                // required anymore but consume memory
+                clazz.shrinkSoot();
             }
         };
         

--- a/compiler/compiler/src/main/java/org/robovm/compiler/ClassCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/ClassCompiler.java
@@ -328,10 +328,6 @@ public class ClassCompiler {
                 } catch (Throwable t) {
                     listener.failure(clazz, t);
                 }
-
-                // remove all soot structures that are not
-                // required anymore but consume memory
-                clazz.shrinkSoot();
             }
         };
         

--- a/compiler/compiler/src/main/java/org/robovm/compiler/Linker.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/Linker.java
@@ -446,7 +446,10 @@ public class Linker {
             }
         }
 
-        config.getTarget().build(objectFiles);
+        File binaryFile = config.getTarget().build(objectFiles);
+        for (CompilerPlugin plugin : config.getCompilerPlugins()) {
+            plugin.afterLinker(config, binaryFile);
+        }
     }
 
     private void generateMachineCode(final Config config, ModuleBuilder[] mbs,

--- a/compiler/compiler/src/main/java/org/robovm/compiler/clazz/AbstractPath.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/clazz/AbstractPath.java
@@ -31,9 +31,9 @@ public abstract class AbstractPath implements Path {
     protected final Clazzes clazzes;
     protected final int index;
     protected Set<Clazz> clazzSet = null;
-    protected Set<Package> packageSet = null;
-    protected boolean inBootclasspath = false;
-    protected Map<String, Clazz> generatedClasses = new HashMap<String, Clazz>();
+    protected boolean disposed = false;
+    protected boolean inBootclasspath;
+    protected Map<String, Clazz> generatedClasses = new HashMap<>();
     protected final File generatedClassDir;
     
     AbstractPath(File file, Clazzes clazzes, int index, boolean inBootclasspath) {
@@ -57,6 +57,8 @@ public abstract class AbstractPath implements Path {
     }
     
     public Set<Clazz> listClasses() {
+        if (disposed)
+            throw new IllegalStateException("Path was disposed!");
         if (clazzSet == null) {
             clazzSet = doListClasses();
         }
@@ -119,5 +121,11 @@ public abstract class AbstractPath implements Path {
     public String toString() {
         return file.toString();
     }
-    
+
+    @Override
+    public void disposeBuildData() {
+        disposed = true;
+        clazzSet = null;
+        generatedClasses = null;
+    }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/clazz/Clazz.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/clazz/Clazz.java
@@ -18,6 +18,7 @@ package org.robovm.compiler.clazz;
 
 import org.apache.commons.io.IOUtils;
 import soot.SootClass;
+import soot.SootMethod;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -204,5 +205,19 @@ public abstract class Clazz implements Comparable<Clazz> {
     @Override
     public String toString() {
         return className;
+    }
+
+    /**
+     * Drops Soot object and releases all its resolved bodies
+     */
+    public void shrinkSoot() {
+        if (sootClass != null) {
+            // dropping all bodies
+            for (SootMethod m: sootClass.getMethods()) {
+                if (m.hasActiveBody())
+                    m.releaseActiveBody();
+            }
+            sootClass = null;
+        }
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/clazz/ClazzInfo.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/clazz/ClazzInfo.java
@@ -43,13 +43,13 @@ public class ClazzInfo implements Serializable {
     private String name;
     private String internalName;
     private String superclassName;
-    private final List<String> interfaceNames = new ArrayList<String>();
-    private final List<MethodInfo> methods = new ArrayList<MethodInfo>();
-    private final Set<String> catchNames = new HashSet<String>();
-    private Map<String, Dependency> dependencies = new HashMap<String,Dependency>();
-    private final Set<String> checkcasts = new HashSet<String>();
-    private final Set<String> instanceofs = new HashSet<String>();
-    private final Set<String> invokes = new HashSet<String>();
+    private final List<String> interfaceNames = new ArrayList<>();
+    private final List<MethodInfo> methods = new ArrayList<>();
+    private final Set<String> catchNames = new HashSet<>();
+    private Map<String, Dependency> dependencies = new HashMap<>();
+    private final Set<String> checkcasts = new HashSet<>();
+    private final Set<String> instanceofs = new HashSet<>();
+    private final Set<String> invokes = new HashSet<>();
     private boolean isStruct;
     private boolean isEnum;
     
@@ -190,7 +190,7 @@ public class ClazzInfo implements Serializable {
     }
     
     public List<ClazzInfo> getInterfaces() {
-        List<ClazzInfo> result = new ArrayList<ClazzInfo>();
+        List<ClazzInfo> result = new ArrayList<>();
         for (String ifname : interfaceNames) {
             result.add(loadClazzInfo(ifname));
         }
@@ -207,7 +207,7 @@ public class ClazzInfo implements Serializable {
     }
 
     public List<ClazzInfo> getCatches() {
-        List<ClazzInfo> result = new ArrayList<ClazzInfo>();
+        List<ClazzInfo> result = new ArrayList<>();
         for (String n : catchNames) {
             result.add(loadClazzInfo(n));
         }
@@ -268,11 +268,11 @@ public class ClazzInfo implements Serializable {
     }
     
     public void clearDependencies() {
-        dependencies = new HashMap<String, Dependency>();
+        dependencies = new HashMap<>();
     }
 
     public Set<Dependency> getDependencies() {
-        return new HashSet<Dependency>(dependencies.values());
+        return new HashSet<>(dependencies.values());
     }
 
     public Set<Dependency> getAllDependencies() {
@@ -359,5 +359,11 @@ public class ClazzInfo implements Serializable {
             return false;
         }
         return true;
+    }
+
+    public void dropDependencyData() {
+        for (MethodInfo mi : getMethods())
+                mi.dropDependencyData();
+        dependencies = null;
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/clazz/MethodInfo.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/clazz/MethodInfo.java
@@ -204,6 +204,10 @@ public class MethodInfo implements Serializable {
         return true;
     }
 
+    public void dropDependencyData() {
+        dependencies = null;
+    }
+
     @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this);

--- a/compiler/compiler/src/main/java/org/robovm/compiler/clazz/Path.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/clazz/Path.java
@@ -58,4 +58,9 @@ public interface Path {
     boolean contains(String file);
     
     InputStream open(String file) throws IOException;
+
+    /**
+     * Dispose any cached data to reduce memory footprint
+     */
+    void disposeBuildData();
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -32,11 +32,7 @@ import org.robovm.compiler.config.StripArchivesConfig.StripArchivesBuilder;
 import org.robovm.compiler.config.tools.Tools;
 import org.robovm.compiler.llvm.DataLayout;
 import org.robovm.compiler.log.Logger;
-import org.robovm.compiler.plugin.CompilerPlugin;
-import org.robovm.compiler.plugin.LaunchPlugin;
-import org.robovm.compiler.plugin.Plugin;
-import org.robovm.compiler.plugin.PluginArgument;
-import org.robovm.compiler.plugin.TargetPlugin;
+import org.robovm.compiler.plugin.*;
 import org.robovm.compiler.plugin.annotation.AnnotationImplPlugin;
 import org.robovm.compiler.plugin.debug.DebugInformationPlugin;
 import org.robovm.compiler.plugin.debug.DebuggerLaunchPlugin;
@@ -259,7 +255,8 @@ public class Config {
                 new ByteBufferJava9ApiPlugin(),
                 new LambdaPlugin(),
                 new DebugInformationPlugin(),
-                new DebuggerLaunchPlugin()
+                new DebuggerLaunchPlugin(),
+                new BuildGarbageCollectorPlugin()
                 ));
         this.loadPluginsFromClassPath();
     }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -404,6 +404,8 @@ public class Config {
     }
 
     public DependencyGraph getDependencyGraph() {
+        if (dependencyGraph == null)
+            throw new IllegalStateException(".dependencyGraph has been disposed!");
         return dependencyGraph;
     }
 
@@ -504,14 +506,29 @@ public class Config {
     }
 
     public Clazzes getClazzes() {
+        if (clazzes == null)
+            throw new IllegalStateException(".clazzes has been disposed!");
         return clazzes;
     }
 
+    public void disposeBuildData() {
+        // not null clazzes as some data like allPath is required post-build (e.g. to stripArchives)
+        clazzes.disposeData();
+        dependencyGraph = null;
+        vtableCache = null;
+        itableCache = null;
+        marshalerLookup = null;
+    }
+
     public VTable.Cache getVTableCache() {
+        if (vtableCache == null)
+            throw new IllegalStateException(".vtableCache has been disposed!");
         return vtableCache;
     }
 
     public ITable.Cache getITableCache() {
+        if (itableCache == null)
+            throw new IllegalStateException(".itableCache has been disposed!");
         return itableCache;
     }
 

--- a/compiler/compiler/src/main/java/org/robovm/compiler/plugin/AbstractCompilerPlugin.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/plugin/AbstractCompilerPlugin.java
@@ -64,8 +64,14 @@ public abstract class AbstractCompilerPlugin extends CompilerPlugin {
             ModuleBuilder moduleBuilder, Function function) throws IOException {}
 
     @Override
+    public void afterClassDependenciesResolved(Config config, Clazz clazz) {}
+
+    @Override
     public void afterObjectFile(Config config, Clazz clazz, File objectFile, ObjectFile objectFileData) throws IOException {}
 
     @Override
     public void beforeLinker(Config config, Linker linker, Set<Clazz> classes) throws IOException {}
+
+    @Override
+    public void afterLinker(Config config, File executable) throws IOException {}
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/plugin/BuildGarbageCollectorPlugin.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/plugin/BuildGarbageCollectorPlugin.java
@@ -1,0 +1,70 @@
+package org.robovm.compiler.plugin;
+
+import org.robovm.compiler.Linker;
+import org.robovm.compiler.clazz.Clazz;
+import org.robovm.compiler.config.Config;
+import org.robovm.llvm.ObjectFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Plugins that release resources/caches once these are not needed
+ */
+public class BuildGarbageCollectorPlugin extends AbstractCompilerPlugin {
+    private static final String ARG_KEY_ENABLE_PLUGIN = "enable";
+    private Boolean enabled;
+
+    @Override
+    public PluginArguments getArguments() {
+        List<PluginArgument> args = new ArrayList<>();
+        args.add(new PluginArgument(ARG_KEY_ENABLE_PLUGIN, "false", "Flag: disables releasing compilation caches as soon as not needed"));
+        return new PluginArguments("buildGC", args);
+    }
+
+    private boolean isEnabled(Config config) {
+        if (enabled == null) {
+            enabled = argumentValue(parseArguments(config), ARG_KEY_ENABLE_PLUGIN, true);
+        }
+        return enabled;
+    }
+
+    @Override
+    public void afterClassDependenciesResolved(Config config, Clazz clazz) {
+        if (isEnabled(config)) {
+            // at this moment this class is processed and all dependency information not required any more
+            // can be dropped to reduce memory usage
+            clazz.getClazzInfo().dropDependencyData();
+        }
+    }
+
+    @Override
+    public void afterObjectFile(Config config, Clazz clazz, File objectFile, ObjectFile objectFileData) throws IOException {
+        if (isEnabled(config)) {
+            // remove all soot structures that are not
+            // required anymore but consume memory
+            clazz.shrinkSoot();
+        }
+    }
+
+    @Override
+    public void beforeLinker(Config config, Linker linker, Set<Clazz> classes) {
+        if (isEnabled(config)) {
+            // reset anything that can be retained by Soot library. As it keeps structures that are not required
+            // any more
+            // this to be called here as some plugins (like Framework Target) use classes cache during linkage
+            config.getClazzes().disposeSoot();
+        }
+    }
+
+    @Override
+    public void afterLinker(Config config, File executable) throws IOException {
+        if (isEnabled(config)) {
+            // dispose compilation data that is not required anymore (clazzes, dependency trie etc)
+            config.disposeBuildData();
+        }
+    }
+}

--- a/compiler/compiler/src/main/java/org/robovm/compiler/plugin/CompilerPlugin.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/plugin/CompilerPlugin.java
@@ -112,6 +112,15 @@ public abstract class CompilerPlugin extends Plugin {
             ModuleBuilder moduleBuilder, Function function) throws IOException;
 
     /**
+     * Called after dependencies resolved and added to the list. It is the moment when all work with
+     * clazz is finished (machine code generation pending) and all associated resources might be released
+     *
+     * @param config the current {@link Config}
+     * @param clazz the {@link Clazz} being compiled
+     */
+    public abstract void afterClassDependenciesResolved(Config config, Clazz clazz);
+
+    /**
      * Called after the object file of a class has been compiled to an object
      * file.
      * 
@@ -130,4 +139,12 @@ public abstract class CompilerPlugin extends Plugin {
      * @param classes the classes that will be linked.
      */
     public abstract void beforeLinker(Config config, Linker linker, Set<Clazz> classes) throws IOException;
+
+    /**
+     * Called just before {@link Linker} is invoked.
+     *
+     * @param config the current {@link Config}
+     * @param executable the binary
+     */
+    public abstract void afterLinker(Config config, File executable) throws IOException;
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
@@ -90,7 +90,7 @@ public abstract class AbstractTarget implements Target {
         return Collections.emptyList();
     }
 
-    public void build(List<File> objectFiles) throws IOException {
+    public File build(List<File> objectFiles) throws IOException {
         File outFile = new File(config.getTmpDir(), config.getExecutableName());
 
         config.getLogger().info("Building %s binary %s", config.getTarget().getType(), outFile);
@@ -261,6 +261,7 @@ public abstract class AbstractTarget implements Target {
         }
 
         doBuild(outFile, ccArgs, objectFiles, libs);
+        return outFile;
     }
 
     protected void doBuild(File outFile, List<String> ccArgs, List<File> objectFiles,

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/Target.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/Target.java
@@ -87,7 +87,7 @@ public interface Target {
     /**
      * Builds a binary out of the specified object files.
      */
-    void build(List<File> objectFiles) throws IOException;
+    File build(List<File> objectFiles) throws IOException;
 
     /**
      * Builds a fat binary out of the specified slices.

--- a/compiler/compiler/src/test/java/org/robovm/compiler/AppCompilerTest.java
+++ b/compiler/compiler/src/test/java/org/robovm/compiler/AppCompilerTest.java
@@ -216,6 +216,9 @@ public class AppCompilerTest {
             }
             throw new IOException();
         }
-        
+
+        @Override
+        public void disposeBuildData() {
+        }
     }
 }


### PR DESCRIPTION
fix for #150 

## Fix for robovm being quite memory hungry. Example project with 30K classes:
- during compilation required up to 6.5Gb of heap;
- once compilation is finished and app started on simulator -- was consuming 3.4Gb of heap.

## (2nd June update) Reworked into compiler plugin
Issue discovered in Framework target: class information was required to build list of NSObject subclasses for registration but at this moment soot was disposed

Reworking into plugin fixed this issue as we follow plugin notification cycle and GC plugin is called last.
Also having it as plugin allows to disable this functionality through robovm.xml by using `buildGC:enable=false` plugin argument

## Results achieved: 
- 4GB heap settings is enough to compile sample project;
- most consuming moment was about 2.7 GB after garbage collector;
- when compilation is complete and app is started memory usage is ~300MB (UI responsible, debugger happy);
- compilation time (31601 classes): reduced from `506.72 (8GB heap)` to `394.75 (4GB heap)` seconds.  

Problems divided into two categories.
## post compilation pressure:
- Soot was keeping all parsed classes in singleton. Solution -- reset soot after compilation
- Lot of structures were kept in Clazzes/Config that are not required after compilation. Solution -- dispose these once not required.

## in compilation pressure -- most memory consuming.
- Soot -- once class is processed, no need to keep its parsed Body.
- ClazzInfo -- no need to keep dependency map for it once it processed through dependency trie;

To exclude usage of classes in disposed state corresponding checks were added that might cause IllegalStateException if misused.