### PR TITLE
* fixed: Idea 2023.1 EAP Beta -- RoboVM log failed to be created

### DIFF
--- a/plugins/idea/src/main/java/org/robovm/idea/RoboVmPlugin.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/RoboVmPlugin.java
@@ -249,9 +249,11 @@ public class RoboVmPlugin {
             @Override
             public void toolWindowRegistered(@NotNull String id) {
                 if (id.equals(RoboVmToolWindowFactory.ID)) {
-                    ConsoleView consoleView = getConsoleView(project);
-                    if (consoleView != null)
-                        dumpUnprintedMessages(consoleView);
+                    UIUtil.invokeLaterIfNeeded(() -> {
+                        ConsoleView consoleView = getConsoleView(project);
+                        if (consoleView != null)
+                            dumpUnprintedMessages(consoleView);
+                    });
                 }
             }
         });


### PR DESCRIPTION
Root case: Access is allowed from Event Dispatch Thread (EDT) only
```
Caused by: com.intellij.openapi.diagnostic.RuntimeExceptionWithAttachments: Access is allowed from Event Dispatch Thread (EDT) only; see https://jb.gg/ij-platform-threading for details
Current thread: Thread[DefaultDispatcher-worker-24 @initFrame#462,5,main] 386176022 (EventQueue.isDispatchThread()=false)
SystemEventQueueThread: Thread[AWT-EventQueue-0,6,main] 1034080717
	at com.intellij.openapi.application.impl.ApplicationImpl.throwThreadAccessException(ApplicationImpl.java:1046)
	at com.intellij.openapi.application.impl.ApplicationImpl.assertIsDispatchThread(ApplicationImpl.java:1033)
	at com.intellij.execution.impl.ConsoleViewImpl.getComponent(ConsoleViewImpl.java:429)
	at org.robovm.idea.components.RoboVmToolWindowFactory$MyContent.<init>(RoboVmToolWindowFactory.java:35)
	at org.robovm.idea.components.RoboVmToolWindowFactory.createToolWindowContent(RoboVmToolWindowFactory.java:23)
	at com.intellij.openapi.wm.impl.ToolWindowImpl.createContentIfNeeded(ToolWindowImpl.kt:548)
	at com.intellij.openapi.wm.impl.ToolWindowImpl.getContentManager(ToolWindowImpl.kt:421)
	at org.robovm.idea.RoboVmPlugin.getConsoleView(RoboVmPlugin.java:165)
	at org.robovm.idea.RoboVmPlugin.getConsoleView(RoboVmPlugin.java:175)
	at org.robovm.idea.RoboVmPlugin.access$100(RoboVmPlugin.java:81)
	at org.robovm.idea.RoboVmPlugin$3.toolWindowRegistered(RoboVmPlugin.java:252)
```