### PR TITLE
Limited support for JEP181 Nestbased access control

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/TrampolineCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/TrampolineCompiler.java
@@ -447,7 +447,7 @@ public class TrampolineCompiler {
             runtimeClass = c.getSootClass();
         }
         
-        if (Access.checkMemberAccessible(member, caller, target, runtimeClass)) {
+        if (Access.checkMemberAccessible(config.getClazzes(), member, caller, target, runtimeClass)) {
             return true;
         }
 

--- a/compiler/compiler/src/main/java/org/robovm/compiler/clazz/Clazzes.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/clazz/Clazzes.java
@@ -147,6 +147,11 @@ public class Clazzes {
         return clazz;
     }
 
+    public SootClass loadSootClass(String internalName) {
+        Clazz clazz = load(internalName);
+        return clazz != null ? clazz.getSootClass() : null;
+    }
+
     public List<InputStream> loadResources(String resource) throws IOException {
         List<InputStream> arr = new ArrayList<>();
         for (Path p : getPaths()) {

--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
             <dependency>
                 <groupId>com.mobidevelop.robovm</groupId>
                 <artifactId>robovm-soot</artifactId>
-                <version>2.5.0-7</version>
+                <version>2.5.0-8</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
             <dependency>
                 <groupId>com.mobidevelop.robovm</groupId>
                 <artifactId>robovm-soot</artifactId>
-                <version>2.5.0-8</version>
+                <version>2.5.0-9</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
# Description
this implements nest based access control as specified in [JEP181](https://openjdk.java.net/jeps/181). This is reproducible with Java11 class files. Sample to reproduce: 
```
public class Test {
    private int a;
    public void foo() {
        DispatchQueue.getMainQueue().async(new Runnable() {
            @Override
            public void run() {
                System.out.println(a);
            }
        });
    }
}
```

Gradle settings:
```
sourceCompatibility = 11
targetCompatibility = 11
```

also fixes https://github.com/MobiVM/robovm/issues/652

# limitations
it covers only compilation time access control. Runtime (reflection one) is not covered.

# soot to be updated 
https://github.com/MobiVM/soot/pull/3/files

