### PR TITLE
* fixed: IDEA missing OK button in directory picker

### DIFF
--- a/plugins/idea/src/main/java/org/robovm/idea/actions/CreateFrameworkDialog.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/actions/CreateFrameworkDialog.java
@@ -73,7 +73,7 @@ public class CreateFrameworkDialog extends DialogWrapper {
             @Override
             public void actionPerformed(ActionEvent e) {
                 FileChooserDialog fileChooser = FileChooserFactory.getInstance()
-                        .createFileChooser(new FileChooserDescriptor(true, false, false, false, false, false) {
+                        .createFileChooser(new FileChooserDescriptor(false, true, false, false, false, false) {
                             @Override
                             public boolean isFileVisible(VirtualFile file, boolean showHiddenFiles) {
                                 return file.isDirectory();

--- a/plugins/idea/src/main/java/org/robovm/idea/actions/CreateIpaDialog.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/actions/CreateIpaDialog.java
@@ -111,7 +111,7 @@ public class CreateIpaDialog extends DialogWrapper {
 
         browseButton.addActionListener(e -> {
             FileChooserDialog fileChooser = FileChooserFactory.getInstance()
-                    .createFileChooser(new FileChooserDescriptor(true, false, false, false, false, false) {
+                    .createFileChooser(new FileChooserDescriptor(false, true, false, false, false, false) {
                         @Override
                         public boolean isFileVisible(VirtualFile file, boolean showHiddenFiles) {
                             return file.isDirectory();

--- a/plugins/idea/src/main/java/org/robovm/idea/components/setupwizard/JdkSetupDialog.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/components/setupwizard/JdkSetupDialog.java
@@ -47,7 +47,7 @@ public class JdkSetupDialog extends JDialog {
 
         browseButton.addActionListener(e -> {
             FileChooserDialog fileChooser = FileChooserFactory.getInstance()
-                    .createFileChooser(new FileChooserDescriptor(true, false, false, false, false, false) {
+                    .createFileChooser(new FileChooserDescriptor(false, true, false, false, false, false) {
                         @Override
                         public boolean isFileVisible(VirtualFile file, boolean showHiddenFiles) {
                             return file.isDirectory();

--- a/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmConsoleRunConfigurationSettingsEditor.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmConsoleRunConfigurationSettingsEditor.java
@@ -93,7 +93,7 @@ public class RoboVmConsoleRunConfigurationSettingsEditor extends SettingsEditor<
         this.workingDir.setText(dir);
         this.browseButton.addActionListener(e -> {
             FileChooserDialog fileChooser = FileChooserFactory.getInstance()
-                    .createFileChooser(new FileChooserDescriptor(true, false, false, false, false, false) {
+                    .createFileChooser(new FileChooserDescriptor(false, true, false, false, false, false) {
                         @Override
                         public boolean isFileVisible(VirtualFile file, boolean showHiddenFiles) {
                             return file.isDirectory();


### PR DESCRIPTION
Root case: wrong params were used: choseFiles=true, choseDir=false
Descriptor is defined as bellow:
```
  /**
   * Use {@link FileChooserDescriptorFactory} for most used descriptors.
   *
   * @param chooseFiles       controls whether files can be chosen
   * @param chooseFolders     controls whether folders can be chosen
   * @param chooseJars        controls whether .jar files can be chosen
   * @param chooseJarsAsFiles controls whether .jar files will be returned as files or as folders
   * @param chooseJarContents controls whether .jar file contents can be chosen
   * @param chooseMultiple    controls whether multiple files can be chosen
   */
  public FileChooserDescriptor(boolean chooseFiles,
                               boolean chooseFolders,
                               boolean chooseJars,
                               boolean chooseJarsAsFiles,
                               boolean chooseJarContents,
                               boolean chooseMultiple) 
```                               