### PR TITLE
* fixed: in case of simulator, embedded frameworks/dylibs were stripped for not required arches

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
@@ -366,7 +366,7 @@ public abstract class AbstractTarget implements Target {
 
                                 if (isDynamicLibrary(file)) {
                                     // remove simulator and deprecated archs, also strip bitcode if not used
-                                    if (config.getOs() == OS.ios && config.getArch().isArm()) {
+                                    if (config.getOs() == OS.ios && config.getArch().getEnv() != Environment.Simulator) {
                                         File libFile = new File(destDir, file.getName());
                                         stripExtraArches(libFile);
                                         if (!config.isEnableBitcode())
@@ -440,7 +440,7 @@ public abstract class AbstractTarget implements Target {
                 public void processFile(Resource resource, File file, File destDir) throws IOException {
                     copyFile(resource, file, destDir);
 
-                    if (config.getOs() == OS.ios && config.getArch().isArm()) {
+                    if (config.getOs() == OS.ios && config.getArch().getEnv() != Environment.Simulator) {
                         // remove simulator and deprecated archs, also strip bitcode if not used
                         if (isAppExtension(file)) {
                             File libFile = new File(destDir, file.getName());
@@ -670,7 +670,7 @@ public abstract class AbstractTarget implements Target {
 			// don't strip if libraries goes to SwiftSupport folder
 			if (strip) {
                 // remove simulator and deprecated archs, also strip bitcode if not used
-                if (config.getOs() == OS.ios && config.getArch().isArm()) {
+                if (config.getOs() == OS.ios && config.getArch().getEnv() != Environment.Simulator) {
                     File libFile = new File(targetDir, swiftLibrary.getName());
                     stripExtraArches(libFile);
                     if (!config.isEnableBitcode())

--- a/compiler/compiler/src/main/java/org/robovm/compiler/util/ToolchainUtil.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/util/ToolchainUtil.java
@@ -329,7 +329,7 @@ public class ToolchainUtil {
         }
         args.add("-output");
         args.add(outFile);
-        new Executor(Logger.NULL_LOGGER, getLipo()).args(args).exec();
+        new Executor(config.getLogger(), getLipo()).args(args).exec();
     }
 
 


### PR DESCRIPTION
## Root case
its a regression after M1 support: `.isArm()` doesn't mean device target anymore, to filter out simulator `environment` check to be done

## other moment
currently compiler will try to copy swift dynamic libraries but these lack `arm64-simulator` slice and `arch strip` will fail that block launch on simulator. described behaviour is an another issue itself -- we should not try to copy swift dylibs in case of `arm64-simulator` but its to be provided as standalone PR