### PR TITLE
* fixed: de-sugared ByteBuffer (java9) calls are not visible at second compilation session

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/TrampolineCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/TrampolineCompiler.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.tuple.Triple;
 import org.robovm.compiler.clazz.Clazz;
 import org.robovm.compiler.config.Config;
 import org.robovm.compiler.llvm.*;
+import org.robovm.compiler.plugin.CompilerPlugin;
 import org.robovm.compiler.trampoline.Anewarray;
 import org.robovm.compiler.trampoline.Checkcast;
 import org.robovm.compiler.trampoline.FieldAccessor;
@@ -609,6 +610,15 @@ public class TrampolineCompiler {
                 c = !c.isInterface() && c.hasSuperclass() ? c.getSuperclass() : null;
             }
         }
+
+        // allow compiler plugin to resolve method
+        // its possible that method was added during de-sugaring
+        for (CompilerPlugin plugin: config.getCompilerPlugins()) {
+            SootMethod method = plugin.resolveMethod(config, clazz, name, desc);
+            if (method != null)
+                return method;
+        }
+
         return null;
     }
     

--- a/compiler/compiler/src/main/java/org/robovm/compiler/plugin/AbstractCompilerPlugin.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/plugin/AbstractCompilerPlugin.java
@@ -29,6 +29,7 @@ import org.robovm.compiler.config.Config.Builder;
 import org.robovm.compiler.llvm.Function;
 
 import org.robovm.llvm.ObjectFile;
+import soot.SootClass;
 import soot.SootMethod;
 
 /**
@@ -62,6 +63,11 @@ public abstract class AbstractCompilerPlugin extends CompilerPlugin {
     @Override
     public void afterMethod(Config config, Clazz clazz, SootMethod method,
             ModuleBuilder moduleBuilder, Function function) throws IOException {}
+
+    @Override
+    public SootMethod resolveMethod(Config config, SootClass sootClass, String name, String desc) {
+        return null;
+    }
 
     @Override
     public void afterClassDependenciesResolved(Config config, Clazz clazz) {}

--- a/compiler/compiler/src/main/java/org/robovm/compiler/plugin/CompilerPlugin.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/plugin/CompilerPlugin.java
@@ -112,6 +112,20 @@ public abstract class CompilerPlugin extends Plugin {
             ModuleBuilder moduleBuilder, Function function) throws IOException;
 
     /**
+     * Called by TrampolineCompiler when method is not resolved but this method might be added
+     * by de-sugaring plugin (for ex. ByteBuffer methods are added during class compilation.
+     * but next session when ByteBuffer is not processed -- other classes don't know about
+     * these changes
+     *
+     * @param config the current {@link Config}.
+     * @param sootClass to resolve method in
+     * @param name      name of method
+     * @param desc      its signature
+     * @return          generated method
+     */
+    public abstract SootMethod resolveMethod(Config config, SootClass sootClass, String name, String desc);
+
+    /**
      * Called after dependencies resolved and added to the list. It is the moment when all work with
      * clazz is finished (machine code generation pending) and all associated resources might be released
      *


### PR DESCRIPTION
## Root Case
these methods are added when ByteBuffer is compiled. At next session ByteBuffer class is considered compiled and its structure only parsed (and not desugared) as result de-sugared methods are not present in SootClass as result this produces `java.lang.NoSuchMethodError` compilation time.

## The Fix
trampoline compiler allows now compiler plugin to resolve missing methods. ByteBuffer de-sugaring plugin in this case returns references to target methods.