### PR TITLE
* fixed: (regression) functions are generated as strong and this breaks tree-shaking.

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/AbstractMethodCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/AbstractMethodCompiler.java
@@ -86,7 +86,7 @@ public abstract class AbstractMethodCompiler {
     protected abstract Function doCompile(ModuleBuilder moduleBuilder, SootMethod method);
 
     protected Function createMethodFunction(SootMethod method) {
-        return FunctionBuilder.method(method, false);
+        return FunctionBuilder.method(method, true);
     }
 
     private void compileSynchronizedWrapper(ModuleBuilder moduleBuilder, SootMethod method) {


### PR DESCRIPTION
fix for #699 

root case: introduced by removing x86 arch https://github.com/MobiVM/robovm/pull/695

error message sample:
```
duplicate symbol '_[J]sun.misc.Unsafe.putLongVolatile(Ljava/lang/Object;JJ)V' in:
[ERROR] 12:44:48.131     ~/alpods-failure-test/ios/robovm-build/tmp/iOS/ios/arm64-simulator/linker2.o
[ERROR] 12:44:48.131     ~/.robovm/cache/ios/arm64-simulator/release/Users/dkimitsa/robovm-m1/compiler/rt/target/robovm-rt-2.3.19-SNAPSHOT.jar/sun/misc/Unsafe.class.o
```