### PR TITLE
* Memory usage optimization (2/2): reduced number of produced string

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/ClassCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/ClassCompiler.java
@@ -229,7 +229,7 @@ public class ClassCompiler {
     private final TrampolineCompiler trampolineResolver;
     private final ObjCMemberPlugin.MethodCompiler objcMethodCompiler;
 
-    private final ByteArrayOutputStream output = new ByteArrayOutputStream(256 * 1024);
+    private final ByteArrayOutputStream output = new ByteArrayOutputStream(4 * 1024 * 1024);
     
     public ClassCompiler(Config config) {
         this.config = config;

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Alias.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Alias.java
@@ -17,11 +17,14 @@
 package org.robovm.compiler.llvm;
 
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
  */
-public class Alias {
+public class Alias implements Writable{
     private final String name;
     private final Linkage linkage;
     private final Constant value;
@@ -48,22 +51,29 @@ public class Alias {
         return value.getType();
     }
     
-    public String getDefinition() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("@\"");
-        sb.append(name);
-        sb.append("\" = ");
+     public void writeDefinition(Writer writer) throws IOException {
+        writer.write("@\"");
+        writer.write(name);
+        writer.write("\" = ");
         if (linkage != null) {
-            sb.append(linkage);
-            sb.append(' ');
+            writer.write(linkage.toString());
+            writer.write(' ');
         }
-        sb.append("alias ");
-        sb.append(value.getType());
-        sb.append(' ');
-        sb.append(value);
-        return sb.toString();
+        writer.write("alias ");
+        value.getType().write(writer);
+        writer.write(' ');
+        value.write(writer);
     }
-    
+
+    public String getDefinition() {
+        return toString(this::writeDefinition);
+    }
+
+    @Override
+    public void write(Writer writer) throws IOException {
+        throw new IllegalStateException("writeDefinition to be used");
+    }
+
     @Override
     public String toString() {
         return name;

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/AliasRef.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/AliasRef.java
@@ -17,6 +17,9 @@
 package org.robovm.compiler.llvm;
 
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -83,5 +86,10 @@ public class AliasRef extends Constant {
     @Override
     public String toString() {
         return "@\"" + name + "\"";
+    }
+
+    @Override
+    public void write(Writer writer) throws IOException {
+        writer.write(toString());
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Alloca.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Alloca.java
@@ -16,6 +16,8 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
 import java.util.Collections;
 import java.util.Set;
 
@@ -46,7 +48,13 @@ public class Alloca extends Instruction {
     }
 
     @Override
+    public void write(Writer writer) throws IOException {
+        writer.append(result.toString()).append(" = alloca ");
+        type.write(writer);
+    }
+
+    @Override
     public String toString() {
-        return result + " = alloca " + type;
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Argument.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Argument.java
@@ -16,13 +16,15 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
 import java.util.Arrays;
 
 /**
  *
  * @version $Id$
  */
-public class Argument {
+public class Argument implements Writable {
     private final Value value;
     private final ParameterAttribute[] attributes;
 
@@ -78,13 +80,16 @@ public class Argument {
     }
 
     @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
+    public void write(Writer writer) throws IOException {
         for (ParameterAttribute attribute : attributes) {
-            sb.append(attribute);
-            sb.append(' ');
+            writer.write(attribute.toString());
+            writer.write(' ');
         }
-        sb.append(value);
-        return sb.toString();
+        value.write(writer);
+    }
+
+    @Override
+    public String toString() {
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/ArrayConstant.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/ArrayConstant.java
@@ -16,6 +16,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -35,18 +38,22 @@ public class ArrayConstant extends Constant {
     }
 
     @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append('[');
+    public void write(Writer writer) throws IOException {
+        writer.write('[');
         for (int i = 0; i < values.length; i++) {
             if (i > 0) {
-                sb.append(", ");
+                writer.write(", ");
             }
-            sb.append(values[i].getType());
-            sb.append(' ');
-            sb.append(values[i]);
+            values[i].getType().write(writer);
+            writer.write(' ');
+            values[i].write(writer);
         }
-        sb.append(']');
-        return sb.toString();
+        writer.write(']');
+
+    }
+
+    @Override
+    public String toString() {
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/ArrayType.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/ArrayType.java
@@ -16,6 +16,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -53,10 +56,17 @@ public class ArrayType extends AggregateType {
     public int getTypeCount() {
         return (int) size;
     }
-    
+
+    @Override
+    public void writeDefinition(Writer writer) throws IOException {
+        writer.append('[').append(Long.toString(size)).append(" x ");
+        elementType.write(writer);
+        writer.write("]");
+    }
+
     @Override
     public String getDefinition() {
-        return "[" + size + " x " + elementType + "]";
+        return toString(this::writeDefinition);
     }
 
     @Override

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/BasicBlock.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/BasicBlock.java
@@ -16,6 +16,8 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -25,7 +27,7 @@ import java.util.Set;
  *
  * @version $Id$
  */
-public class BasicBlock {
+public class BasicBlock implements Writable {
     private final Function function;
     private final Label label;
     private final List<Instruction> instructions = new ArrayList<Instruction>();
@@ -99,24 +101,27 @@ public class BasicBlock {
         }
         return instructions.get(instructions.size() - 1);
     }
-    
+
     @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(getName());
-        sb.append(":\n");
+    public void write(Writer writer) throws IOException {
+        writer.write(getName());
+        writer.write(":\n");
         for (Instruction instruction : instructions) {
-            sb.append("    ");
-            sb.append(instruction.toString());
+            writer.write("    ");
+            instruction.write(writer);
             List<Metadata> metadata = instruction.getMetadata();
             if (!metadata.isEmpty()) {
                 for (Metadata md : metadata) {
-                    sb.append(", ");
-                    sb.append(md.toString());
+                    writer.write(", ");
+                    md.write(writer);
                 }
             }
-            sb.append('\n');
+            writer.write('\n');
         }
-        return sb.toString();
+    }
+
+    @Override
+    public String toString() {
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/BooleanConstant.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/BooleanConstant.java
@@ -16,6 +16,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -39,5 +42,10 @@ public class BooleanConstant extends Constant {
     @Override
     public String toString() {
         return String.valueOf(value);
+    }
+
+    @Override
+    public void write(Writer writer) throws IOException {
+        writer.write(toString());
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Br.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Br.java
@@ -16,6 +16,8 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -61,12 +63,20 @@ public class Br extends Instruction {
         }
         return result;
     }
-    
+
+    @Override
+    public void write(Writer writer) throws IOException {
+        if (cond != null) {
+            writer.write("br i1 ");
+            cond.write(writer);
+            writer.append(", label %").append(destTrue.getName()).append(", label %").append(destFalse.getName());
+        } else {
+            writer.append("br label %").append(destTrue.getName());
+        }
+    }
+
     @Override
     public String toString() {
-        if (cond != null) {
-            return "br i1 " + cond + ", label %" + destTrue.getName() + ", label %" + destFalse.getName();
-        }
-        return "br label %" + destTrue.getName();
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/ByteArrayConstant.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/ByteArrayConstant.java
@@ -15,6 +15,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  * Straight forward implementation of byte array constant to reduce amount of memory
  * required to do same foe ArrayConstant
@@ -35,17 +38,20 @@ public class ByteArrayConstant extends Constant {
     }
 
     @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append('[');
+    public void write(Writer writer) throws IOException {
+        writer.write('[');
         for (int i = 0; i < values.length; i++) {
             if (i > 0) {
-                sb.append(", ");
+                writer.write(", ");
             }
-            sb.append("i8 ");
-            sb.append(values[i]);
+            writer.write("i8 ");
+            writer.write(Byte.toString(values[i]));
         }
-        sb.append(']');
-        return sb.toString();
+        writer.write(']');
+    }
+
+    @Override
+    public String toString() {
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/ConstantGetelementptr.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/ConstantGetelementptr.java
@@ -16,6 +16,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -48,17 +51,20 @@ public class ConstantGetelementptr extends Constant {
     }
 
     @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("getelementptr (");
-        sb.append(cst.getType());
-        sb.append(' ');
-        sb.append(cst);
-        for (int i = 0; i < idx.length; i++) {
-            sb.append(", i32 ");
-            sb.append(idx[i]);
+    public void write(Writer writer) throws IOException {
+        writer.write("getelementptr (");
+        cst.getType().write(writer);
+        writer.write(' ');
+        cst.write(writer);
+        for (int j : idx) {
+            writer.write(", i32 ");
+            writer.write(Integer.toString(j));
         }
-        sb.append(")");
-        return sb.toString();
+        writer.write(')');
+    }
+
+    @Override
+    public String toString() {
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/ConversionConstant.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/ConversionConstant.java
@@ -16,6 +16,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -37,7 +40,19 @@ public abstract class ConversionConstant extends Constant {
     }
 
     @Override
+    public void write(Writer writer) throws IOException {
+        writer.write(name);
+        writer.write(" (");
+        cst.getType().write(writer);
+        writer.write(' ');
+        cst.write(writer);
+        writer.write(" to ");
+        type.write(writer);
+        writer.write(')');
+    }
+
+    @Override
     public String toString() {
-        return name + " (" + cst.getType() + " " + cst + " to " + type + ")";
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/ConversionInstruction.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/ConversionInstruction.java
@@ -16,6 +16,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -29,9 +32,19 @@ public abstract class ConversionInstruction extends UnaryOpInstruction {
         this.name = name;
         this.type = type;
     }
-    
+
+    @Override
+    public void write(Writer writer) throws IOException {
+        writer.append(result.toString()).append(" = ").append(name).append(' ');
+        op.getType().write(writer);
+        writer.write(' ');
+        op.write(writer);
+        writer.write(" to ");
+        type.write(writer);
+    }
+
     @Override
     public String toString() {
-        return result + " = " + name + " " + op.getType() + " " + op + " to " + type;
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/DebugMetadata.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/DebugMetadata.java
@@ -16,6 +16,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  * {@link Metadata} used to attach debug info to instructions.
  */
@@ -27,8 +30,13 @@ public class DebugMetadata extends Metadata {
     }
 
     @Override
-    public String toString() {
-        return "!dbg " + value;
+    public void write(Writer writer) throws IOException {
+        writer.write( "!dbg ");
+        value.write(writer);
     }
-    
+
+    @Override
+    public String toString() {
+        return toString(this::write);
+    }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Fcmp.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Fcmp.java
@@ -16,6 +16,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -40,9 +43,19 @@ public class Fcmp extends BinaryOpInstruction {
         }
         this.cond = cond;
     }
-    
+
+    @Override
+    public void write(Writer writer) throws IOException {
+        writer.append(result.toString()).append(" = fcmp ").append(cond.toString()).append(' ');
+        op1.getType().write(writer);
+        writer.write(' ');
+        op1.write(writer);
+        writer.write(", ");
+        op2.write(writer);
+    }
+
     @Override
     public String toString() {
-        return result + " = fcmp " + cond + " " + op1.getType() + " " + op1 + ", " + op2;
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Fence.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Fence.java
@@ -16,6 +16,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  * @author niklas
  *
@@ -32,4 +35,8 @@ public class Fence extends Instruction {
         return "fence " + ordering;
     }
 
+    @Override
+    public void write(Writer writer) throws IOException {
+        writer.write(toString());
+    }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/FloatingPointBinaryInstruction.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/FloatingPointBinaryInstruction.java
@@ -17,6 +17,9 @@
 package org.robovm.compiler.llvm;
 
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -34,9 +37,19 @@ public abstract class FloatingPointBinaryInstruction extends BinaryOpInstruction
         }
         this.name = name;
     }
-    
+
+    @Override
+    public void write(Writer writer) throws IOException {
+        writer.append(result.toString()).append(" = ").append(name).append(' ');
+        op1.getType().write(writer);
+        writer.write(' ');
+        op1.write(writer);
+        writer.write(", ");
+        op2.write(writer);
+    }
+
     @Override
     public String toString() {
-        return result + " = " + name + " " + op1.getType() + " " + op1 + ", " + op2;
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/FloatingPointConstant.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/FloatingPointConstant.java
@@ -16,6 +16,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -25,15 +28,15 @@ public class FloatingPointConstant extends Constant {
     private final Object value;
 
     public FloatingPointConstant(float value) {
-        this(new Float(value), Type.FLOAT);
+        this(value, Type.FLOAT);
     }
     
     public FloatingPointConstant(double value) {
-        this(new Double(value), Type.DOUBLE);
+        this(value, Type.DOUBLE);
     }
     
     public FloatingPointConstant(double value, FloatingPointType type) {
-        this.value = new Double(value);
+        this.value = value;
         this.type = type;
     }
     
@@ -89,5 +92,10 @@ public class FloatingPointConstant extends Constant {
             double d = ((Number) value).doubleValue();
             return "bitcast (i64 " + Double.doubleToLongBits(d) + " to double)";
         }
+    }
+
+    @Override
+    public void write(Writer writer) throws IOException {
+        writer.write(toString());
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Function.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Function.java
@@ -28,7 +28,7 @@ import java.util.Map;
  *
  * @version $Id$
  */
-public class Function {
+public class Function implements Writable {
     private final String name;
     private final Linkage linkage;
     private final FunctionAttribute[] attributes;
@@ -178,6 +178,7 @@ public class Function {
         return sig;
     }
     
+    @Override
     public void write(Writer writer) throws IOException {
         Type returnType = type.getReturnType();
         Type[] parameterTypes = type.getParameterTypes();
@@ -186,7 +187,7 @@ public class Function {
             writer.write(linkage.toString());
             writer.write(' ');
         }
-        writer.write(returnType.toString());
+        returnType.write(writer);
         writer.write(" @\"");
         writer.write(name);
         writer.write("\"(");
@@ -194,7 +195,7 @@ public class Function {
             if (i > 0) {
                 writer.write(", ");
             }
-            writer.write(parameterTypes[i].toString());
+            parameterTypes[i].write(writer);
             if (parameterAttributes[i] != null) {
                 for (ParameterAttribute attrib : parameterAttributes[i]) {
                     writer.write(' ');
@@ -221,19 +222,13 @@ public class Function {
         }
         writer.write(" {\n");
         for (BasicBlock bb : basicBlockList) {
-            writer.write(bb.toString());
+            bb.write(writer);
         }
         writer.write("}\n");
     }
 
     @Override
     public String toString() {
-        StringWriter sw = new StringWriter();
-        try {
-            write(sw);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return sw.toString();
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/FunctionCallInstruction.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/FunctionCallInstruction.java
@@ -16,6 +16,8 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -134,28 +136,34 @@ public abstract class FunctionCallInstruction extends Instruction {
     }
 
     @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
+    public void write(Writer writer) throws IOException {
         if (result != null) {
-            sb.append(result.toString());
-            sb.append(" = ");
+            writer.write(result.toString());
+            writer.write(" = ");
         }
-        sb.append(name);
-        sb.append(' ');
+        writer.write(name);
+        writer.write(' ');
         FunctionType ftype = (FunctionType) function.getType();
-        sb.append(ftype.isVarargs() ? ftype.getDefinition() : ftype.getReturnType().toString());
-        sb.append(" ");
-        sb.append(function.toString());
-        sb.append('(');
+        if (ftype.isVarargs())
+            ftype.writeDefinition(writer);
+        else
+            ftype.getReturnType().write(writer);
+        writer.write(' ');
+        function.write(writer);
+        writer.write('(');
         for (int i = 0; i < args.length; i++) {
             if (i > 0) {
-                sb.append(", ");
+                writer.write(", ");
             }
-            sb.append(args[i].getType());
-            sb.append(' ');
-            sb.append(args[i]);
+            args[i].getType().write(writer);
+            writer.write(' ');
+            args[i].write(writer);
         }
-        sb.append(')');
-        return sb.toString();
+        writer.write(')');
+    }
+
+    @Override
+    public String toString() {
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/FunctionDeclaration.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/FunctionDeclaration.java
@@ -17,11 +17,14 @@
 package org.robovm.compiler.llvm;
 
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
  */
-public class FunctionDeclaration {
+public class FunctionDeclaration implements Writable{
     private final String name;
     private final FunctionType type;
 
@@ -45,27 +48,30 @@ public class FunctionDeclaration {
     public FunctionRef ref() {
         return new FunctionRef(name, type);
     }
-    
+
     @Override
-    public String toString() {
+    public void write(Writer writer) throws IOException {
         Type returnType = type.getReturnType();
         Type[] parameterTypes = type.getParameterTypes();
-        StringBuilder sb = new StringBuilder();
-        sb.append("declare ");
-        sb.append(returnType.toString());
-        sb.append(" @\"");
-        sb.append(name);
-        sb.append("\"(");
+        writer.write("declare ");
+        returnType.write(writer);
+        writer.write(" @\"");
+        writer.write(name);
+        writer.write("\"(");
         for (int i = 0; i < parameterTypes.length; i++) {
             if (i > 0) {
-                sb.append(", ");
+                writer.write(", ");
             }
-            sb.append(parameterTypes[i].toString());
+            parameterTypes[i].write(writer);
         }
         if (type.isVarargs()) {
-            sb.append(", ...");
+            writer.write(", ...");
         }
-        sb.append(")");
-        return sb.toString();
+        writer.write(')');
+    }
+
+    @Override
+    public String toString() {
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/FunctionRef.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/FunctionRef.java
@@ -17,6 +17,9 @@
 package org.robovm.compiler.llvm;
 
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -45,5 +48,10 @@ public class FunctionRef extends Constant {
     @Override
     public String toString() {
         return "@\"" + name + "\"";
+    }
+
+    @Override
+    public void write(Writer writer) throws IOException {
+        writer.write(toString());
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/FunctionType.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/FunctionType.java
@@ -16,6 +16,8 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
 import java.util.Arrays;
 
 
@@ -66,26 +68,29 @@ public class FunctionType extends PointerType {
     public Type[] getParameterTypes() {
         return parameterTypes;
     }
-    
+
     @Override
-    public String getDefinition() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(returnType.toString());
-        sb.append(" (");
+    public void writeDefinition(Writer writer) throws IOException {
+        returnType.write(writer);
+        writer.write(" (");
         for (int i = 0; i < parameterTypes.length; i++) {
             if (i > 0) {
-                sb.append(", ");
+                writer.write(", ");
             }
-            sb.append(parameterTypes[i].toString());
+            parameterTypes[i].write(writer);
         }
         if (varargs) {
             if (parameterTypes.length > 0) {
-                sb.append(", ");
+                writer.write(", ");
             }
-            sb.append("...");            
+            writer.write("...");
         }
-        sb.append(")*");
-        return sb.toString();
+        writer.write(")*");
+    }
+
+    @Override
+    public String getDefinition() {
+        return toString(this::writeDefinition);
     }
 
     @Override

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Getelementptr.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Getelementptr.java
@@ -16,6 +16,8 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
 import java.util.Collections;
 import java.util.Set;
 
@@ -73,21 +75,24 @@ public class Getelementptr extends Instruction {
         }
         return super.getReadsFrom();
     }
-    
+
+    @Override
+    public void write(Writer writer) throws IOException {
+        writer.write(result.toString());
+        writer.write(" = getelementptr ");
+        ptr.getType().write(writer);
+        writer.write(' ');
+        ptr.write(writer);
+        for (Value value : idx) {
+            writer.write(", ");
+            value.getType().write(writer);
+            writer.write(" ");
+            value.write(writer);
+        }
+    }
+
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(result);
-        sb.append(" = getelementptr ");
-        sb.append(ptr.getType());
-        sb.append(' ');
-        sb.append(ptr);
-        for (int i = 0; i < idx.length; i++) {
-            sb.append(", ");
-            sb.append(idx[i].getType());
-            sb.append(" ");
-            sb.append(idx[i]);
-        }
-        return sb.toString();
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Global.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Global.java
@@ -17,11 +17,14 @@
 package org.robovm.compiler.llvm;
 
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
  */
-public class Global {
+public class Global implements Writable {
     private final String name;
     private final Linkage linkage;
     private final Constant value;
@@ -86,34 +89,41 @@ public class Global {
     public PointerType getType() {
         return new PointerType(type);
     }
-    
-    public String getDefinition() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("@\"");
-        sb.append(name);
-        sb.append("\" = ");
+
+    public void writeDefinition(Writer writer) throws IOException {
+        writer.write("@\"");
+        writer.write(name);
+        writer.write("\" = ");
         if (linkage != null) {
-            sb.append(linkage);
-            sb.append(' ');
+            writer.write(linkage.toString());
+            writer.write(' ');
         }
         if (constant) {
-            sb.append("constant ");
+            writer.write("constant ");
         } else {
-            sb.append("global ");
+            writer.write("global ");
         }
-        sb.append(type);
+        type.write(writer);
         if (value != null) {
-            sb.append(' ');
-            sb.append(value);
+            writer.write(' ');
+            value.write(writer);
         }
         if (section != null) {
-            sb.append(", section \"");
-            sb.append(section);
-            sb.append('"');
+            writer.write(", section \"");
+            writer.write(section);
+            writer.write('"');
         }
-        return sb.toString();
     }
-    
+
+    public String getDefinition() {
+        return toString(this::writeDefinition);
+    }
+
+    @Override
+    public void write(Writer writer) throws IOException {
+        throw new IllegalStateException("writeDefinition to be called!");
+    }
+
     @Override
     public String toString() {
         return "@\"" + name + "\"";

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/GlobalRef.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/GlobalRef.java
@@ -17,6 +17,9 @@
 package org.robovm.compiler.llvm;
 
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -83,5 +86,10 @@ public class GlobalRef extends Constant {
     @Override
     public String toString() {
         return "@\"" + name + "\"";
+    }
+
+    @Override
+    public void write(Writer writer) throws IOException {
+        writer.write(toString());
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Icmp.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Icmp.java
@@ -16,6 +16,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -41,7 +44,17 @@ public class Icmp extends BinaryOpInstruction {
     }
     
     @Override
+    public void write(Writer writer) throws IOException {
+        writer.append(result.toString()).append(" = icmp ").append(cond.toString()).append(' ');
+        op1.getType().write(writer);
+        writer.write(' ');
+        op1.write(writer);
+        writer.write(", ");
+        op2.write(writer);
+    }
+
+    @Override
     public String toString() {
-        return result + " = icmp " + cond + " " + op1.getType() + " " + op1 + ", " + op2;
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Instruction.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Instruction.java
@@ -25,7 +25,7 @@ import java.util.Set;
  *
  * @version $Id$
  */
-public abstract class Instruction {
+public abstract class Instruction implements Writable{
     BasicBlock basicBlock;
     private List<Metadata> metadata;
     private List<Object> attachments;

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/IntegerBinaryConstant.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/IntegerBinaryConstant.java
@@ -17,6 +17,9 @@
 package org.robovm.compiler.llvm;
 
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -39,9 +42,23 @@ public abstract class IntegerBinaryConstant extends BinaryOpConstant {
     public Type getType() {
         return op1.getType();
     }
-    
+
+    @Override
+    public void write(Writer writer) throws IOException {
+        writer.write(name);
+        writer.write(" (");
+        op1.getType().write(writer);
+        writer.write(' ');
+        op1.write(writer);
+        writer.write(", ");
+        op2.getType().write(writer);
+        writer.write(' ');
+        op2.write(writer);
+        writer.write(')');
+    }
+
     @Override
     public String toString() {
-        return name + " (" + op1.getType() + " " + op1 + ", " + op2.getType() + " " + op2 + ")";
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/IntegerBinaryInstruction.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/IntegerBinaryInstruction.java
@@ -17,6 +17,9 @@
 package org.robovm.compiler.llvm;
 
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -36,7 +39,17 @@ public abstract class IntegerBinaryInstruction extends BinaryOpInstruction {
     }
     
     @Override
+    public void write(Writer writer) throws IOException {
+        writer.append(result.toString()).append(" = ").append(name).append(' ');
+        op1.getType().write(writer);
+        writer.write(' ');
+        op1.write(writer);
+        writer.write(", ");
+        op2.write(writer);
+    }
+
+    @Override
     public String toString() {
-        return result + " = " + name + " " + op1.getType() + " " + op1 + ", " + op2;
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/IntegerConstant.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/IntegerConstant.java
@@ -16,6 +16,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -30,27 +33,27 @@ public class IntegerConstant extends Constant implements Comparable<IntegerConst
     }
     
     public IntegerConstant(long value, IntegerType type) {
-        this(new Long(value), type);
+        this(Long.valueOf(value), type);
     }
     
     public IntegerConstant(byte value) {
-        this(new Byte(value), Type.I8);
+        this(Byte.valueOf(value), Type.I8);
     }
     
     public IntegerConstant(short value) {
-        this(new Short(value), Type.I16);
+        this(Short.valueOf(value), Type.I16);
     }
     
     public IntegerConstant(char value) {
-        this(new Integer(value), Type.I16);
+        this(Integer.valueOf(value), Type.I16);
     }
     
     public IntegerConstant(int value) {
-        this(new Integer(value), Type.I32);
+        this(Integer.valueOf(value), Type.I32);
     }
     
     public IntegerConstant(long value) {
-        this(new Long(value), Type.I64);
+        this(Long.valueOf(value), Type.I64);
     }
     
     @Override
@@ -104,5 +107,10 @@ public class IntegerConstant extends Constant implements Comparable<IntegerConst
     @Override
     public String toString() {
         return String.valueOf(value);
+    }
+
+    @Override
+    public void write(Writer writer) throws IOException {
+        writer.write(toString());
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Invoke.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Invoke.java
@@ -17,6 +17,9 @@
 package org.robovm.compiler.llvm;
 
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -89,8 +92,13 @@ public class Invoke extends FunctionCallInstruction {
     }
     
     @Override
+    public void write(Writer writer) throws IOException {
+        super.write(writer);
+        writer.append(" to label %").append(to.toString()).append(" unwind label %").append(unwind.toString());
+    }
+
+    @Override
     public String toString() {
-        String s = super.toString();
-        return s + " to label %" + to + " unwind label %" + unwind;
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Landingpad.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Landingpad.java
@@ -16,6 +16,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  * @author niklas
  *
@@ -41,35 +44,47 @@ public class Landingpad extends Instruction {
     }
 
     @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(result);
-        sb.append(" = landingpad ");
-        sb.append(result.getType());
-        sb.append(" personality ");
-        sb.append(personalityFn.getType());
-        sb.append(' ');
-        sb.append(personalityFn);
+    public void write(Writer writer) throws IOException {
+        writer.write(result.toString());
+        writer.write(" = landingpad ");
+        result.getType().write(writer);
+        writer.write(" personality ");
+        personalityFn.getType().write(writer);
+        writer.write(' ');
+        personalityFn.write(writer);
         if (cleanup) {
-            sb.append(" cleanup");
+            writer.write(" cleanup");
         }
         for (Clause clause : clauses) {
-            sb.append(' ');
-            sb.append(clause);
+            writer.write(' ');
+            clause.write(writer);
         }
-        return sb.toString();
     }
-    
-    public interface Clause {}
+
+    @Override
+    public String toString() {
+        return toString(this::write);
+    }
+
+    public interface Clause extends Writable {}
     
     public static class Catch implements Clause {
         private final Value value;
         public Catch(Value value) {
             this.value = value;
         }
+
+        @Override
+        public void write(Writer writer) throws IOException {
+            writer.write("catch ");
+            value.getType().write(writer);
+            writer.write(' ');
+            value.write(writer);
+        }
+
         @Override
         public String toString() {
-            return "catch " + value.getType() + " " + value;
+            return toString(this::write);
         }
     }
     
@@ -78,9 +93,18 @@ public class Landingpad extends Instruction {
         public Filter(ArrayConstant value) {
             this.value = value;
         }
+
+        @Override
+        public void write(Writer writer) throws IOException {
+            writer.write("filter ");
+            value.getType().write(writer);
+            writer.write(' ');
+            value.write(writer);
+        }
+
         @Override
         public String toString() {
-            return "filter " + value.getType() + " " + value;
+            return toString(this::write);
         }
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Load.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Load.java
@@ -17,6 +17,8 @@
 package org.robovm.compiler.llvm;
 
 
+import java.io.IOException;
+import java.io.Writer;
 
 /**
  *
@@ -43,27 +45,30 @@ public class Load extends UnaryOpInstruction {
     }
     
     @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(result);
-        sb.append(" = load ");
+    public void write(Writer writer) throws IOException {
+        writer.write(result.toString());
+        writer.write(" = load ");
         if (_volatile) {
-            sb.append("volatile ");
+            writer.write("volatile ");
         }
         if (ordering != null) {
-            sb.append("atomic ");
+            writer.write("atomic ");
         }
-        sb.append(op.getType());
-        sb.append(" ");
-        sb.append(op);
+        op.getType().write(writer);
+        writer.write(" ");
+        op.write(writer);
         if (ordering != null) {
-            sb.append(" ");
-            sb.append(ordering);
+            writer.write(" ");
+            writer.write(ordering.toString());
         }
         if (alignment > 0) {
-            sb.append(", align ");
-            sb.append(alignment);            
+            writer.write(", align ");
+            writer.write(Integer.toString(alignment));
         }
-        return sb.toString();
+    }
+
+    @Override
+    public String toString() {
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/MetadataNode.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/MetadataNode.java
@@ -16,6 +16,8 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
 import java.util.List;
 
 /**
@@ -34,24 +36,27 @@ public class MetadataNode extends Metadata {
     }
 
     @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("!{");
+    public void write(Writer writer) throws IOException {
+        writer.write("!{");
         for (int i = 0; i < values.length; i++) {
             if (i > 0) {
-                sb.append(", ");
+                writer.write(", ");
             }
             if (values[i] == null) {
-                sb.append("null");
+                writer.write("null");
             } else {
                 if (values[i].getType() != Type.METADATA) {
-                    sb.append(values[i].getType());
-                    sb.append(' ');
+                    values[i].getType().write(writer);
+                    writer.write(' ');
                 }
-                sb.append(values[i]);
+                values[i].write(writer);
             }
         }
-        sb.append('}');
-        return sb.toString();
+        writer.write('}');
+    }
+
+    @Override
+    public String toString() {
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/MetadataString.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/MetadataString.java
@@ -16,7 +16,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.io.Writer;
 
 /**
  *
@@ -38,11 +40,14 @@ public class MetadataString extends Metadata {
     }
 
     @Override
+    public void write(Writer writer) throws IOException {
+        writer.write("!\"");
+        StringConstant.escape(writer, bytes);
+        writer.write('"');
+    }
+
+    @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("!\"");
-        StringConstant.escape(sb, bytes);
-        sb.append('"');
-        return sb.toString();
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/MetadataType.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/MetadataType.java
@@ -16,6 +16,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -28,5 +31,10 @@ public class MetadataType extends Type {
     @Override
     public String toString() {
         return "metadata";
+    }
+
+    @Override
+    public void write(Writer writer) throws IOException {
+        writer.write(toString());
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/MetadataValue.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/MetadataValue.java
@@ -17,6 +17,9 @@
 package org.robovm.compiler.llvm;
 
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -29,13 +32,16 @@ public class MetadataValue extends Metadata {
     }
 
     @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
+    public void write(Writer writer) throws IOException {
         if (value.getType() != Type.METADATA) {
-            sb.append(value.getType());
-            sb.append(' ');
+            value.getType().write(writer);
+            writer.write(' ');
         }
-        sb.append(value);
-        return sb.toString();
+        value.write(writer);
+    }
+
+    @Override
+    public String toString() {
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Module.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Module.java
@@ -29,7 +29,7 @@ import org.apache.commons.io.IOUtils;
  *
  * @version $Id$
  */
-public class Module {
+public class Module implements Writable{
     private final Collection<URL> includes;
     private final Collection<Global> globals;
     private final Collection<Alias> aliases;    
@@ -57,6 +57,7 @@ public class Module {
         this.unnamedMetadata = unnamedMetadata;
     }
 
+    @Override
     public void write(Writer writer) throws IOException {
         for (URL g : includes) {
             InputStream in = null;
@@ -80,49 +81,43 @@ public class Module {
         for (UserType type : types) {
             writer.write(type.getAlias());
             writer.write(" = type ");
-            writer.write(type.getDefinition());
+            type.writeDefinition(writer);
             writer.write("\n");
         }
         writer.write("\n");
         for (FunctionDeclaration fd : functionDeclarations) {
-            writer.write(fd.toString());
+            fd.write(writer);
             writer.write("\n");
         }
         writer.write("\n");
         for (Global g : globals) {
-            writer.write(g.getDefinition());
+            g.writeDefinition(writer);
             writer.write("\n");
         }
         writer.write("\n");
         for (Alias a : aliases) {
-            writer.write(a.getDefinition());
+            a.writeDefinition(writer);
             writer.write("\n");
         }
         writer.write("\n");
         for (Function f : functions) {
-            writer.write(f.toString());
+            f.write(writer);
             writer.write("\n");
         }
         writer.write("\n");
         for (NamedMetadata md : namedMetadata) {
-            writer.write(md.toString());
+            md.write(writer);
             writer.write("\n");
         }
         writer.write("\n");
         for (UnnamedMetadata md : unnamedMetadata) {
-            writer.write(md.getDefinition());
+            md.writeDefinition(writer);
             writer.write("\n");
         }
     }
 
     @Override
     public String toString() {
-        StringWriter sw = new StringWriter();
-        try {
-            write(sw);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return sw.toString();
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/NamedMetadata.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/NamedMetadata.java
@@ -16,11 +16,14 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
  */
-public class NamedMetadata {
+public class NamedMetadata implements Writable{
     private final String name;
     private final UnnamedMetadata[] values;
 
@@ -34,19 +37,22 @@ public class NamedMetadata {
     }
     
     @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append('!');
-        sb.append(name);
-        sb.append(" = ");
-        sb.append("!{");
+    public void write(Writer writer) throws IOException {
+        writer.write('!');
+        writer.write(name);
+        writer.write(" = ");
+        writer.write("!{");
         for (int i = 0; i < values.length; i++) {
             if (i > 0) {
-                sb.append(", ");
+                writer.write(", ");
             }
-            sb.append(values[i]);
+            writer.write(values[i].toString());
         }
-        sb.append('}');
-        return sb.toString();
+        writer.write('}');
+    }
+
+    @Override
+    public String toString() {
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/NullConstant.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/NullConstant.java
@@ -16,6 +16,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -36,5 +39,10 @@ public class NullConstant extends Constant {
     @Override
     public String toString() {
         return "null";
+    }
+
+    @Override
+    public void write(Writer writer) throws IOException {
+        writer.write(toString());
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/OpaqueType.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/OpaqueType.java
@@ -16,6 +16,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -32,5 +35,10 @@ public class OpaqueType extends UserType {
     @Override
     public String getDefinition() {
         return "opaque";
+    }
+
+    @Override
+    public void writeDefinition(Writer writer) throws IOException {
+        writer.write(getDefinition());
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/PackedStructureType.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/PackedStructureType.java
@@ -17,6 +17,8 @@
 package org.robovm.compiler.llvm;
 
 
+import java.io.IOException;
+import java.io.Writer;
 
 /**
  *
@@ -42,8 +44,15 @@ public class PackedStructureType extends StructureType {
     }
 
     @Override
+    public void writeDefinition(Writer writer) throws IOException {
+        writer.write('<');
+        super.writeDefinition(writer);
+        writer.write('>');
+    }
+
+    @Override
     public String getDefinition() {
-        return "<" + super.getDefinition() + ">";
+        return toString(this::writeDefinition);
     }
 
     public int getAlign() {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Phi.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Phi.java
@@ -16,6 +16,8 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -54,23 +56,26 @@ public class Phi extends Instruction {
     }
     
     @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(result.toString());
-        sb.append(" = phi ");
-        sb.append(result.getType().toString());
+    public void write(Writer writer) throws IOException {
+        writer.write(result.toString());
+        writer.write(" = phi ");
+        result.getType().write(writer);
         for (int i = 0; i < vars.length; i++) {
             if (i > 0) {
-                sb.append(", ");                
+                writer.write(", ");
             }
-            sb.append("[ ");
-            sb.append(vars[i].toString());
-            sb.append(", ");
+            writer.write("[ ");
+            writer.write(vars[i].toString());
+            writer.write(", ");
             BasicBlock bb = basicBlock.getFunction().getDefinedIn(vars[i]);
-            sb.append('%');
-            sb.append(bb.getName());
-            sb.append(" ]");
+            writer.write('%');
+            writer.write(bb.getName());
+            writer.write(" ]");
         }
-        return sb.toString();
+    }
+
+    @Override
+    public String toString() {
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/PlainTextInstruction.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/PlainTextInstruction.java
@@ -1,5 +1,8 @@
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 public class PlainTextInstruction extends Instruction {
     private final String plainText;
     
@@ -14,5 +17,10 @@ public class PlainTextInstruction extends Instruction {
     @Override
     public String toString() {
         return plainText;
+    }
+
+    @Override
+    public void write(Writer writer) throws IOException {
+        writer.write(toString());
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/PointerType.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/PointerType.java
@@ -16,6 +16,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -36,10 +39,16 @@ public class PointerType extends UserType {
     public Type getBase() {
         return base;
     }
-    
+
+    @Override
+    public void writeDefinition(Writer writer) throws IOException {
+        base.write(writer);
+        writer.write('*');
+    }
+
     @Override
     public String getDefinition() {
-        return base.toString() + "*";
+        return toString(this::writeDefinition);
     }
 
     @Override

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/PrimitiveType.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/PrimitiveType.java
@@ -16,6 +16,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -64,5 +67,10 @@ public class PrimitiveType extends Type {
     @Override
     public String toString() {
         return name;
+    }
+
+    @Override
+    public void write(Writer writer) throws IOException {
+        writer.write(toString());
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Ret.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Ret.java
@@ -16,6 +16,8 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
 import java.util.Collections;
 import java.util.Set;
 
@@ -43,10 +45,19 @@ public class Ret extends Instruction {
     }
     
     @Override
-    public String toString() {
+    public void write(Writer writer) throws IOException {
         if (value != null) {
-            return "ret " + value.getType() + " " + value;
+            writer.write("ret ");
+            value.getType().write(writer);
+            writer.write(' ');
+            value.write(writer);
+        } else {
+            writer.write("ret void");
         }
-        return "ret void";
+    }
+
+    @Override
+    public String toString() {
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Store.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Store.java
@@ -16,6 +16,8 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -69,30 +71,33 @@ public class Store extends Instruction {
     }
     
     @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("store ");
+    public void write(Writer writer) throws IOException {
+        writer.write("store ");
         if (_volatile) {
-            sb.append("volatile ");
+            writer.write("volatile ");
         }
         if (ordering != null) {
-            sb.append("atomic ");
+            writer.write("atomic ");
         }
-        sb.append(value.getType());
-        sb.append(" ");
-        sb.append(value);
-        sb.append(", ");
-        sb.append(pointer.getType());
-        sb.append(" ");
-        sb.append(pointer);
+        value.getType().write(writer);
+        writer.write(" ");
+        value.write(writer);
+        writer.write(", ");
+        pointer.getType().write(writer);
+        writer.write(" ");
+        pointer.write(writer);
         if (ordering != null) {
-            sb.append(" ");
-            sb.append(ordering);
+            writer.write(" ");
+            writer.write(ordering.toString());
         }
         if (alignment > 0) {
-            sb.append(", align ");
-            sb.append(alignment);            
+            writer.write(", align ");
+            writer.write(Integer.toString(alignment));
         }
-        return sb.toString();
+    }
+
+    @Override
+    public String toString() {
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/StringConstant.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/StringConstant.java
@@ -16,6 +16,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -35,21 +38,24 @@ public class StringConstant extends Constant {
     }
 
     @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("c\"");
-        escape(sb, bytes);
-        sb.append('"');
-        return sb.toString();
+    public void write(Writer writer) throws IOException {
+        writer.write("c\"");
+        escape(writer, bytes);
+        writer.write('"');
     }
 
-    static void escape(StringBuilder sb, byte[] bytes) {
+    @Override
+    public String toString() {
+        return toString(this::write);
+    }
+
+    static void escape(Writer writer, byte[] bytes) throws IOException {
         for (int i = 0; i < bytes.length; i++) {
             int b = bytes[i] & 0xff;
             if (b < ' ' || b > '~' || b == '"' || b == '\\') {
-                sb.append(String.format("\\%02X", b));
+                writer.write(String.format("\\%02X", b));
             } else {
-                sb.append((char) b);
+                writer.write((char) b);
             }
         }
     }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/StructureConstant.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/StructureConstant.java
@@ -16,6 +16,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/StructureConstant.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/StructureConstant.java
@@ -35,18 +35,21 @@ public class StructureConstant extends Constant {
     }
 
     @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append('{');
+    public void write(Writer writer) throws IOException {
+        writer.write('{');
         for (int i = 0; i < values.length; i++) {
             if (i > 0) {
-                sb.append(", ");
+                writer.write(", ");
             }
-            sb.append(values[i].getType());
-            sb.append(' ');
-            sb.append(values[i]);
+            values[i].getType().write(writer);
+            writer.write(' ');
+            values[i].write(writer);
         }
-        sb.append('}');
-        return sb.toString();
+        writer.write('}');
+    }
+
+    @Override
+    public String toString() {
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/StructureType.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/StructureType.java
@@ -16,6 +16,8 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
 import java.util.Arrays;
 
 
@@ -72,16 +74,19 @@ public class StructureType extends AggregateType {
     }
 
     @Override
-    public String getDefinition() {
-        StringBuilder sb = new StringBuilder("{");
+    public void writeDefinition(Writer writer) throws IOException {
+        writer.write('{');
         for (int i = 0; i < types.length; i++) {
-            if (i > 0) {
-                sb.append(", ");
-            }
-            sb.append(types[i].toString());
+            if (i > 0)
+                writer.write(", ");
+            types[i].write(writer);
         }
-        sb.append("}");
-        return sb.toString();
+        writer.write('}');
+    }
+
+    @Override
+    public String getDefinition() {
+        return toString(this::writeDefinition);
     }
 
     @Override

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Switch.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Switch.java
@@ -16,6 +16,8 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -61,24 +63,27 @@ public class Switch extends Instruction {
     }
 
     @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("switch ");
-        sb.append(value.getType());
-        sb.append(' ');
-        sb.append(value);
-        sb.append(", label %");
-        sb.append(def.getName());
-        sb.append(" [ ");
+    public void write(Writer writer) throws IOException {
+        writer.write("switch ");
+        value.getType().write(writer);
+        writer.write(' ');
+        value.write(writer);
+        writer.write(", label %");
+        writer.write(def.getName());
+        writer.write(" [ ");
         for (Entry<IntegerConstant, BasicBlockRef> pair : alt.entrySet()) {
-            sb.append(pair.getKey().getType());
-            sb.append(' ');
-            sb.append(pair.getKey());
-            sb.append(", label %");
-            sb.append(pair.getValue().getName());
-            sb.append(' ');
+            pair.getKey().getType().write(writer);
+            writer.write(' ');
+            pair.getKey().write(writer);
+            writer.write(", label %");
+            writer.write(pair.getValue().getName());
+            writer.write(' ');
         }
-        sb.append("]");
-        return sb.toString();
+        writer.write(']');
+    }
+
+    @Override
+    public String toString() {
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Type.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Type.java
@@ -20,7 +20,7 @@ package org.robovm.compiler.llvm;
  *
  * @version $Id$
  */
-public abstract class Type {
+public abstract class Type implements Writable{
     public static final IntegerType I1 = new IntegerType(1);
     public static final IntegerType I8 = new IntegerType(8);
     public static final IntegerType I16 = new IntegerType(16);

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/UnnamedMetadata.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/UnnamedMetadata.java
@@ -16,11 +16,14 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
  */
-public class UnnamedMetadata {
+public class UnnamedMetadata implements Writable {
     private final int index;
     private Metadata value;
 
@@ -49,17 +52,24 @@ public class UnnamedMetadata {
     public String toString() {
         return "!" + index;
     }
-    
-    public String getDefinition() {
-        StringBuilder sb = new StringBuilder();
-        sb.append('!');
-        sb.append(index);
-        sb.append(" = ");
+
+    public void writeDefinition(Writer writer) throws IOException {
+        writer.write('!');
+        writer.write(Integer.toString(index));
+        writer.write(" = ");
         if (value.getType() != Type.METADATA) {
-            sb.append(value.getType());
-            sb.append(' ');
+            value.getType().write(writer);
+            writer.write(' ');
         }
-        sb.append(value.toString());
-        return sb.toString();
+        value.write(writer);
+    }
+
+    public String getDefinition() {
+        return toString(this::writeDefinition);
+    }
+
+    @Override
+    public void write(Writer writer) throws IOException {
+        throw new IllegalStateException("Use writeDefinition!");
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/UnnamedMetadataRef.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/UnnamedMetadataRef.java
@@ -17,6 +17,9 @@
 package org.robovm.compiler.llvm;
 
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -61,5 +64,10 @@ public class UnnamedMetadataRef extends Metadata {
     @Override
     public String toString() {
         return "!" + index;
+    }
+
+    @Override
+    public void write(Writer writer) throws IOException {
+        writer.write(toString());
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Unreachable.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Unreachable.java
@@ -17,6 +17,9 @@
 package org.robovm.compiler.llvm;
 
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -26,5 +29,10 @@ public class Unreachable extends Instruction {
     @Override
     public String toString() {
         return "unreachable";
+    }
+
+    @Override
+    public void write(Writer writer) throws IOException {
+        writer.write(toString());
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/UserType.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/UserType.java
@@ -16,11 +16,14 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
  */
-public abstract class UserType extends Type {
+public abstract class UserType extends Type implements Writable{
     protected final String alias;
     
     UserType() {
@@ -40,7 +43,9 @@ public abstract class UserType extends Type {
     }
     
     public abstract String getDefinition();
-    
+
+    public abstract void writeDefinition(Writer writer) throws IOException;
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -72,7 +77,12 @@ public abstract class UserType extends Type {
     }
 
     @Override
+    public void write(Writer writer) throws IOException {
+        if (alias != null) writer.write(alias); else writeDefinition(writer);
+    }
+
+    @Override
     public String toString() {
-        return alias != null ? alias : getDefinition();
+        return toString(this::write);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Value.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Value.java
@@ -21,7 +21,7 @@ package org.robovm.compiler.llvm;
  *
  * @version $Id$
  */
-public abstract class Value {
+public abstract class Value implements Writable{
     
     public boolean isInteger() {
         return getType() instanceof IntegerType;

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/VariableRef.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/VariableRef.java
@@ -17,6 +17,9 @@
 package org.robovm.compiler.llvm;
 
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  *
  * @version $Id$
@@ -83,5 +86,10 @@ public class VariableRef extends Value {
     @Override
     public String toString() {
         return "%" + name;
+    }
+
+    @Override
+    public void write(Writer writer) throws IOException {
+        writer.write(toString());
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/VectorStructureType.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/VectorStructureType.java
@@ -17,6 +17,8 @@
 package org.robovm.compiler.llvm;
 
 
+import java.io.IOException;
+import java.io.Writer;
 
 /**
  *
@@ -47,13 +49,26 @@ public class VectorStructureType extends StructureType {
 
 
     @Override
-    public String getDefinition() {
+    public void writeDefinition(Writer writer) throws IOException {
         if (types[0] instanceof StructureType) {
             // return as struct that contains array
             StructureType st = (StructureType) types[0];
-            return "{ [" + types.length + " x " + st.getDefinition() + "] }";
+            writer.write("{ [");
+            writer.write(Integer.toString(types.length));
+            writer.write(" x ");
+            st.writeDefinition(writer);
+            writer.write("] }");
         } else {
-            return "<" + types.length + " x " + types[0].toString() + ">";
+            writer.write("<");
+            writer.write(Integer.toString(types.length));
+            writer.write(" x ");
+            types[0].write(writer);
+            writer.write(">");
         }
+    }
+
+    @Override
+    public String getDefinition() {
+        return toString(this::writeDefinition);
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Writable.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/Writable.java
@@ -1,0 +1,26 @@
+package org.robovm.compiler.llvm;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+
+/**
+ * interface for classes that can write own text presentation using Writer.
+ * Used as toString() replacement to optimize memory usage
+ */
+public interface Writable {
+    interface Provider {
+        void write(Writer writer) throws IOException;
+    }
+
+    void write(Writer writer) throws IOException;
+
+    default String toString(Provider provider) {
+        try (StringWriter sbw = new StringWriter()) {
+            provider.write(sbw);
+            return sbw.toString();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/ZeroInitializer.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/ZeroInitializer.java
@@ -15,6 +15,9 @@
  */
 package org.robovm.compiler.llvm;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  * @author Demyan Kimitsa
  * returns zeroinitializer to be used as value with arrays structs ect
@@ -35,5 +38,10 @@ public class ZeroInitializer extends Constant {
     @Override
     public String toString() {
         return "zeroinitializer";
+    }
+
+    @Override
+    public void write(Writer writer) throws IOException {
+        writer.write(this.toString());
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/debug/dwarf/DIBaseItem.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/debug/dwarf/DIBaseItem.java
@@ -23,6 +23,9 @@ import org.robovm.compiler.llvm.MetadataString;
 import org.robovm.compiler.llvm.NamedMetadata;
 import org.robovm.compiler.llvm.UnnamedMetadata;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  * base class for metadata, used as single point of data to be attached to builder and once attached this data
  * should be used as everywhere as metadata reference
@@ -60,7 +63,7 @@ public class DIBaseItem {
      * @param name to give to metadata
      */
     public DIBaseItem(ModuleBuilder builder, String name) {
-        this(builder, name, null);
+        this(builder, name, (Metadata[])null);
     }
 
     protected DIBaseItem(ModuleBuilder builder, String name, Metadata... values) {
@@ -98,7 +101,12 @@ public class DIBaseItem {
         public String toString() {
             return "!" + name;
         }
-    };
+
+        @Override
+        public void write(Writer writer) throws IOException {
+            writer.write(toString());
+        }
+    }
 
 
     /** just a wrapper that allows this class to be considered as metadata */
@@ -106,6 +114,11 @@ public class DIBaseItem {
         @Override
         public String toString() {
             return DIBaseItem.this.toString();
+        }
+
+        @Override
+        public void write(Writer writer) throws IOException {
+            writer.write(toString());
         }
     }
 

--- a/compiler/compiler/src/main/java/org/robovm/compiler/llvm/debug/dwarf/DIHeader.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/llvm/debug/dwarf/DIHeader.java
@@ -15,9 +15,10 @@
  */
 package org.robovm.compiler.llvm.debug.dwarf;
 
-import org.apache.commons.lang3.StringUtils;
 import org.robovm.compiler.llvm.Metadata;
 
+import java.io.IOException;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,8 +49,19 @@ public class DIHeader extends Metadata{
     }
 
     @Override
+    public void write(Writer writer) throws IOException {
+        writer.write("!\"");
+        for (int i = 0; i < values.size(); i++) {
+            if (i > 0)
+                writer.write("\\00");
+            writer.write(values.get(i));
+        }
+        writer.write("\"");
+    }
+
+    @Override
     public String toString() {
-        return "!\"" + StringUtils.join(values, "\\00") + "\"";
+        return toString(this::write);
     }
 
 


### PR DESCRIPTION
As a fix of #150 
It doesn't fix memory consumption but make life of GC a bit easier as millions of strings are not being constructed.

## Changes
Compiler produces LLVM IR `.ll` file from Java class file. It's a text file and compiler converts instructions into strings and concatenates everything into one big text file. During operation, it produces thousands of string and glues them together. 
All these strings in results are being written into destination byte buffer using `Writer`.
Optimization here is to make all entities to write itself directly to `Writer` instead of producing intermediate strings.