### PR TITLE
* web links updated, disabled update check

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Build Status](https://github.com/MobiVM/robovm/actions/workflows/build.yml/badge.svg)
 
 
-[**Website**](http://robovm.mobidevelop.com) -
+[**Website**](https://mobivm.github.io) -
 [**Developer Guide**](https://github.com/MobiVM/robovm/wiki/Developer-Guide) -
 [**Changelog**](https://github.com/MobiVM/robovm/wiki/Changelog) -
 [**RoboPods**](https://github.com/MobiVM/robovm-robopods) -
@@ -15,7 +15,7 @@ This is a fork of the [last open-source release of RoboVM](https://github.com/ro
 
 ## Key Features
 
-**iOS 12 and XCode 10** are fully supported.
+**iOS 16 and XCode 14** are fully supported.
 
 **Interface Builder Integration** is also available, details in [this wiki article](https://github.com/MobiVM/robovm/wiki/Is-XCode-interface-builder-supported%3F).
 

--- a/compiler/compiler/src/main/java/org/robovm/compiler/AppCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/AppCompiler.java
@@ -496,7 +496,9 @@ public class AppCompiler {
     }
 
     private void compile() throws IOException {
-        updateCheck();
+        // FIXME: dkimitsa -- update check is disabled as facility is not available anymore and due GDRP related
+        //        moments
+        // updateCheck();
 
         //Let's look, if we really need to recompile
         if (needsRecompilation(config)) {

--- a/plugins/idea/README.md
+++ b/plugins/idea/README.md
@@ -10,14 +10,14 @@ Not supported any more due removed `-extdir` in Java9+
 
 ### Development with Maven 
 * Install recent *Intellij IDEA Community Edition * under /Applications/Intellij IDEA CE.app/ (https://download.jetbrains.com/idea/)
-* Install this plugin, it allows us to use Maven for plugin development https://plugins.jetbrains.com/plugin/7127?pr=
+* Install this plugin, it allows us to use [Maven for plugin development](https://plugins.jetbrains.com/plugin/7127?pr=). *Note*: outdated and might not work for recent versions of Idea, open source alternative is available at [dkimitsa/support-maven-devkit-plugins](https://github.com/dkimitsa/support-maven-devkit-plugins).   
 * Clone this repo https://github.com/JetBrains/intellij-community.git
 * Checkout the branch that corresponds to the respective IDEA version you installed, e.g. 139 for Idea 14.0.x, see http://www.jetbrains.org/pages/viewpage.action?pageId=983225
 * Open Intellij IDEA CE, setup the IDEA sdk pointing it at your IDEA installation. Add source path to root of repo cloned above. Also add following JARs to SDK from IDEA directory:
- - /Applications/IntelliJ IDEA 2021.2 CE EAP.app/Contents/plugins/maven/lib/maven.jar
- - /Applications/IntelliJ IDEA 2021.2 CE EAP.app/Contents/plugins/gradle/lib/gradle.jar
- - /Applications/IntelliJ IDEA 2021.2 CE EAP.app/Contents/plugins/gradle/lib/gradle-api-7.1.jar
- - /Applications/IntelliJ IDEA 2021.2 CE EAP.app/Contents/plugins/gradle-java/lib/gradle-java.jar
+ - /Applications/IntelliJ IDEA CE.app/Contents/plugins/maven/lib/maven.jar
+ - /Applications/IntelliJ IDEA CE.app/Contents/plugins/gradle/lib/gradle.jar
+ - /Applications/IntelliJ IDEA CE.app/Contents/plugins/gradle/lib/gradle-api-?.?.jar
+ - /Applications/IntelliJ IDEA CE.app/Contents/plugins/gradle-java/lib/gradle-java.jar
 * Open the project by selecting it's POM
 * Open File -> Project Structure, Click on the Project menu entry, and select the IDEA sdk under Project SDK
 * Click OK


### PR DESCRIPTION
- link to http://robovm.mobidevelop.com replaced with https://mobivm.github.io #620
- mentioned recent versions of ios/xcode
- idea plugin readme updated (generic path, mentioned issue with maven project importer)
- disabled version check as endpoint doesn't seem to be working, and we should respect GDPR (e.g. ask user before using)