### PR TITLE
* fixed: `swiftSupport` was picking iphoneos for m1 arm simulator and failed to link

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
@@ -25,6 +25,7 @@ import org.robovm.compiler.Version;
 import org.robovm.compiler.clazz.Path;
 import org.robovm.compiler.config.*;
 import org.robovm.compiler.config.Resource.Walker;
+import org.robovm.compiler.target.ios.IOSTarget;
 import org.robovm.compiler.util.ToolchainUtil;
 import org.simpleframework.xml.Transient;
 
@@ -580,7 +581,7 @@ public abstract class AbstractTarget implements Target {
     private String getSwiftSystemName(Config config) {
         String system;
         if (config.getOs() == OS.ios) {
-            if (config.getArch().isArm()) {
+            if (IOSTarget.isDeviceArch(config.getArch())) {
                 system = "iphoneos";
             } else {
                 system = "iphonesimulator";


### PR DESCRIPTION
Problem: linker error like this:
> ld: .../swift/iphoneos/libswiftCompatibilityConcurrency.a(CompatibilityConcurrency.cpp.o), building for iOS Simulator,
> but linking in object file built for iOS, for architecture arm64

Root case: old code that was targeting device if arch is `arm`. But should also check `environment` for simulator