### PR TITLE
* fixed: Failure to strip archive should not be silent

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
@@ -911,6 +911,7 @@ public abstract class AbstractTarget implements Target {
         } catch (IOException e) {
             IOUtils.closeQuietly(out);
             output.delete();
+            config.getLogger().error("Filed to strip archive file %s due %s", output, e.getMessage());
         } finally {
             IOUtils.closeQuietly(out);
         }


### PR DESCRIPTION
now it produce error log output without stopping of build
> [ERROR] 16:27:58.844 Filed to strip archive file lib/gdx-1.10.1-wheelergames-SNAPSHOT.jar due duplicate entry: com/badlogic/gdx.gwt.xml