### PR TITLE
* fixed 682: Subscription APIs mix NSObjectProtocol and NSObject

### DIFF
--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/accounts/ACAccountStore.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/accounts/ACAccountStore.java
@@ -44,7 +44,7 @@ import org.robovm.apple.foundation.*;
         /**
          * @since Available in iOS 5.0 and later.
          */
-        public NSObjectProtocol observeDidChange(final Runnable block) {
+        public NSObject observeDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/assetslibrary/ALAssetsLibrary.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/assetslibrary/ALAssetsLibrary.java
@@ -43,7 +43,7 @@ import org.robovm.apple.imageio.*;
     /*<implements>*//*</implements>*/ {
 
     public static class Notifications {
-        public static NSObjectProtocol observeChanged(ALAssetsLibrary object, final VoidBlock2<ALAssetsLibrary, ALAssetsLibraryChangedNotification> block) {
+        public static NSObject observeChanged(ALAssetsLibrary object, final VoidBlock2<ALAssetsLibrary, ALAssetsLibraryChangedNotification> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(ChangedNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/audiotoolbox/AudioComponent.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/audiotoolbox/AudioComponent.java
@@ -46,7 +46,7 @@ import org.robovm.apple.uikit.*;
         /**
          * @since Available in iOS 7.0 and later.
          */
-        public static NSObjectProtocol observeRegistrationsChanged(final Runnable block) {
+        public static NSObject observeRegistrationsChanged(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(RegistrationsChangedNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVAsset.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVAsset.java
@@ -52,7 +52,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 9.0 and later.
          */
-        public static NSObjectProtocol observeDurationDidChange(AVAsset object, final VoidBlock1<AVAsset> block) {
+        public static NSObject observeDurationDidChange(AVAsset object, final VoidBlock1<AVAsset> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DurationDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification notification) {
@@ -63,7 +63,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 9.0 and later.
          */
-        public static NSObjectProtocol observeChapterMetadataGroupsDidChange(AVAsset object, final VoidBlock1<AVAsset> block) {
+        public static NSObject observeChapterMetadataGroupsDidChange(AVAsset object, final VoidBlock1<AVAsset> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(ChapterMetadataGroupsDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification notification) {
@@ -74,7 +74,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 9.0 and later.
          */
-        public static NSObjectProtocol observeMediaSelectionGroupsDidChange(AVAsset object, final VoidBlock1<AVAsset> block) {
+        public static NSObject observeMediaSelectionGroupsDidChange(AVAsset object, final VoidBlock1<AVAsset> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(MediaSelectionGroupsDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification notification) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVAssetTrack.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVAssetTrack.java
@@ -52,7 +52,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 9.0 and later.
          */
-        public static NSObjectProtocol observeTrackAssociationsDidChange(AVAssetTrack object, final VoidBlock1<AVAssetTrack> block) {
+        public static NSObject observeTrackAssociationsDidChange(AVAssetTrack object, final VoidBlock1<AVAssetTrack> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(TrackAssociationsDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification notification) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVAudioEngine.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVAudioEngine.java
@@ -52,7 +52,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 8.0 and later.
          */
-        public static NSObjectProtocol observeConfigurationChange(AVAudioEngine object, final VoidBlock1<AVAudioEngine> block) {
+        public static NSObject observeConfigurationChange(AVAudioEngine object, final VoidBlock1<AVAudioEngine> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(ConfigurationChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVAudioSession.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVAudioSession.java
@@ -52,7 +52,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 6.0 and later.
          */
-        public static NSObjectProtocol observeInterruption(final VoidBlock1<AVAudioSessionInterruptionNotification> block) {
+        public static NSObject observeInterruption(final VoidBlock1<AVAudioSessionInterruptionNotification> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(InterruptionNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -69,7 +69,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 6.0 and later.
          */
-        public static NSObjectProtocol observeRouteChange(final VoidBlock1<AVAudioSessionRouteChangeNotification> block) {
+        public static NSObject observeRouteChange(final VoidBlock1<AVAudioSessionRouteChangeNotification> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(RouteChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -85,7 +85,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 7.0 and later.
          */
-        public static NSObjectProtocol observeMediaServicesWereLost(final Runnable block) {
+        public static NSObject observeMediaServicesWereLost(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(MediaServicesWereLostNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -96,7 +96,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 6.0 and later.
          */
-        public static NSObjectProtocol observeMediaServicesWereReset(final Runnable block) {
+        public static NSObject observeMediaServicesWereReset(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(MediaServicesWereResetNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -107,7 +107,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 8.0 and later.
          */
-        public static NSObjectProtocol observeSilenceSecondaryAudioHint(final VoidBlock1<AVAudioSessionSilenceSecondaryAudioHintType> block) {
+        public static NSObject observeSilenceSecondaryAudioHint(final VoidBlock1<AVAudioSessionSilenceSecondaryAudioHintType> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(SilenceSecondaryAudioHintNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVAudioUnitComponent.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVAudioUnitComponent.java
@@ -54,7 +54,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 9.0 and later.
          */
-        public static NSObjectProtocol observeTagsDidChange(AVAudioUnitComponent object, final VoidBlock1<AVAudioUnitComponent> block) {
+        public static NSObject observeTagsDidChange(AVAudioUnitComponent object, final VoidBlock1<AVAudioUnitComponent> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(TagsDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification notification) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVCaptureDevice.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVCaptureDevice.java
@@ -52,7 +52,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 4.0 and later.
          */
-        public static NSObjectProtocol observeWasConnected(final VoidBlock1<AVCaptureDevice> block) {
+        public static NSObject observeWasConnected(final VoidBlock1<AVCaptureDevice> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(WasConnectedNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -63,7 +63,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 4.0 and later.
          */
-        public static NSObjectProtocol observeWasDisconnected(final VoidBlock1<AVCaptureDevice> block) {
+        public static NSObject observeWasDisconnected(final VoidBlock1<AVCaptureDevice> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(WasDisconnectedNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -74,7 +74,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 5.0 and later.
          */
-        public static NSObjectProtocol observeSubjectAreaDidChange(AVCaptureDevice object, final VoidBlock1<AVCaptureDevice> block) {
+        public static NSObject observeSubjectAreaDidChange(AVCaptureDevice object, final VoidBlock1<AVCaptureDevice> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(SubjectAreaDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVCaptureInputPort.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVCaptureInputPort.java
@@ -52,7 +52,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 4.0 and later.
          */
-        public static NSObjectProtocol observeFormatDescriptionDidChange(AVCaptureInputPort object, final VoidBlock1<AVCaptureInputPort> block) {
+        public static NSObject observeFormatDescriptionDidChange(AVCaptureInputPort object, final VoidBlock1<AVCaptureInputPort> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(FormatDescriptionDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVCaptureSession.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVCaptureSession.java
@@ -52,7 +52,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 4.0 and later.
          */
-        public static NSObjectProtocol observeRuntimeError(AVCaptureSession object, final VoidBlock2<AVCaptureSession, NSError> block) {
+        public static NSObject observeRuntimeError(AVCaptureSession object, final VoidBlock2<AVCaptureSession, NSError> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(RuntimeErrorNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -68,7 +68,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 4.0 and later.
          */
-        public static NSObjectProtocol observeDidStartRunning(AVCaptureSession object, final VoidBlock1<AVCaptureSession> block) {
+        public static NSObject observeDidStartRunning(AVCaptureSession object, final VoidBlock1<AVCaptureSession> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidStartRunningNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -79,7 +79,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 4.0 and later.
          */
-        public static NSObjectProtocol observeDidStopRunning(AVCaptureSession object, final VoidBlock1<AVCaptureSession> block) {
+        public static NSObject observeDidStopRunning(AVCaptureSession object, final VoidBlock1<AVCaptureSession> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidStopRunningNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -90,7 +90,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 4.0 and later.
          */
-        public static NSObjectProtocol observeWasInterrupted(AVCaptureSession object, final VoidBlock2<AVCaptureSession, AVCaptureSessionInterruptionReason> block) {
+        public static NSObject observeWasInterrupted(AVCaptureSession object, final VoidBlock2<AVCaptureSession, AVCaptureSessionInterruptionReason> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(WasInterruptedNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification notification) {
@@ -109,7 +109,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 4.0 and later.
          */
-        public static NSObjectProtocol observeInterruptionEnded(AVCaptureSession object, final VoidBlock1<AVCaptureSession> block) {
+        public static NSObject observeInterruptionEnded(AVCaptureSession object, final VoidBlock1<AVCaptureSession> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(InterruptionEndedNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVPlayerItem.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVPlayerItem.java
@@ -52,7 +52,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 5.0 and later.
          */
-        public static NSObjectProtocol observeTimeJumped(AVPlayerItem object, final VoidBlock1<AVPlayerItem> block) {
+        public static NSObject observeTimeJumped(AVPlayerItem object, final VoidBlock1<AVPlayerItem> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(TimeJumpedNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification notification) {
@@ -63,7 +63,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 4.0 and later.
          */
-        public static NSObjectProtocol observeDidPlayToEndTime(AVPlayerItem object, final VoidBlock1<AVPlayerItem> block) {
+        public static NSObject observeDidPlayToEndTime(AVPlayerItem object, final VoidBlock1<AVPlayerItem> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidPlayToEndTimeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification notification) {
@@ -74,7 +74,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 4.3 and later.
          */
-        public static NSObjectProtocol observeFailedToPlayToEndTime(AVPlayerItem object, final VoidBlock2<AVPlayerItem, NSError> block) {
+        public static NSObject observeFailedToPlayToEndTime(AVPlayerItem object, final VoidBlock2<AVPlayerItem, NSError> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(FailedToPlayToEndTimeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification notification) {
@@ -90,7 +90,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 6.0 and later.
          */
-        public static NSObjectProtocol observePlaybackStalled(AVPlayerItem object, final VoidBlock1<AVPlayerItem> block) {
+        public static NSObject observePlaybackStalled(AVPlayerItem object, final VoidBlock1<AVPlayerItem> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(PlaybackStalledNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification notification) {
@@ -101,7 +101,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 6.0 and later.
          */
-        public static NSObjectProtocol observeNewAccessLogEntry(AVPlayerItem object, final VoidBlock1<AVPlayerItem> block) {
+        public static NSObject observeNewAccessLogEntry(AVPlayerItem object, final VoidBlock1<AVPlayerItem> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(NewAccessLogEntryNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification notification) {
@@ -112,7 +112,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 6.0 and later.
          */
-        public static NSObjectProtocol observeNewErrorLogEntry(AVPlayerItem object, final VoidBlock1<AVPlayerItem> block) {
+        public static NSObject observeNewErrorLogEntry(AVPlayerItem object, final VoidBlock1<AVPlayerItem> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(NewErrorLogEntryNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification notification) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVSampleBufferDisplayLayer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/avfoundation/AVSampleBufferDisplayLayer.java
@@ -52,7 +52,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 8.0 and later.
          */
-        public static NSObjectProtocol observeFailedToDecode(AVSampleBufferDisplayLayer object, final VoidBlock2<AVSampleBufferDisplayLayer, NSError> block) {
+        public static NSObject observeFailedToDecode(AVSampleBufferDisplayLayer object, final VoidBlock2<AVSampleBufferDisplayLayer, NSError> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(FailedToDecodeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/cloudkit/CKContainer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/cloudkit/CKContainer.java
@@ -45,7 +45,7 @@ import org.robovm.apple.fileprovider.*;
         /**
          * @since Available in iOS 9.0 and later.
          */
-        public static NSObjectProtocol observeAccountChanged(final Runnable block) {
+        public static NSObject observeAccountChanged(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(AccountChangedNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/contacts/CNContactStore.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/contacts/CNContactStore.java
@@ -44,7 +44,7 @@ import org.robovm.apple.foundation.*;
         /**
          * @since Available in iOS 9.0 and later.
          */
-        public static NSObjectProtocol observeDidChange(CNContactStore object, final Runnable block) {
+        public static NSObject observeDidChange(CNContactStore object, final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSManagedObjectContext.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSManagedObjectContext.java
@@ -45,7 +45,7 @@ import org.robovm.apple.uikit.*;
         /**
          * @since Available in iOS 3.0 and later.
          */
-        public static NSObjectProtocol observeWillSave(NSManagedObject object, final VoidBlock1<NSManagedObject> block) {
+        public static NSObject observeWillSave(NSManagedObject object, final VoidBlock1<NSManagedObject> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(WillSaveNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -56,7 +56,7 @@ import org.robovm.apple.uikit.*;
         /**
          * @since Available in iOS 3.0 and later.
          */
-        public static NSObjectProtocol observeDidSave(NSManagedObject object, final VoidBlock2<NSManagedObject, NSManagedObjectContextNotification> block) {
+        public static NSObject observeDidSave(NSManagedObject object, final VoidBlock2<NSManagedObject, NSManagedObjectContextNotification> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidSaveNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -72,7 +72,7 @@ import org.robovm.apple.uikit.*;
         /**
          * @since Available in iOS 3.0 and later.
          */
-        public static NSObjectProtocol observeObjectsDidChange(NSManagedObject object, final VoidBlock3<NSManagedObject, NSManagedObjectContextNotification, NSNotification> block) {
+        public static NSObject observeObjectsDidChange(NSManagedObject object, final VoidBlock3<NSManagedObject, NSManagedObjectContextNotification, NSNotification> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(ObjectsDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSPersistentStoreCoordinator.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSPersistentStoreCoordinator.java
@@ -45,7 +45,7 @@ import org.robovm.apple.uikit.*;
         /**
          * @since Available in iOS 7.0 and later.
          */
-        public static NSObjectProtocol observeStoresWillChange(NSPersistentStoreCoordinator object, final VoidBlock2<NSPersistentStoreCoordinator, NSPersistentStoreCoordinatorChangeNotification> block) {
+        public static NSObject observeStoresWillChange(NSPersistentStoreCoordinator object, final VoidBlock2<NSPersistentStoreCoordinator, NSPersistentStoreCoordinatorChangeNotification> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(NotificationKeys.CoordinatorStoresWillChange(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -61,7 +61,7 @@ import org.robovm.apple.uikit.*;
         /**
          * @since Available in iOS 3.0 and later.
          */
-        public static NSObjectProtocol observeStoresDidChange(NSPersistentStoreCoordinator object, final VoidBlock2<NSPersistentStoreCoordinator, NSPersistentStoreCoordinatorChangeNotification> block) {
+        public static NSObject observeStoresDidChange(NSPersistentStoreCoordinator object, final VoidBlock2<NSPersistentStoreCoordinator, NSPersistentStoreCoordinatorChangeNotification> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(NotificationKeys.CoordinatorStoresDidChange(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -77,7 +77,7 @@ import org.robovm.apple.uikit.*;
         /**
          * @since Available in iOS 3.0 and later.
          */
-        public static NSObjectProtocol observeWillRemoveStore(NSPersistentStoreCoordinator object, final VoidBlock1<NSPersistentStoreCoordinator> block) {
+        public static NSObject observeWillRemoveStore(NSPersistentStoreCoordinator object, final VoidBlock1<NSPersistentStoreCoordinator> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(NotificationKeys.CoordinatorWillRemoveStore(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -88,7 +88,7 @@ import org.robovm.apple.uikit.*;
         /**
          * @since Available in iOS 5.0 and later.
          */
-        public static NSObjectProtocol observeDidImportUbiquitousContentChanges(NSPersistentStoreCoordinator object, final VoidBlock2<NSPersistentStoreCoordinator, NSNotification> block) {
+        public static NSObject observeDidImportUbiquitousContentChanges(NSPersistentStoreCoordinator object, final VoidBlock2<NSPersistentStoreCoordinator, NSNotification> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(NotificationKeys.DidImportUbiquitousContentChanges(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corefoundation/CFLocale.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corefoundation/CFLocale.java
@@ -43,7 +43,7 @@ import org.robovm.apple.coretext.*;
     /*<implements>*//*</implements>*/ {
 
     public static class Notifications {
-        public static NSObjectProtocol observeCurrentLocaleDidChange(final Runnable block) {
+        public static NSObject observeCurrentLocaleDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(CurrentLocaleDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corefoundation/CFTimeZone.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corefoundation/CFTimeZone.java
@@ -43,7 +43,7 @@ import org.robovm.apple.coretext.*;
     /*<implements>*//*</implements>*/ {
 
     public static class Notifications {
-        public NSObjectProtocol observeSystemTimeZoneDidChangeNotification(final Runnable block) {
+        public NSObject observeSystemTimeZoneDidChangeNotification(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(SystemTimeZoneDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMSampleBuffer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMSampleBuffer.java
@@ -47,7 +47,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 4.0 and later.
          */
-        public static NSObjectProtocol observeDataBecameReady(CMSampleBuffer object, final VoidBlock1<CMSampleBuffer> block) {
+        public static NSObject observeDataBecameReady(CMSampleBuffer object, final VoidBlock1<CMSampleBuffer> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DataBecameReadyNotification(), object.as(NSObject.class), NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -58,7 +58,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 8.0 and later.
          */
-        public static NSObjectProtocol observeDataFailed(CMSampleBuffer object, final VoidBlock2<CMSampleBuffer, OSStatus> block) {
+        public static NSObject observeDataFailed(CMSampleBuffer object, final VoidBlock2<CMSampleBuffer, OSStatus> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DataFailedNotification(), object.as(NSObject.class), NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -72,7 +72,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 4.0 and later.
          */
-        public static NSObjectProtocol observeInhibitOutputUntil(CMSampleBuffer object, final VoidBlock2<CMSampleBuffer, Long> block) {
+        public static NSObject observeInhibitOutputUntil(CMSampleBuffer object, final VoidBlock2<CMSampleBuffer, Long> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(InhibitOutputUntilConduitNotification(), object.as(NSObject.class), NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -86,7 +86,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 4.0 and later.
          */
-        public static NSObjectProtocol observeResetOutput(CMSampleBuffer object, final VoidBlock1<CMSampleBuffer> block) {
+        public static NSObject observeResetOutput(CMSampleBuffer object, final VoidBlock1<CMSampleBuffer> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(ResetOutputConduitNotification(), object.as(NSObject.class), NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -97,7 +97,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 4.3 and later.
          */
-        public static NSObjectProtocol observeUpcomingOutputPTSRangeChanged(CMSampleBuffer object, final VoidBlock4<CMSampleBuffer, Boolean, CMTime, CMTime> block) {
+        public static NSObject observeUpcomingOutputPTSRangeChanged(CMSampleBuffer object, final VoidBlock4<CMSampleBuffer, Boolean, CMTime, CMTime> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(UpcomingOutputPTSRangeChangedConduitNotification(), object.as(NSObject.class), NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -115,7 +115,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 4.0 and later.
          */
-        public static NSObjectProtocol observeBufferConsumed(CMSampleBuffer object, final VoidBlock2<CMSampleBuffer, NSDictionary<?, ?>> block) {
+        public static NSObject observeBufferConsumed(CMSampleBuffer object, final VoidBlock2<CMSampleBuffer, NSDictionary<?, ?>> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(BufferConsumedConsumerNotification(), object.as(NSObject.class), NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMTimebase.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMTimebase.java
@@ -47,7 +47,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 6.0 and later.
          */
-        public static NSObjectProtocol observeEffectiveRateChanged(CMTimebase object, final VoidBlock2<CMTimebase, CMTime> block) {
+        public static NSObject observeEffectiveRateChanged(CMTimebase object, final VoidBlock2<CMTimebase, CMTime> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(EffectiveRateChangedNotification(), object.as(NSObject.class), NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -65,7 +65,7 @@ import org.robovm.apple.audiotoolbox.*;
         /**
          * @since Available in iOS 6.0 and later.
          */
-        public static NSObjectProtocol observeTimeJumped(CMTimebase object, final VoidBlock2<CMTimebase, CMTime> block) {
+        public static NSObject observeTimeJumped(CMTimebase object, final VoidBlock2<CMTimebase, CMTime> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(TimeJumpedNotification(), object.as(NSObject.class), NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretelephony/CTSubscriber.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretelephony/CTSubscriber.java
@@ -43,7 +43,7 @@ import org.robovm.apple.corefoundation.*;
         /**
          * @since Available in iOS 7.0 and later.
          */
-        public static NSObjectProtocol observeTokenRefreshed(CTSubscriber object, final VoidBlock1<CTSubscriber> block) {
+        public static NSObject observeTokenRefreshed(CTSubscriber object, final VoidBlock1<CTSubscriber> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(TokenRefreshedNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretelephony/CTTelephonyNetworkInfo.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretelephony/CTTelephonyNetworkInfo.java
@@ -40,7 +40,7 @@ import org.robovm.apple.corefoundation.*;
     /*<implements>*//*</implements>*/ {
 
     public static class Notifications {
-        public static NSObjectProtocol observeRadioAccessTechnologyDidChange(CTTelephonyNetworkInfo object, final VoidBlock1<CTTelephonyNetworkInfo> block) {
+        public static NSObject observeRadioAccessTechnologyDidChange(CTTelephonyNetworkInfo object, final VoidBlock1<CTTelephonyNetworkInfo> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(RadioAccessTechnologyDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTFontManager.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTFontManager.java
@@ -45,7 +45,7 @@ import org.robovm.apple.uikit.*;
         /**
          * @since Available in iOS 7.0 and later.
          */
-        public static NSObjectProtocol observeRegisteredFontsChanged(final Runnable block) {
+        public static NSObject observeRegisteredFontsChanged(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(RegisteredFontsChangedNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corevideo/CVPixelBufferPool.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corevideo/CVPixelBufferPool.java
@@ -46,7 +46,7 @@ import org.robovm.apple.iosurface.*;
         /**
          * @since Available in iOS 4.0 and later.
          */
-        public static NSObjectProtocol observeFreeBuffer(CVPixelBufferPool object, final VoidBlock1<CVPixelBufferPool> block) {
+        public static NSObject observeFreeBuffer(CVPixelBufferPool object, final VoidBlock1<CVPixelBufferPool> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(FreeBufferNotification(), object.as(NSObject.class), NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/eventkit/EKEventStore.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/eventkit/EKEventStore.java
@@ -46,7 +46,7 @@ import org.robovm.apple.mapkit.*;
         /**
          * @since Available in iOS 4.0 and later.
          */
-        public static NSObjectProtocol observeChanged(EKEventStore object, final VoidBlock1<EKEventStore> block) {
+        public static NSObject observeChanged(EKEventStore object, final VoidBlock1<EKEventStore> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(ChangedNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/externalaccessory/EAAccessoryManager.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/externalaccessory/EAAccessoryManager.java
@@ -44,7 +44,7 @@ import org.robovm.apple.uikit.*;
         /**
          * @since Available in iOS 3.0 and later.
          */
-        public static NSObjectProtocol observeAccessoryDidConnect(EAAccessoryManager object, final VoidBlock3<EAAccessoryManager, EAAccessory, EAAccessory> block) {
+        public static NSObject observeAccessoryDidConnect(EAAccessoryManager object, final VoidBlock3<EAAccessoryManager, EAAccessory, EAAccessory> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(AccessoryDidConnectNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -64,7 +64,7 @@ import org.robovm.apple.uikit.*;
         /**
          * @since Available in iOS 3.0 and later.
          */
-        public static NSObjectProtocol observeAccessoryDidDisconnect(EAAccessoryManager object, final VoidBlock2<EAAccessoryManager, EAAccessory> block) {
+        public static NSObject observeAccessoryDidDisconnect(EAAccessoryManager object, final VoidBlock2<EAAccessoryManager, EAAccessory> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(AccessoryDidDisconnectNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSBundle.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSBundle.java
@@ -47,7 +47,7 @@ import org.robovm.apple.dispatch.*;
     /*<implements>*//*</implements>*/ {
 
     public static class Notifications {
-        public static NSObjectProtocol observeDidLoad(NSBundle object, final VoidBlock2<NSBundle, List<String>> block) {
+        public static NSObject observeDidLoad(NSBundle object, final VoidBlock2<NSBundle, List<String>> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidLoadNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @SuppressWarnings("unchecked")
                 @Override

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSBundleResourceRequest.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSBundleResourceRequest.java
@@ -52,7 +52,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 9.0 and later.
          */
-        public static NSObjectProtocol observeLowDiskSpace(final Runnable block) {
+        public static NSObject observeLowDiskSpace(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(LowDiskSpaceNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSCalendar.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSCalendar.java
@@ -50,7 +50,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 7.0 and later.
          */
-        public static NSObjectProtocol observeDayChanged(final Runnable block) {
+        public static NSObject observeDayChanged(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DayChangedNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSDate.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSDate.java
@@ -50,7 +50,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 4.0 and later.
          */
-        public static NSObjectProtocol observeSystemClockDidChange(final Runnable block) {
+        public static NSObject observeSystemClockDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(SystemClockDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSExtensionContext.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSExtensionContext.java
@@ -50,7 +50,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 8.2 and later.
          */
-        public static NSObjectProtocol observeHostWillEnterForeground(NSExtensionContext object, final VoidBlock1<NSExtensionContext> block) {
+        public static NSObject observeHostWillEnterForeground(NSExtensionContext object, final VoidBlock1<NSExtensionContext> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(HostWillEnterForegroundNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -61,7 +61,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 8.2 and later.
          */
-        public static NSObjectProtocol observeHostDidEnterBackground(NSExtensionContext object, final VoidBlock1<NSExtensionContext> block) {
+        public static NSObject observeHostDidEnterBackground(NSExtensionContext object, final VoidBlock1<NSExtensionContext> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(HostDidEnterBackgroundNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -72,7 +72,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 8.2 and later.
          */
-        public static NSObjectProtocol observeHostWillResignActive(NSExtensionContext object, final VoidBlock1<NSExtensionContext> block) {
+        public static NSObject observeHostWillResignActive(NSExtensionContext object, final VoidBlock1<NSExtensionContext> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(HostWillResignActiveNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -83,7 +83,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 8.2 and later.
          */
-        public static NSObjectProtocol observeHostDidBecomeActive(NSExtensionContext object, final VoidBlock1<NSExtensionContext> block) {
+        public static NSObject observeHostDidBecomeActive(NSExtensionContext object, final VoidBlock1<NSExtensionContext> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(HostDidBecomeActiveNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSFileHandle.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSFileHandle.java
@@ -47,7 +47,7 @@ import org.robovm.apple.dispatch.*;
     /*<implements>*/implements NSSecureCoding/*</implements>*/ {
 
     public static class Notifications {
-        public static NSObjectProtocol observeReadCompletion(NSFileHandle object, final VoidBlock2<NSFileHandle, NSData> block) {
+        public static NSObject observeReadCompletion(NSFileHandle object, final VoidBlock2<NSFileHandle, NSData> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(ReadCompletionNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -60,7 +60,7 @@ import org.robovm.apple.dispatch.*;
                 }
             });
         }
-        public static NSObjectProtocol observeReadToEndOfFileCompletion(NSFileHandle object, final VoidBlock2<NSFileHandle, NSData> block) {
+        public static NSObject observeReadToEndOfFileCompletion(NSFileHandle object, final VoidBlock2<NSFileHandle, NSData> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(ReadToEndOfFileCompletionNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -73,7 +73,7 @@ import org.robovm.apple.dispatch.*;
                 }
             });
         }
-        public static NSObjectProtocol observeConnectionAccepted(NSFileHandle object, final VoidBlock2<NSFileHandle, NSFileHandle> block) {
+        public static NSObject observeConnectionAccepted(NSFileHandle object, final VoidBlock2<NSFileHandle, NSFileHandle> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(ConnectionAcceptedNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -86,7 +86,7 @@ import org.robovm.apple.dispatch.*;
                 }
             });
         }
-        public static NSObjectProtocol observeDataAvailable(NSFileHandle object, final VoidBlock1<NSFileHandle> block) {
+        public static NSObject observeDataAvailable(NSFileHandle object, final VoidBlock1<NSFileHandle> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DataAvailableNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSFileManager.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSFileManager.java
@@ -50,7 +50,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 6.0 and later.
          */
-        public static NSObjectProtocol observeUbiquityIdentityDidChange(final Runnable block) {
+        public static NSObject observeUbiquityIdentityDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(UbiquityIdentityDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSHTTPCookieStorage.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSHTTPCookieStorage.java
@@ -47,7 +47,7 @@ import org.robovm.apple.dispatch.*;
     /*<implements>*//*</implements>*/ {
 
     public static class Notifications {
-        public static NSObjectProtocol observeAcceptPolicyChanged(NSHTTPCookieStorage object, final VoidBlock1<NSHTTPCookieStorage> block) {
+        public static NSObject observeAcceptPolicyChanged(NSHTTPCookieStorage object, final VoidBlock1<NSHTTPCookieStorage> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(AcceptPolicyChangedNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -55,7 +55,7 @@ import org.robovm.apple.dispatch.*;
                 }
             });
         }
-        public static NSObjectProtocol observeCookiesChanged(NSHTTPCookieStorage object, final VoidBlock1<NSHTTPCookieStorage> block) {
+        public static NSObject observeCookiesChanged(NSHTTPCookieStorage object, final VoidBlock1<NSHTTPCookieStorage> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(CookiesChangedNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSLocale.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSLocale.java
@@ -50,7 +50,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 2.0 and later.
          */
-        public static NSObjectProtocol observeCurrentLocaleDidChange(final Runnable block) {
+        public static NSObject observeCurrentLocaleDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(CurrentLocaleDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMetadataQuery.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMetadataQuery.java
@@ -50,7 +50,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 5.0 and later.
          */
-        public static NSObjectProtocol observeDidStartGathering(NSMetadataQuery object, final VoidBlock2<NSMetadataQuery, NSMetadataQueryUpdatedItems> block) {
+        public static NSObject observeDidStartGathering(NSMetadataQuery object, final VoidBlock2<NSMetadataQuery, NSMetadataQueryUpdatedItems> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidStartGatheringNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -61,7 +61,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 5.0 and later.
          */
-        public static NSObjectProtocol observeGatheringProgress(NSMetadataQuery object, final VoidBlock2<NSMetadataQuery, NSMetadataQueryUpdatedItems> block) {
+        public static NSObject observeGatheringProgress(NSMetadataQuery object, final VoidBlock2<NSMetadataQuery, NSMetadataQueryUpdatedItems> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(GatheringProgressNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -72,7 +72,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 5.0 and later.
          */
-        public static NSObjectProtocol observeDidFinishGathering(NSMetadataQuery object, final VoidBlock2<NSMetadataQuery, NSMetadataQueryUpdatedItems> block) {
+        public static NSObject observeDidFinishGathering(NSMetadataQuery object, final VoidBlock2<NSMetadataQuery, NSMetadataQueryUpdatedItems> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidFinishGatheringNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -83,7 +83,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 5.0 and later.
          */
-        public static NSObjectProtocol observeDidUpdate(NSMetadataQuery object, final VoidBlock2<NSMetadataQuery, NSMetadataQueryUpdatedItems> block) {
+        public static NSObject observeDidUpdate(NSMetadataQuery object, final VoidBlock2<NSMetadataQuery, NSMetadataQueryUpdatedItems> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidUpdateNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSNotificationCenter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSNotificationCenter.java
@@ -86,7 +86,7 @@ import org.robovm.apple.dispatch.*;
     /**
      * @since Available in iOS 4.0 and later.
      */
-    public NSObjectProtocol addObserver(String name, NSObject object, NSOperationQueue queue, @Block VoidBlock1<NSNotification> block) {
+    public NSObject addObserver(String name, NSObject object, NSOperationQueue queue, @Block VoidBlock1<NSNotification> block) {
         return addObserver(new NSString(name), object, queue, block);
     }
     /*<methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSPort.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSPort.java
@@ -47,7 +47,7 @@ import org.robovm.apple.dispatch.*;
     /*<implements>*/implements NSCoding/*</implements>*/ {
 
     public static class Notifications {
-        public static NSObjectProtocol observeDidBecomeInvalid(NSPort object, final VoidBlock1<NSPort> block) {
+        public static NSObject observeDidBecomeInvalid(NSPort object, final VoidBlock1<NSPort> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidBecomeInvalidNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSProcessInfo.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSProcessInfo.java
@@ -50,7 +50,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 9.0 and later.
          */
-        public static NSObjectProtocol observePowerStateDidChange(final Runnable block) {
+        public static NSObject observePowerStateDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(PowerStateDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSThread.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSThread.java
@@ -47,7 +47,7 @@ import org.robovm.apple.dispatch.*;
     /*<implements>*//*</implements>*/ {
 
     public static class Notifications {
-        public static NSObjectProtocol observeWillBecomeMultiThreaded(final Runnable block) {
+        public static NSObject observeWillBecomeMultiThreaded(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(WillBecomeMultiThreadedNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -55,7 +55,7 @@ import org.robovm.apple.dispatch.*;
                 }
             });
         }
-        public static NSObjectProtocol observeDidBecomeSingleThreaded(final Runnable block) {
+        public static NSObject observeDidBecomeSingleThreaded(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidBecomeSingleThreadedNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -63,7 +63,7 @@ import org.robovm.apple.dispatch.*;
                 }
             });
         }
-        public static NSObjectProtocol observeWillExit(NSThread object, final VoidBlock1<NSThread> block) {
+        public static NSObject observeWillExit(NSThread object, final VoidBlock1<NSThread> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(WillExitNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSTimeZone.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSTimeZone.java
@@ -50,7 +50,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 2.0 and later.
          */
-        public static NSObjectProtocol observeDidChange(final Runnable block) {
+        public static NSObject observeDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURLCredentialStorage.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURLCredentialStorage.java
@@ -47,7 +47,7 @@ import org.robovm.apple.dispatch.*;
     /*<implements>*//*</implements>*/ {
 
     public static class Notifications {
-        public static NSObjectProtocol observeChanged(NSURLCredentialStorage object, final VoidBlock1<NSURLCredentialStorage> block) {
+        public static NSObject observeChanged(NSURLCredentialStorage object, final VoidBlock1<NSURLCredentialStorage> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(ChangedNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSUbiquitousKeyValueStore.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSUbiquitousKeyValueStore.java
@@ -50,7 +50,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 5.0 and later.
          */
-        public static NSObjectProtocol observeDidChangeExternally(NSUbiquitousKeyValueStore object, final VoidBlock3<NSUbiquitousKeyValueStore, String, List<String>> block) {
+        public static NSObject observeDidChangeExternally(NSUbiquitousKeyValueStore object, final VoidBlock3<NSUbiquitousKeyValueStore, String, List<String>> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidChangeExternallyNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSUndoManager.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSUndoManager.java
@@ -50,7 +50,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 3.0 and later.
          */
-        public static NSObjectProtocol observeCheckpoint(NSUndoManager object, final VoidBlock1<NSUndoManager> block) {
+        public static NSObject observeCheckpoint(NSUndoManager object, final VoidBlock1<NSUndoManager> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(CheckpointNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -61,7 +61,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 3.0 and later.
          */
-        public static NSObjectProtocol observeWillUndoChange(NSUndoManager object, final VoidBlock1<NSUndoManager> block) {
+        public static NSObject observeWillUndoChange(NSUndoManager object, final VoidBlock1<NSUndoManager> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(WillUndoChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -72,7 +72,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 3.0 and later.
          */
-        public static NSObjectProtocol observeWillRedoChange(NSUndoManager object, final VoidBlock1<NSUndoManager> block) {
+        public static NSObject observeWillRedoChange(NSUndoManager object, final VoidBlock1<NSUndoManager> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(WillRedoChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -83,7 +83,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 3.0 and later.
          */
-        public static NSObjectProtocol observeDidUndoChange(NSUndoManager object, final VoidBlock1<NSUndoManager> block) {
+        public static NSObject observeDidUndoChange(NSUndoManager object, final VoidBlock1<NSUndoManager> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidUndoChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -94,7 +94,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 3.0 and later.
          */
-        public static NSObjectProtocol observeDidRedoChange(NSUndoManager object, final VoidBlock1<NSUndoManager> block) {
+        public static NSObject observeDidRedoChange(NSUndoManager object, final VoidBlock1<NSUndoManager> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidRedoChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -105,7 +105,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 3.0 and later.
          */
-        public static NSObjectProtocol observeDidOpenUndoGroup(NSUndoManager object, final VoidBlock1<NSUndoManager> block) {
+        public static NSObject observeDidOpenUndoGroup(NSUndoManager object, final VoidBlock1<NSUndoManager> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidOpenUndoGroupNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -116,7 +116,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 3.0 and later.
          */
-        public static NSObjectProtocol observeWillCloseUndoGroup(NSUndoManager object, final VoidBlock2<NSUndoManager, Boolean> block) {
+        public static NSObject observeWillCloseUndoGroup(NSUndoManager object, final VoidBlock2<NSUndoManager, Boolean> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(WillCloseUndoGroupNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -133,7 +133,7 @@ import org.robovm.apple.dispatch.*;
         /**
          * @since Available in iOS 5.0 and later.
          */
-        public static NSObjectProtocol observeDidCloseUndoGroup(NSUndoManager object, final VoidBlock1<NSUndoManager> block) {
+        public static NSObject observeDidCloseUndoGroup(NSUndoManager object, final VoidBlock1<NSUndoManager> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidCloseUndoGroupNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSUserDefaults.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSUserDefaults.java
@@ -47,7 +47,7 @@ import org.robovm.apple.dispatch.*;
     /*<implements>*//*</implements>*/ {
 
     public static class Notifications {
-        public static NSObjectProtocol observeDidChange(NSUserDefaults object, final VoidBlock1<NSUserDefaults> block) {
+        public static NSObject observeDidChange(NSUserDefaults object, final VoidBlock1<NSUserDefaults> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/gamecontroller/GCController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/gamecontroller/GCController.java
@@ -42,7 +42,7 @@ import org.robovm.apple.corehaptic.*;
     /*<implements>*/implements GCDevice/*</implements>*/ {
 
     public static class Notifications {
-        public static NSObjectProtocol observeDidConnect(final VoidBlock1<GCController> block) {
+        public static NSObject observeDidConnect(final VoidBlock1<GCController> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidConnectNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -50,7 +50,7 @@ import org.robovm.apple.corehaptic.*;
                 }
             });
         }
-        public static NSObjectProtocol observeDidDisconnect(final VoidBlock1<GCController> block) {
+        public static NSObject observeDidDisconnect(final VoidBlock1<GCController> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidDisconnectNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/healthkit/HKHealthStore.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/healthkit/HKHealthStore.java
@@ -42,7 +42,7 @@ import org.robovm.apple.foundation.*;
         /**
          * @since Available in iOS 8.2 and later.
          */
-        public static NSObjectProtocol observeUserPreferencesDidChange(HKHealthStore object, final VoidBlock1<HKHealthStore> block) {
+        public static NSObject observeUserPreferencesDidChange(HKHealthStore object, final VoidBlock1<HKHealthStore> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(UserPreferencesDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/mediaplayer/MPMediaLibrary.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/mediaplayer/MPMediaLibrary.java
@@ -42,7 +42,7 @@ import org.robovm.apple.coreanimation.*;
     /*<implements>*/implements NSSecureCoding/*</implements>*/ {
     
     public static class Notifications {
-        public static NSObjectProtocol observeDidChange(final Runnable block) {
+        public static NSObject observeDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/mediaplayer/MPMoviePlayerController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/mediaplayer/MPMoviePlayerController.java
@@ -48,7 +48,7 @@ import org.robovm.rt.annotation.WeaklyLinked;
         /**
          * @since Available in iOS 3.2 and later.
          */
-        public static NSObjectProtocol observeIsPreparedToPlayDidChange(MPMoviePlayerController object, final VoidBlock1<MPMediaPlayback> block) {
+        public static NSObject observeIsPreparedToPlayDidChange(MPMoviePlayerController object, final VoidBlock1<MPMediaPlayback> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(IsPreparedToPlayDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {
@@ -59,7 +59,7 @@ import org.robovm.rt.annotation.WeaklyLinked;
         /**
          * @since Available in iOS 3.2 and later.
          */
-        public static NSObjectProtocol observeDurationAvailable(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
+        public static NSObject observeDurationAvailable(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DurationAvailableNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {
@@ -70,7 +70,7 @@ import org.robovm.rt.annotation.WeaklyLinked;
         /**
          * @since Available in iOS 3.2 and later.
          */
-        public static NSObjectProtocol observeMediaTypesAvailable(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
+        public static NSObject observeMediaTypesAvailable(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(MediaTypesAvailableNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {
@@ -81,7 +81,7 @@ import org.robovm.rt.annotation.WeaklyLinked;
         /**
          * @since Available in iOS 3.2 and later.
          */
-        public static NSObjectProtocol observeNaturalSizeAvailable(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
+        public static NSObject observeNaturalSizeAvailable(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(NaturalSizeAvailableNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {
@@ -92,7 +92,7 @@ import org.robovm.rt.annotation.WeaklyLinked;
         /**
          * @since Available in iOS 3.2 and later.
          */
-        public static NSObjectProtocol observeDidEnterFullscreen(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
+        public static NSObject observeDidEnterFullscreen(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidEnterFullscreenNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {
@@ -103,7 +103,7 @@ import org.robovm.rt.annotation.WeaklyLinked;
         /**
          * @since Available in iOS 3.2 and later.
          */
-        public static NSObjectProtocol observeDidExitFullscreen(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
+        public static NSObject observeDidExitFullscreen(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidExitFullscreenNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {
@@ -114,7 +114,7 @@ import org.robovm.rt.annotation.WeaklyLinked;
         /**
          * @since Available in iOS 5.0 and later.
          */
-        public static NSObjectProtocol observeIsAirPlayVideoActiveDidChange(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
+        public static NSObject observeIsAirPlayVideoActiveDidChange(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(IsAirPlayVideoActiveDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {
@@ -125,7 +125,7 @@ import org.robovm.rt.annotation.WeaklyLinked;
         /**
          * @since Available in iOS 3.2 and later.
          */
-        public static NSObjectProtocol observeLoadStateDidChange(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
+        public static NSObject observeLoadStateDidChange(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(LoadStateDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {
@@ -136,7 +136,7 @@ import org.robovm.rt.annotation.WeaklyLinked;
         /**
          * @since Available in iOS 3.2 and later.
          */
-        public static NSObjectProtocol observeNowPlayingMovieDidChange(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
+        public static NSObject observeNowPlayingMovieDidChange(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(NowPlayingMovieDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {
@@ -144,7 +144,7 @@ import org.robovm.rt.annotation.WeaklyLinked;
                 }
             });
         }
-        public static NSObjectProtocol observePlaybackDidFinish(MPMoviePlayerController object, final VoidBlock3<MPMoviePlayerController, MPMovieFinishReason, NSError> block) {
+        public static NSObject observePlaybackDidFinish(MPMoviePlayerController object, final VoidBlock3<MPMoviePlayerController, MPMovieFinishReason, NSError> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(PlaybackDidFinishNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {
@@ -158,7 +158,7 @@ import org.robovm.rt.annotation.WeaklyLinked;
         /**
          * @since Available in iOS 3.2 and later.
          */
-        public static NSObjectProtocol observePlaybackStateDidChange(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
+        public static NSObject observePlaybackStateDidChange(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(PlaybackStateDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {
@@ -169,7 +169,7 @@ import org.robovm.rt.annotation.WeaklyLinked;
         /**
          * @since Available in iOS 3.2 and later.
          */
-        public static NSObjectProtocol observeScalingModeDidChange(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
+        public static NSObject observeScalingModeDidChange(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(ScalingModeDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {
@@ -180,7 +180,7 @@ import org.robovm.rt.annotation.WeaklyLinked;
         /**
          * @since Available in iOS 3.2 and later.
          */
-        public static NSObjectProtocol observeThumbnailImageRequestDidFinish(MPMoviePlayerController object, final VoidBlock2<MPMoviePlayerController, MPMoviePlayerThumbnailRequest> block) {
+        public static NSObject observeThumbnailImageRequestDidFinish(MPMoviePlayerController object, final VoidBlock2<MPMoviePlayerController, MPMoviePlayerThumbnailRequest> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(ThumbnailImageRequestDidFinishNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {
@@ -191,7 +191,7 @@ import org.robovm.rt.annotation.WeaklyLinked;
         /**
          * @since Available in iOS 3.2 and later.
          */
-        public static NSObjectProtocol observeWillEnterFullscreen(MPMoviePlayerController object, final VoidBlock2<MPMoviePlayerController, MPMoviePlayerFullscreenAnimation> block) {
+        public static NSObject observeWillEnterFullscreen(MPMoviePlayerController object, final VoidBlock2<MPMoviePlayerController, MPMoviePlayerFullscreenAnimation> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(WillEnterFullscreenNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {
@@ -202,7 +202,7 @@ import org.robovm.rt.annotation.WeaklyLinked;
         /**
          * @since Available in iOS 3.2 and later.
          */
-        public static NSObjectProtocol observeWillExitFullscreen(MPMoviePlayerController object, final VoidBlock2<MPMoviePlayerController, MPMoviePlayerFullscreenAnimation> block) {
+        public static NSObject observeWillExitFullscreen(MPMoviePlayerController object, final VoidBlock2<MPMoviePlayerController, MPMoviePlayerFullscreenAnimation> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(WillExitFullscreenNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {
@@ -213,7 +213,7 @@ import org.robovm.rt.annotation.WeaklyLinked;
         /**
          * @since Available in iOS 3.2 and later.
          */
-        public static NSObjectProtocol observeNewSourceTypeAvailable(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
+        public static NSObject observeNewSourceTypeAvailable(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(SourceTypeAvailableNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {
@@ -224,7 +224,7 @@ import org.robovm.rt.annotation.WeaklyLinked;
         /**
          * @since Available in iOS 6.0 and later.
          */
-        public static NSObjectProtocol observeReadyForDisplayDidChange(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
+        public static NSObject observeReadyForDisplayDidChange(MPMoviePlayerController object, final VoidBlock1<MPMoviePlayerController> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(ReadyForDisplayDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {
@@ -235,7 +235,7 @@ import org.robovm.rt.annotation.WeaklyLinked;
         /**
          * @since Available in iOS 4.0 and later.
          */
-        public static NSObjectProtocol observeTimedMetadataUpdated(MPMoviePlayerController object, final VoidBlock2<MPMoviePlayerController, NSArray<MPTimedMetadata>> block) {
+        public static NSObject observeTimedMetadataUpdated(MPMoviePlayerController object, final VoidBlock2<MPMoviePlayerController, NSArray<MPTimedMetadata>> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(TimedMetadataUpdatedNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @SuppressWarnings("unchecked")
                 @Override

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/mediaplayer/MPMusicPlayerController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/mediaplayer/MPMusicPlayerController.java
@@ -45,7 +45,7 @@ import org.robovm.apple.coreanimation.*;
         /**
          * @since Available in iOS 3.2 and later.
          */
-        public static NSObjectProtocol observeIsPreparedToPlayDidChange(MPMusicPlayerController object, final VoidBlock1<MPMediaPlayback> block) {
+        public static NSObject observeIsPreparedToPlayDidChange(MPMusicPlayerController object, final VoidBlock1<MPMediaPlayback> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(IsPreparedToPlayDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {
@@ -53,7 +53,7 @@ import org.robovm.apple.coreanimation.*;
                 }
             });
         }
-        public static NSObjectProtocol observePlaybackStateDidChange(MPMusicPlayerController object, final VoidBlock1<MPMusicPlayerController> block) {
+        public static NSObject observePlaybackStateDidChange(MPMusicPlayerController object, final VoidBlock1<MPMusicPlayerController> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(PlaybackStateDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {
@@ -61,7 +61,7 @@ import org.robovm.apple.coreanimation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeNowPlayingItemDidChange(MPMusicPlayerController object, final VoidBlock1<MPMusicPlayerController> block) {
+        public static NSObject observeNowPlayingItemDidChange(MPMusicPlayerController object, final VoidBlock1<MPMusicPlayerController> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(NowPlayingItemDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {
@@ -69,7 +69,7 @@ import org.robovm.apple.coreanimation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeVolumeDidChange(MPMusicPlayerController object, final VoidBlock1<MPMusicPlayerController> block) {
+        public static NSObject observeVolumeDidChange(MPMusicPlayerController object, final VoidBlock1<MPMusicPlayerController> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(VolumeDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/mediaplayer/MPVolumeView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/mediaplayer/MPVolumeView.java
@@ -45,7 +45,7 @@ import org.robovm.apple.coreanimation.*;
         /**
          * @since Available in iOS 7.0 and later.
          */
-        public static NSObjectProtocol observeWirelessRoutesAvailableDidChange(MPVolumeView object, final VoidBlock1<MPVolumeView> block) {
+        public static NSObject observeWirelessRoutesAvailableDidChange(MPVolumeView object, final VoidBlock1<MPVolumeView> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(WirelessRoutesAvailableDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {
@@ -56,7 +56,7 @@ import org.robovm.apple.coreanimation.*;
         /**
          * @since Available in iOS 7.0 and later.
          */
-        public static NSObjectProtocol observeWirelessRouteActiveDidChange(MPVolumeView object, final VoidBlock1<MPVolumeView> block) {
+        public static NSObject observeWirelessRouteActiveDidChange(MPVolumeView object, final VoidBlock1<MPVolumeView> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(WirelessRouteActiveDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/messageui/MFMessageComposeViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/messageui/MFMessageComposeViewController.java
@@ -44,7 +44,7 @@ import org.robovm.apple.messages.*;
         /**
          * @since Available in iOS 5.0 and later.
          */
-        public static NSObjectProtocol observeTextMessageAvailabilityDidChange(final VoidBlock1<Boolean> block) {
+        public static NSObject observeTextMessageAvailabilityDidChange(final VoidBlock1<Boolean> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(TextMessageAvailabilityDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/networkextension/NEVPNConnection.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/networkextension/NEVPNConnection.java
@@ -44,7 +44,7 @@ import org.robovm.apple.network.*;
         /**
          * @since Available in iOS 8.0 and later.
          */
-        public static NSObjectProtocol observeStatusDidChange(NEVPNConnection object, final VoidBlock1<NEVPNConnection> block) {
+        public static NSObject overseStatusDidChange(NEVPNConnection object, final VoidBlock1<NEVPNConnection> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(StatusDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/networkextension/NEVPNManager.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/networkextension/NEVPNManager.java
@@ -44,7 +44,7 @@ import org.robovm.apple.network.*;
         /**
          * @since Available in iOS 8.0 and later.
          */
-        public static NSObjectProtocol observeConfigurationChange(final Runnable block) {
+        public static NSObject observeConfigurationChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(ConfigurationChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/newsstandkit/NKIssue.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/newsstandkit/NKIssue.java
@@ -41,7 +41,7 @@ import org.robovm.apple.foundation.*;
     /*<implements>*//*</implements>*/ {
     
     public static class Notifications {
-        public static NSObjectProtocol observeDownloadCompleted(NKIssue object, final VoidBlock1<NKIssue> block) {
+        public static NSObject observeDownloadCompleted(NKIssue object, final VoidBlock1<NKIssue> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DownloadCompletedNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/passkit/PKPassLibrary.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/passkit/PKPassLibrary.java
@@ -44,7 +44,7 @@ import org.robovm.apple.coreanimation.*;
     /*<implements>*//*</implements>*/ {
 
     public static class Notifications {
-        public static NSObjectProtocol observeDidChange(final VoidBlock1<PKPassLibraryNotification> block) {
+        public static NSObject observeDidChange(final VoidBlock1<PKPassLibraryNotification> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {
@@ -57,7 +57,7 @@ import org.robovm.apple.coreanimation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeRemotePaymentPassesDidChange(final VoidBlock1<PKPassLibraryNotification> block) {
+        public static NSObject observeRemotePaymentPassesDidChange(final VoidBlock1<PKPassLibraryNotification> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(RemotePaymentPassesDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke (NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSTextStorage.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSTextStorage.java
@@ -53,7 +53,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 7.0 and later.
          */
-        public static NSObjectProtocol observeWillProcessEditing(NSTextStorage object, final VoidBlock1<NSTextStorage> block) {
+        public static NSObject observeWillProcessEditing(NSTextStorage object, final VoidBlock1<NSTextStorage> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(WillProcessEditingNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -64,7 +64,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 7.0 and later.
          */
-        public static NSObjectProtocol observeDidProcessEditing(NSTextStorage object, final VoidBlock1<NSTextStorage> block) {
+        public static NSObject observeDidProcessEditing(NSTextStorage object, final VoidBlock1<NSTextStorage> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidProcessEditingNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibility.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibility.java
@@ -52,7 +52,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 9.0 and later.
          */
-        public static NSObjectProtocol observeElementFocused(final Runnable block) {
+        public static NSObject observeElementFocused(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(UIAccessibilityGlobals.ElementFocusedNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -63,7 +63,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 6.0 and later.
          */
-        public static NSObjectProtocol observeAnnouncementDidFinish(final VoidBlock2<String, Boolean> block) {
+        public static NSObject observeAnnouncementDidFinish(final VoidBlock2<String, Boolean> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(UIAccessibilityGlobals.AnnouncementDidFinishNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -77,7 +77,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 5.0 and later.
          */
-        public static NSObjectProtocol observeMonoAudioStatusDidChange(final Runnable block) {
+        public static NSObject observeMonoAudioStatusDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(UIAccessibilityGlobals.MonoAudioStatusDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -88,7 +88,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 5.0 and later.
          */
-        public static NSObjectProtocol observeClosedCaptioningStatusDidChange(final Runnable block) {
+        public static NSObject observeClosedCaptioningStatusDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(UIAccessibilityGlobals.ClosedCaptioningStatusDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -99,7 +99,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 6.0 and later.
          */
-        public static NSObjectProtocol observeInvertColorsStatusDidChange(final Runnable block) {
+        public static NSObject observeInvertColorsStatusDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(UIAccessibilityGlobals.InvertColorsStatusDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -110,7 +110,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 6.0 and later.
          */
-        public static NSObjectProtocol observeGuidedAccessStatusDidChange(final Runnable block) {
+        public static NSObject observeGuidedAccessStatusDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(UIAccessibilityGlobals.GuidedAccessStatusDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -121,7 +121,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 4.0 and later.
          */
-        public static NSObjectProtocol observeVoiceOverStatusChanged(final Runnable block) {
+        public static NSObject observeVoiceOverStatusChanged(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(UIAccessibilityGlobals.VoiceOverStatusChangedNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -132,7 +132,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 8.0 and later.
          */
-        public static NSObjectProtocol observeBoldTextStatusDidChange(final Runnable block) {
+        public static NSObject observeBoldTextStatusDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(UIAccessibilityGlobals.BoldTextStatusDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -143,7 +143,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 8.0 and later.
          */
-        public static NSObjectProtocol observeGrayscaleStatusDidChange(final Runnable block) {
+        public static NSObject observeGrayscaleStatusDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(UIAccessibilityGlobals.GrayscaleStatusDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -154,7 +154,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 8.0 and later.
          */
-        public static NSObjectProtocol observeReduceTransparencyStatusDidChange(final Runnable block) {
+        public static NSObject observeReduceTransparencyStatusDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(UIAccessibilityGlobals.ReduceTransparencyStatusDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -165,7 +165,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 8.0 and later.
          */
-        public static NSObjectProtocol observeReduceMotionStatusDidChange(final Runnable block) {
+        public static NSObject observeReduceMotionStatusDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(UIAccessibilityGlobals.ReduceMotionStatusDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -176,7 +176,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 8.0 and later.
          */
-        public static NSObjectProtocol observeDarkerSystemColorsStatusDidChange(final Runnable block) {
+        public static NSObject observeDarkerSystemColorsStatusDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(UIAccessibilityGlobals.DarkerSystemColorsStatusDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -187,7 +187,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 8.0 and later.
          */
-        public static NSObjectProtocol observeSwitchControlStatusDidChange(final Runnable block) {
+        public static NSObject observeSwitchControlStatusDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(UIAccessibilityGlobals.SwitchControlStatusDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -198,7 +198,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 8.0 and later.
          */
-        public static NSObjectProtocol observeSpeakSelectionStatusDidChange(final Runnable block) {
+        public static NSObject observeSpeakSelectionStatusDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(UIAccessibilityGlobals.SpeakSelectionStatusDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -209,7 +209,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 8.0 and later.
          */
-        public static NSObjectProtocol observeSpeakScreenStatusDidChange(final Runnable block) {
+        public static NSObject observeSpeakScreenStatusDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(UIAccessibilityGlobals.SpeakScreenStatusDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -220,7 +220,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 9.0 and later.
          */
-        public static NSObjectProtocol observeShakeToUndoDidChange(final Runnable block) {
+        public static NSObject observeShakeToUndoDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(UIAccessibilityGlobals.ShakeToUndoDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplication.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplication.java
@@ -53,7 +53,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 4.0 and later.
          */
-        public static NSObjectProtocol observeDidEnterBackground(final Runnable block) {
+        public static NSObject observeDidEnterBackground(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidEnterBackgroundNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -64,7 +64,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 4.0 and later.
          */
-        public static NSObjectProtocol observeWillEnterForeground(final Runnable block) {
+        public static NSObject observeWillEnterForeground(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(WillEnterForegroundNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -72,7 +72,7 @@ import org.robovm.apple.linkpresentation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeDidFinishLaunching(final VoidBlock1<UIApplicationLaunchOptions> block) {
+        public static NSObject observeDidFinishLaunching(final VoidBlock1<UIApplicationLaunchOptions> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidFinishLaunchingNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -84,7 +84,7 @@ import org.robovm.apple.linkpresentation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeDidBecomeActive(final Runnable block) {
+        public static NSObject observeDidBecomeActive(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidBecomeActiveNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -92,7 +92,7 @@ import org.robovm.apple.linkpresentation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeWillResignActive(final Runnable block) {
+        public static NSObject observeWillResignActive(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(WillResignActiveNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -100,7 +100,7 @@ import org.robovm.apple.linkpresentation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeDidReceiveMemoryWarning(final Runnable block) {
+        public static NSObject observeDidReceiveMemoryWarning(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidReceiveMemoryWarningNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -108,7 +108,7 @@ import org.robovm.apple.linkpresentation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeWillTerminate(final Runnable block) {
+        public static NSObject observeWillTerminate(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(WillTerminateNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -116,7 +116,7 @@ import org.robovm.apple.linkpresentation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeSignificantTimeChange(final Runnable block) {
+        public static NSObject observeSignificantTimeChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(SignificantTimeChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -124,7 +124,7 @@ import org.robovm.apple.linkpresentation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeWillChangeStatusBarOrientation(final VoidBlock1<UIInterfaceOrientation> block) {
+        public static NSObject observeWillChangeStatusBarOrientation(final VoidBlock1<UIInterfaceOrientation> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(WillChangeStatusBarOrientationNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -133,7 +133,7 @@ import org.robovm.apple.linkpresentation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeDidChangeStatusBarOrientation(final VoidBlock1<UIInterfaceOrientation> block) {
+        public static NSObject observeDidChangeStatusBarOrientation(final VoidBlock1<UIInterfaceOrientation> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidChangeStatusBarOrientationNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -142,7 +142,7 @@ import org.robovm.apple.linkpresentation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeWillChangeStatusBarFrame(final VoidBlock1<CGRect> block) {
+        public static NSObject observeWillChangeStatusBarFrame(final VoidBlock1<CGRect> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(WillChangeStatusBarFrameNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -151,7 +151,7 @@ import org.robovm.apple.linkpresentation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeDidChangeStatusBarFrame(final VoidBlock1<CGRect> block) {
+        public static NSObject observeDidChangeStatusBarFrame(final VoidBlock1<CGRect> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidChangeStatusBarFrameNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -163,7 +163,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 7.0 and later.
          */
-        public static NSObjectProtocol observeBackgroundRefreshStatusDidChange(final Runnable block) {
+        public static NSObject observeBackgroundRefreshStatusDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(BackgroundRefreshStatusDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -174,7 +174,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 4.0 and later.
          */
-        public static NSObjectProtocol observeProtectedDataWillBecomeUnavailable(final Runnable block) {
+        public static NSObject observeProtectedDataWillBecomeUnavailable(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(ProtectedDataWillBecomeUnavailableNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -185,7 +185,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 4.0 and later.
          */
-        public static NSObjectProtocol observeProtectedDataDidBecomeAvailable(final Runnable block) {
+        public static NSObject observeProtectedDataDidBecomeAvailable(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(ProtectedDataDidBecomeAvailableNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -196,7 +196,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 7.0 and later.
          */
-        public static NSObjectProtocol observeContentSizeCategoryDidChange(final VoidBlock1<UIContentSizeCategory> block) {
+        public static NSObject observeContentSizeCategoryDidChange(final VoidBlock1<UIContentSizeCategory> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(ContentSizeCategoryDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -208,7 +208,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 7.0 and later.
          */
-        public static NSObjectProtocol observeUserDidTakeScreenshot(final Runnable block) {
+        public static NSObject observeUserDidTakeScreenshot(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(UserDidTakeScreenshotNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDevice.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDevice.java
@@ -50,7 +50,7 @@ import org.robovm.apple.linkpresentation.*;
     /*<implements>*//*</implements>*/ {
 
     public static class Notifications {
-        public static NSObjectProtocol observeOrientationDidChange(final Runnable block) {
+        public static NSObject observeOrientationDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(OrientationDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -61,7 +61,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 3.0 and later.
          */
-        public static NSObjectProtocol observeBatteryStateDidChange(final Runnable block) {
+        public static NSObject observeBatteryStateDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(BatteryStateDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -72,7 +72,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 3.0 and later.
          */
-        public static NSObjectProtocol observeBatteryLevelDidChange(final Runnable block) {
+        public static NSObject observeBatteryLevelDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(BatteryLevelDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -83,7 +83,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 3.0 and later.
          */
-        public static NSObjectProtocol observeProximityStateDidChange(final Runnable block) {
+        public static NSObject observeProximityStateDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(ProximityStateDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDocument.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDocument.java
@@ -53,7 +53,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 5.0 and later.
          */
-        public static NSObjectProtocol observeStateChanged(UIDocument object, final VoidBlock1<UIDocument> block) {
+        public static NSObject observeStateChanged(UIDocument object, final VoidBlock1<UIDocument> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(StateChangedNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMenuController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMenuController.java
@@ -50,7 +50,7 @@ import org.robovm.apple.linkpresentation.*;
     /*<implements>*//*</implements>*/ {
 
     public static class Notifications {
-        public static NSObjectProtocol observeWillShowMenu(final Runnable block) {
+        public static NSObject observeWillShowMenu(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(WillShowMenuNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -58,7 +58,7 @@ import org.robovm.apple.linkpresentation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeDidShowMenu(final Runnable block) {
+        public static NSObject observeDidShowMenu(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidShowMenuNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -66,7 +66,7 @@ import org.robovm.apple.linkpresentation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeWillHideMenu(final Runnable block) {
+        public static NSObject observeWillHideMenu(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(WillHideMenuNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -74,7 +74,7 @@ import org.robovm.apple.linkpresentation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeDidHideMenu(final Runnable block) {
+        public static NSObject observeDidHideMenu(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidHideMenuNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -82,7 +82,7 @@ import org.robovm.apple.linkpresentation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeMenuFrameDidChange(final Runnable block) {
+        public static NSObject observeMenuFrameDidChange(final Runnable block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(MenuFrameDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPasteboard.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPasteboard.java
@@ -50,7 +50,7 @@ import org.robovm.apple.linkpresentation.*;
     /*<implements>*//*</implements>*/ {
 
     public static class Notifications {
-        public static NSObjectProtocol observeChanged(UIPasteboard object, final VoidBlock2<UIPasteboard, UIPasteboardChangedNotification> block) {
+        public static NSObject observeChanged(UIPasteboard object, final VoidBlock2<UIPasteboard, UIPasteboardChangedNotification> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(ChangedNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -64,7 +64,7 @@ import org.robovm.apple.linkpresentation.*;
             });
         }
         
-        public static NSObjectProtocol observeRemoved(UIPasteboard object, final VoidBlock1<UIPasteboard> block) {
+        public static NSObject observeRemoved(UIPasteboard object, final VoidBlock1<UIPasteboard> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(RemovedNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIScreen.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIScreen.java
@@ -53,7 +53,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 3.2 and later.
          */
-        public static NSObjectProtocol observeDidConnect(final VoidBlock1<UIScreen> block) {
+        public static NSObject observeDidConnect(final VoidBlock1<UIScreen> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidConnectNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -64,7 +64,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 3.2 and later.
          */
-        public static NSObjectProtocol observeDidDisconnect(final VoidBlock1<UIScreen> block) {
+        public static NSObject observeDidDisconnect(final VoidBlock1<UIScreen> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidDisconnectNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -75,7 +75,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 3.2 and later.
          */
-        public static NSObjectProtocol observeModeDidChange(final VoidBlock1<UIScreen> block) {
+        public static NSObject observeModeDidChange(final VoidBlock1<UIScreen> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(ModeDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -86,7 +86,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 5.0 and later.
          */
-        public static NSObjectProtocol observeBrightnessDidChange(final VoidBlock1<UIScreen> block) {
+        public static NSObject observeBrightnessDidChange(final VoidBlock1<UIScreen> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(BrightnessDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableView.java
@@ -50,7 +50,7 @@ import org.robovm.apple.linkpresentation.*;
     /*<implements>*/implements NSCoding, UIDataSourceTranslating, UISpringLoadedInteractionSupporting/*</implements>*/ {
 
     public static class Notifications {
-        public static NSObjectProtocol observeSelectionDidChange(UITableView object, final VoidBlock1<UITableView> block) {
+        public static NSObject observeSelectionDidChange(UITableView object, final VoidBlock1<UITableView> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(SelectionDidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextField.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextField.java
@@ -52,7 +52,7 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
     /*<implements>*/implements UITextInput, NSCoding, UIContentSizeCategoryAdjusting, UITextDraggable, UITextDroppable, UITextPasteConfigurationSupporting/*</implements>*/ {
 
     public static class Notifications {
-        public static NSObjectProtocol observeDidBeginEditing(UITextField object, final VoidBlock1<UITextField> block) {
+        public static NSObject observeDidBeginEditing(UITextField object, final VoidBlock1<UITextField> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidBeginEditingNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -60,7 +60,7 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
                 }
             });
         }
-        public static NSObjectProtocol observeDidEndEditing(UITextField object, final VoidBlock1<UITextField> block) {
+        public static NSObject observeDidEndEditing(UITextField object, final VoidBlock1<UITextField> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidEndEditingNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -68,7 +68,7 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
                 }
             });
         }
-        public static NSObjectProtocol observeTextDidChange(UITextField object, final VoidBlock1<UITextField> block) {
+        public static NSObject observeTextDidChange(UITextField object, final VoidBlock1<UITextField> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextInputMode.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextInputMode.java
@@ -53,7 +53,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 4.2 and later.
          */
-        public static NSObjectProtocol observeCurrentModeDidChange(final VoidBlock1<UITextInputMode> block) {
+        public static NSObject observeCurrentModeDidChange(final VoidBlock1<UITextInputMode> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(CurrentInputModeDidChange(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextView.java
@@ -52,7 +52,7 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
     /*<implements>*/implements UITextInput, UIContentSizeCategoryAdjusting, UITextDraggable, UITextDroppable, UITextPasteConfigurationSupporting/*</implements>*/ {
 
     public static class Notifications {
-        public static NSObjectProtocol observeDidBeginEditing(UITextView object, final VoidBlock1<UITextView> block) {
+        public static NSObject observeDidBeginEditing(UITextView object, final VoidBlock1<UITextView> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidBeginEditingNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -60,7 +60,7 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
                 }
             });
         }
-        public static NSObjectProtocol observeTextDidChangeEditing(UITextView object, final VoidBlock1<UITextView> block) {
+        public static NSObject observeTextDidChangeEditing(UITextView object, final VoidBlock1<UITextView> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidChangeNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -68,7 +68,7 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
                 }
             });
         }
-        public static NSObjectProtocol observeDidEndEditing(UITextView object, final VoidBlock1<UITextView> block) {
+        public static NSObject observeDidEndEditing(UITextView object, final VoidBlock1<UITextView> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidEndEditingNotification(), object, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewController.java
@@ -55,7 +55,7 @@ import org.robovm.apple.mediaplayer.MPMoviePlayerViewController;
         /**
          * @since Available in iOS 8.0 and later.
          */
-        public static NSObjectProtocol observeDidEnterBackground(UIViewController object, final VoidBlock1<UIViewController> block) {
+        public static NSObject observeDidEnterBackground(UIViewController object, final VoidBlock1<UIViewController> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(ShowDetailTargetDidChangeNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIWindow.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIWindow.java
@@ -50,7 +50,7 @@ import org.robovm.apple.linkpresentation.*;
     /*<implements>*//*</implements>*/ {
 
     public static class Notifications {
-        public static NSObjectProtocol observeDidBecomeVisible(final VoidBlock1<UIWindow> block) {
+        public static NSObject observeDidBecomeVisible(final VoidBlock1<UIWindow> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidBecomeVisibleNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -58,7 +58,7 @@ import org.robovm.apple.linkpresentation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeDidBecomeHidden(final VoidBlock1<UIWindow> block) {
+        public static NSObject observeDidBecomeHidden(final VoidBlock1<UIWindow> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidBecomeHiddenNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -66,7 +66,7 @@ import org.robovm.apple.linkpresentation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeDidBecomeKey(final VoidBlock1<UIWindow> block) {
+        public static NSObject observeDidBecomeKey(final VoidBlock1<UIWindow> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidBecomeKeyNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -74,7 +74,7 @@ import org.robovm.apple.linkpresentation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeDidResignKey(final VoidBlock1<UIWindow> block) {
+        public static NSObject observeDidResignKey(final VoidBlock1<UIWindow> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(DidResignKeyNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -82,7 +82,7 @@ import org.robovm.apple.linkpresentation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeKeyboardWillShow(final VoidBlock1<UIKeyboardAnimation> block) {
+        public static NSObject observeKeyboardWillShow(final VoidBlock1<UIKeyboardAnimation> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(KeyboardWillShowNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -90,7 +90,7 @@ import org.robovm.apple.linkpresentation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeKeyboardDidShow(final VoidBlock1<UIKeyboardAnimation> block) {
+        public static NSObject observeKeyboardDidShow(final VoidBlock1<UIKeyboardAnimation> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(KeyboardDidShowNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -98,7 +98,7 @@ import org.robovm.apple.linkpresentation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeKeyboardWillHide(final VoidBlock1<UIKeyboardAnimation> block) {
+        public static NSObject observeKeyboardWillHide(final VoidBlock1<UIKeyboardAnimation> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(KeyboardWillHideNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -106,7 +106,7 @@ import org.robovm.apple.linkpresentation.*;
                 }
             });
         }
-        public static NSObjectProtocol observeKeyboardDidHide(final VoidBlock1<UIKeyboardAnimation> block) {
+        public static NSObject observeKeyboardDidHide(final VoidBlock1<UIKeyboardAnimation> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(KeyboardDidHideNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -117,7 +117,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 5.0 and later.
          */
-        public static NSObjectProtocol observeKeyboardWillChangeFrame(final VoidBlock1<UIKeyboardAnimation> block) {
+        public static NSObject observeKeyboardWillChangeFrame(final VoidBlock1<UIKeyboardAnimation> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(KeyboardWillChangeFrameNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {
@@ -128,7 +128,7 @@ import org.robovm.apple.linkpresentation.*;
         /**
          * @since Available in iOS 5.0 and later.
          */
-        public static NSObjectProtocol observeKeyboardDidChangeFrame(final VoidBlock1<UIKeyboardAnimation> block) {
+        public static NSObject observeKeyboardDidChangeFrame(final VoidBlock1<UIKeyboardAnimation> block) {
             return NSNotificationCenter.getDefaultCenter().addObserver(KeyboardDidChangeFrameNotification(), null, NSOperationQueue.getMainQueue(), new VoidBlock1<NSNotification>() {
                 @Override
                 public void invoke(NSNotification a) {


### PR DESCRIPTION
PR #632 already reverted NSObjectProtocol back to NSObject using regenerated bindings by bro-gen.
But there was amount of manual changes, and this the fix is to revert corresponding commit:
https://github.com/MobiVM/robovm/pull/613/commits/002b53bd4db624c01af961490c7f5b856a48f533