### PR TITLE
* fixed #669: this enables swift support by default with option to disable it

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -157,7 +157,7 @@ public class Config {
     @ElementList(required = false, entry = "path")
     private ArrayList<QualifiedFile> appExtensionPaths;
     @Element(required = false)
-    private SwiftSupport swiftSupport = null;
+    private SwiftSupport swiftSupport = new SwiftSupport();
     @ElementList(required = false, entry = "resource")
     private ArrayList<Resource> resources;
     @ElementList(required = false, entry = "classpathentry")
@@ -478,15 +478,15 @@ public class Config {
     }
 
     public SwiftSupport getSwiftSupport() {
-        return swiftSupport;
+        return swiftSupport.isEnabled() ? swiftSupport : null;
     }
 
     public boolean hasSwiftSupport() {
-        return swiftSupport != null;
+        return swiftSupport.isEnabled();
     }
 
     public List<File> getSwiftLibPaths() {
-        return swiftSupport == null ? Collections.emptyList()
+        return !swiftSupport.isEnabled() ? Collections.emptyList()
                 : swiftSupport.getSwiftLibPaths().stream()
                 .filter(this::isQualified)
                 .map(f -> f.entry)

--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/SwiftSupport.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/SwiftSupport.java
@@ -13,6 +13,12 @@ import java.util.List;
  */
 public class SwiftSupport {
     /**
+     * specifies if swift support is enabled, allows to disable it if required
+     */
+    @Element(required = false)
+    private boolean enable = true;
+
+    /**
      * path where swift library to be looked at
      * also these libraries will be added to linker library search path
      */
@@ -23,8 +29,12 @@ public class SwiftSupport {
      * specifies if swift runtime libraries to be copied
      */
     @Element(required = false)
-    private Boolean copySwiftLibs = true;
+    private boolean copySwiftLibs = true;
 
+
+    public boolean isEnabled() {
+        return enable;
+    }
 
     public List<Config.QualifiedFile> getSwiftLibPaths() {
         return swiftLibPaths == null ? Collections.emptyList()
@@ -32,6 +42,6 @@ public class SwiftSupport {
     }
 
     public boolean shouldCopySwiftLibs() {
-        return copySwiftLibs != null ? copySwiftLibs : true;
+        return copySwiftLibs;
     }
 }

--- a/compiler/compiler/src/test/java/org/robovm/compiler/config/ConfigTest.java
+++ b/compiler/compiler/src/test/java/org/robovm/compiler/config/ConfigTest.java
@@ -18,10 +18,7 @@ package org.robovm.compiler.config;
 
 import static org.junit.Assert.*;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.StringWriter;
+import java.io.*;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -417,5 +414,35 @@ public class ConfigTest {
 
         assertEquals("com/example/AB9ca44297c0e0d22df654119dce73ee52d3d51c71.class.o",
                 Config.getFileName("com/example/ABCDEFGIHJABCDEFGIHJABCDEFGIHJABCDEFGIHJABCDEFGIHJ", "class.o", 50));
+    }
+
+    @Test
+    public void testSwiftSupportEnabledByDefault() throws Exception {
+        String configText = "<config>\n" +
+                "  <target>ios</target>\n" +
+                "</config>";
+        Config.Builder builder = new Config.Builder();
+
+        builder.read(new StringReader(configText), wd);
+        Config config = builder.config;
+
+        assertTrue(config.hasSwiftSupport());
+        assertNotNull(config.getSwiftSupport());
+        assertTrue(config.getSwiftSupport().isEnabled());
+        assertTrue(config.getSwiftSupport().shouldCopySwiftLibs());
+    }
+
+    @Test
+    public void testSwiftSupportCanBeDisabled() throws Exception {
+        String configText = "<config>\n" +
+                "  <swiftSupport>\n" +
+                "    <enable>false</enable>\n" +
+                "  </swiftSupport>\n" +
+                "</config>";
+        Config.Builder builder = new Config.Builder();
+        builder.read(new StringReader(configText), wd);
+        Config config = builder.config;
+        assertFalse(config.hasSwiftSupport());
+        assertNull(config.getSwiftSupport());
     }
 }

--- a/compiler/compiler/src/test/resources/org/robovm/compiler/config/ConfigTest.console.xml
+++ b/compiler/compiler/src/test/resources/org/robovm/compiler/config/ConfigTest.console.xml
@@ -15,6 +15,10 @@
     <framework>Foundation</framework>
     <framework>AppKit</framework>
   </frameworks>
+  <swiftSupport>
+    <enable>true</enable>
+    <copySwiftLibs>true</copySwiftLibs>
+  </swiftSupport>
   <resources>
     <resource>resources</resource>
     <resource>/usr/share/resources</resource>

--- a/compiler/compiler/src/test/resources/org/robovm/compiler/config/ConfigTest.ios.xml
+++ b/compiler/compiler/src/test/resources/org/robovm/compiler/config/ConfigTest.ios.xml
@@ -1,4 +1,8 @@
 <config>
+  <swiftSupport>
+    <enable>true</enable>
+    <copySwiftLibs>true</copySwiftLibs>
+  </swiftSupport>
   <target>ios</target>
   <iosSdkVersion>6.1</iosSdkVersion>
   <iosInfoPList>Info.plist</iosInfoPList>


### PR DESCRIPTION
as mentioned in #669 its nice to have it enabled to ths compatibility with 2.3.16.
same time added option to disable `swiftSupport` block in case it causes issues, can be turned off with
`robovm.xml` entry:
```
<config>
    <swiftSupport>
        <enable>false</enable>
    </swiftSupport>
</config>
```