### PR TITLE
* fix: annotations are broken on 32 bit targets in 2.3.18

### DIFF
--- a/compiler/vm/bc/src/aligned.h
+++ b/compiler/vm/bc/src/aligned.h
@@ -16,9 +16,11 @@
 #ifndef ALIGNED_H
 #define ALIGNED_H
 
+#include <stddef.h>
 #include <robovm.h>
 
-#define ALIGN(pp, t) (void*)(((uintptr_t) (pp) + sizeof(t) - 1) & ~(sizeof(t) - 1))
+#define ALIGN_OF(t) offsetof(struct { char c; t m; }, m)
+#define ALIGN(pp, t) (void*)(((uintptr_t) (pp) + ALIGN_OF(t) - 1) & ~(ALIGN_OF(t) - 1))
 
 static inline jbyte readByte(void** p) {
     jbyte v = *(jbyte*) *p;

--- a/compiler/vm/core/src/attribute.c
+++ b/compiler/vm/core/src/attribute.c
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <stddef.h>
 #include <string.h>
 #include <robovm.h>
 
@@ -52,7 +53,8 @@ static jboolean throwFormatError(Env* env, char* expectedType) {
     return FALSE;
 }
 
-#define ALIGN(pp, t) (void*)(((uintptr_t) (pp) + sizeof(t) - 1) & ~(sizeof(t) - 1))
+#define ALIGN_OF(t) offsetof(struct { char c; t m; }, m)
+#define ALIGN(pp, t) (void*)(((uintptr_t) (pp) + ALIGN_OF(t) - 1) & ~(ALIGN_OF(t) - 1))
 
 static inline jbyte getByte(void** attributes) {
     jbyte v = *(jbyte*) *attributes;


### PR DESCRIPTION
introduced in https://github.com/MobiVM/robovm/pull/639
## root case
struct member alignment was wrongly calculated for jlong and double: was calculated as aligned by member size (8 bytes) but has to be 4 byte boundary.

## code to reproduce
```
import java.lang.annotation.*;

@Target({ElementType.FIELD})
@Retention(RetentionPolicy.RUNTIME)
@interface SampleAnnotation {
    long first();
    String last();
}

public class Test {
    @SampleAnnotation(first = 33, last = "last")
    private String myField;

    public void test() {
        try {
            Annotation[] anns = this.getClass().getDeclaredField("myField").getDeclaredAnnotations();
            for (Annotation a : anns) {
                System.out.println(((SampleAnnotation) a).first());
                System.out.println(((SampleAnnotation) a).last());
            }
        } catch (NoSuchFieldException e) {
            throw new RuntimeException(e);
        }
    }
}
```

## fix
use `offsetof` to get data layout offsets