### PR TITLE
* fixed: crashing sideloaded app on m1 (fix for #659)

### DIFF
--- a/compiler/rt/robovm/src/main/java/org/robovm/rt/bro/Runtime.java
+++ b/compiler/rt/robovm/src/main/java/org/robovm/rt/bro/Runtime.java
@@ -89,6 +89,10 @@ public final class Runtime {
             if (home != null) {
                 paths.add(new File(home, "lib").getAbsolutePath());
             }
+            if (Bro.IS_IOS) {
+                // support for sideload on m1
+                paths.add("/System/iOSSupport/System/Library/Frameworks");
+            }
         }
         String basePath = System.getProperty("org.robovm.base.path");
         if (basePath != null) {


### PR DESCRIPTION
## problem: SideLoaded apps were silently dying.
Actually -- not. If started with stderror redirection `open --stdout=0.log --stderr=1.log -W /Applications/test_app.app` following exception was observed: 
>java.lang.UnsatisfiedLinkError: Library 'UIKit' not found
	at org.robovm.rt.bro.Runtime.getHandle(Runtime.java:317)
	at org.robovm.rt.bro.Runtime.loadLibrary(Runtime.java:191)
	at org.robovm.rt.bro.Bro.bind(Bro.java:60)
	at org.robovm.objc.ObjCRuntime.bind(ObjCRuntime.java:92)
	at org.robovm.apple.uikit.UIResponder.<clinit>(UIResponder.java:53)
	at com.mycompany.myapp.Main.main(Main.java:89)

## Root case
 library search path for `iOSSupport` was missing
 
## workaround possible 
Manually add search path:
```
    public static void main(String[] args) {
        Runtime.addSearchPath("/System/iOSSupport/System/Library/Frameworks/");
```


