### PR TITLE
* maintenance -- gradle

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -1779,7 +1779,7 @@ public class Config {
             } catch (IOException | RuntimeException e) {
                 throw e;
             } catch (Exception e) {
-                throw new IOException(e);
+                throw new IOException(e.getLocalizedMessage(), e);
             }
             // <roots> was renamed to <forceLinkClasses> but we still support
             // <roots>. We need to copy <roots> to <forceLinkClasses> and set

--- a/plugins/gradle/README.md
+++ b/plugins/gradle/README.md
@@ -7,29 +7,30 @@ To use the RoboVM plugin, include in your build script:
 ```groovy
 // Pull the plugin from Maven Central
 buildscript {
-    project.ext.roboVMVersion = "2.0.0-SNAPSHOT"
-    project.ext.roboVMGradleVersion = "2.0.0-SNAPSHOT"
-
+    ext.roboVMVersion = "2.3.19-SNAPSHOT"
     repositories {
         mavenCentral()
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     }
     dependencies {
-        classpath group: 'com.mobidevelop.robovm', name: 'robovm-gradle-plugin', version: project.roboVMGradleVersion
+        classpath "com.mobidevelop.robovm:robovm-gradle-plugin:${roboVMVersion}"
     }
 }
+
+apply plugin: 'java'
 
 // Apply the plugin
 apply plugin: 'robovm'
 
 repositories {
+    mavenLocal()
     mavenCentral()
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
 }
 
 dependencies {
-    compile group: 'com.mobidevelop.robovm', name: 'robovm-rt', version: project.roboVMVersion
-    compile group: 'com.mobidevelop.robovm', name: 'robovm-cocoatouch', version: project.roboVMVersion
+    implementation "com.mobidevelop.robovm:robovm-rt:${roboVMVersion}"
+    implementation "com.mobidevelop.robovm:robovm-cocoatouch:${roboVMVersion}"
 }
 
 robovm {

--- a/plugins/gradle/build.gradle
+++ b/plugins/gradle/build.gradle
@@ -112,6 +112,11 @@ shadowJar {
     relocate 'org.objectweb.asm', 'com.mobidevelop.robovm.asm'
 }
 
+// suppress "warning: no comment"
+tasks.withType(Javadoc) {
+    options.addBooleanOption("Xdoclint:-missing", true)
+}
+
 signing {
     required { !version.endsWith('SNAPSHOT') && gradle.taskGraph.hasTask("publish") }
     sign publishing.publications.mavenJava

--- a/plugins/gradle/src/main/java/org/robovm/gradle/RoboVMGradleException.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/RoboVMGradleException.java
@@ -1,0 +1,63 @@
+package org.robovm.gradle;
+
+import org.gradle.api.GradleException;
+
+import javax.annotation.Nullable;
+import java.util.HashSet;
+import java.util.Set;
+
+public class RoboVMGradleException extends GradleException {
+    public RoboVMGradleException() {
+    }
+
+    public RoboVMGradleException(String message) {
+        super(message);
+    }
+
+    public RoboVMGradleException(String message, @Nullable Throwable cause) {
+        super(buildMessage(message, cause), cause);
+    }
+
+    @Override
+    public String getLocalizedMessage() {
+        return super.getLocalizedMessage();
+    }
+
+    private static String buildMessage(String message, Throwable cause) {
+        if (cause == null)
+            return message;
+
+        try {
+            // combine all cause messages into single multi-line string
+            StringBuilder sb = new StringBuilder();
+            sb.append(message);
+            Set<Throwable> visitedCause = new HashSet<>();
+            Throwable c = cause;
+            String lastMessage = message;
+            int deep = 10;
+            while (c != null && !visitedCause.contains(c) && deep > 0) {
+                if (visitedCause.contains(c))
+                    break;
+
+                visitedCause.add(c);
+                deep--;
+                String m = c.getLocalizedMessage();
+                if (m != null && !m.isEmpty() && (lastMessage == null || !lastMessage.equals(m))) {
+                    sb.append('\n');
+                    sb.append(m);
+                    lastMessage = m;
+                }
+
+                if (c instanceof RoboVMGradleException) {
+                    // its localized message has all causes already built, nothing to add there
+                    break;
+                }
+
+                c = c.getCause();
+            }
+            return sb.toString();
+        } catch (Exception ignored) {
+            return message;
+        }
+    }
+}

--- a/plugins/gradle/src/main/java/org/robovm/gradle/RoboVMPlugin.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/RoboVMPlugin.java
@@ -20,17 +20,10 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry;
 import org.robovm.compiler.Version;
-import org.robovm.gradle.tasks.ArchiveTask;
-import org.robovm.gradle.tasks.ConsoleTask;
-import org.robovm.gradle.tasks.IOSDeviceTask;
-import org.robovm.gradle.tasks.IPadSimulatorTask;
-import org.robovm.gradle.tasks.IPhoneSimulatorTask;
-import org.robovm.gradle.tasks.InstallTask;
+import org.robovm.gradle.tasks.*;
 import org.robovm.gradle.tooling.ModelBuilder;
 
 import javax.inject.Inject;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Gradle plugin that extends the Java plugin for RoboVM development.
@@ -55,31 +48,30 @@ public class RoboVMPlugin implements Plugin<Project> {
         registry.register(new ModelBuilder());
 
         project.getExtensions().create(RoboVMPluginExtension.NAME, RoboVMPluginExtension.class, project);
-        project.task(params(IPhoneSimulatorTask.class, "Runs your iOS app in the iPhone simulator"),
-                "launchIPhoneSimulator");
-        project.task(params(IPadSimulatorTask.class,"Runs your iOS app in the iPad simulator"),
-                "launchIPadSimulator");
-        project.task(params(IOSDeviceTask.class, "Runs your iOS app on a connected iOS device."),
-                "launchIOSDevice");
-        project.task(params(ConsoleTask.class, "Runs a console app"),"launchConsole");
-        project.task(params(ArchiveTask.class, "Creates .ipa file. This is an alias for the robovmArchive task"),
-                "createIPA");
-        project.task(params(ArchiveTask.class, "Compiles a binary, archives it in a format suitable for distribution and saves it to build/robovm/"),
-                "robovmArchive");
-        project.task(params(InstallTask.class, "Compiles a binary and installs it to build/robovm/"),
-                "robovmInstall");
+        registerTask(project, "launchIPhoneSimulator", IPhoneSimulatorTask.class,
+                "Runs your iOS app in the iPhone simulator");
+        registerTask(project, "launchIPadSimulator", IPadSimulatorTask.class,
+                "Runs your iOS app in the iPad simulator");
+        registerTask(project, "launchIOSDevice", IOSDeviceTask.class,
+                "Runs your iOS app on a connected iOS device.");
+        registerTask(project, "launchConsole", ConsoleTask.class, "Runs a console app");
+        registerTask(project, "createIPA", ArchiveTask.class,
+                "Creates .ipa file. This is an alias for the robovmArchive task");
+        registerTask(project,"robovmArchive", ArchiveTask.class,
+                "Compiles a binary, archives it in a format suitable for distribution and saves it to build/robovm/");
+        registerTask(project,"robovmInstall", InstallTask.class,
+                "Compiles a binary and installs it to build/robovm/");
     }
 
-    private Map<String, Object> params(Class<? extends  Task> task, String description) {
-        return params(task, description, "build"); // by default depends on build
+
+    private <T extends Task>  void registerTask(Project project, String name, Class<T> type, String description) {
+        registerTask(project, name, type, description, "build");
     }
 
-    private Map<String, Object> params(Class<? extends  Task> task, String description, String... dependencies) {
-        Map<String, Object> params = new HashMap<>();
-        params.put(Task.TASK_TYPE, task);
-        params.put(Task.TASK_DESCRIPTION, description);
-        if (dependencies != null)
-            params.put(Task.TASK_DEPENDS_ON, dependencies);
-        return params;
+    private <T extends Task>  void registerTask(Project project, String name, Class<T> type, String description, String ... dependencies) {
+        project.getTasks().register(name, type, task -> {
+            task.dependsOn((Object[]) dependencies);
+            task.setDescription(description);
+        });
     }
 }

--- a/plugins/gradle/src/main/java/org/robovm/gradle/RoboVMPluginExtension.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/RoboVMPluginExtension.java
@@ -216,10 +216,6 @@ public class RoboVMPluginExtension {
         this.installDir = installDir;
     }
     
-    public String getLicenseKey() {
-        return project.hasProperty("robovm.licenseKey") ? project.getProperties().get("robovm.licenseKey").toString() : null;
-    }
-    
     public void setCachedir(String cacheDir) {
         this.cacheDir = cacheDir;
     }

--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMBuildTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMBuildTask.java
@@ -15,14 +15,14 @@
  */
 package org.robovm.gradle.tasks;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.gradle.api.GradleException;
 import org.robovm.compiler.AppCompiler;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
+import org.robovm.gradle.RoboVMGradleException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 
@@ -54,9 +54,9 @@ public abstract class AbstractRoboVMBuildTask extends AbstractRoboVMTask {
             }
         } catch (IOException e) {
             if (shouldArchive()) {
-                throw new GradleException("Failed to create archive", e);
+                throw new RoboVMGradleException("Failed to create archive", e);
             } else {
-                throw new GradleException("Failed to install", e);
+                throw new RoboVMGradleException("Failed to install", e);
             }
         }
     }

--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractSimulatorTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractSimulatorTask.java
@@ -15,17 +15,16 @@
  */
 package org.robovm.gradle.tasks;
 
-import java.io.File;
-
-import org.gradle.api.GradleException;
+import org.gradle.api.tasks.Internal;
 import org.robovm.compiler.AppCompiler;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
-import org.robovm.compiler.config.Environment;
 import org.robovm.compiler.config.OS;
 import org.robovm.compiler.target.ios.DeviceType;
 import org.robovm.compiler.target.ios.IOSSimulatorLaunchParameters;
-import org.gradle.api.tasks.Internal;
+import org.robovm.gradle.RoboVMGradleException;
+
+import java.io.File;
 
 /**
  *
@@ -56,7 +55,7 @@ public abstract class AbstractSimulatorTask extends AbstractRoboVMTask {
                 }
 
                 if (!isWritable) {
-                    throw new GradleException("Unwritable 'stdoutFifo' specified for RoboVM compile: " + stdoutFifo);
+                    throw new RoboVMGradleException("Unwritable 'stdoutFifo' specified for RoboVM compile: " + stdoutFifo);
                 }
 
                 launchParameters.setStdoutFifo(stdoutFifo);
@@ -74,7 +73,7 @@ public abstract class AbstractSimulatorTask extends AbstractRoboVMTask {
                 }
 
                 if (!isWritable) {
-                    throw new GradleException("Unwritable 'stderrFifo' specified for RoboVM compile: " + stderrFifo);
+                    throw new RoboVMGradleException("Unwritable 'stderrFifo' specified for RoboVM compile: " + stderrFifo);
                 }
 
                 launchParameters.setStderrFifo(stderrFifo);
@@ -82,7 +81,7 @@ public abstract class AbstractSimulatorTask extends AbstractRoboVMTask {
 
             compiler.launch(launchParameters);
         } catch (Throwable t) {
-            throw new GradleException("Failed to launch simulator", t);
+            throw new RoboVMGradleException("Failed to launch simulator", t);
         }
     }
 

--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/ConsoleTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/ConsoleTask.java
@@ -15,14 +15,13 @@
  */
 package org.robovm.gradle.tasks;
 
-import org.gradle.api.GradleException;
 import org.robovm.compiler.AppCompiler;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
-import org.robovm.compiler.config.Environment;
 import org.robovm.compiler.config.OS;
 import org.robovm.compiler.target.ConsoleTarget;
 import org.robovm.compiler.target.LaunchParameters;
+import org.robovm.gradle.RoboVMGradleException;
 
 /**
  *
@@ -42,7 +41,7 @@ public class ConsoleTask extends AbstractRoboVMTask {
             LaunchParameters launchParameters = config.getTarget().createLaunchParameters();
             compiler.launch(launchParameters);
         } catch (Throwable t) {
-            throw new GradleException("Failed to launch console application", t);
+            throw new RoboVMGradleException("Failed to launch console application", t);
         }
     }
 }

--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/IOSDeviceTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/IOSDeviceTask.java
@@ -15,15 +15,13 @@
  */
 package org.robovm.gradle.tasks;
 
-import org.gradle.api.GradleException;
 import org.robovm.compiler.AppCompiler;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
-import org.robovm.compiler.config.Environment;
 import org.robovm.compiler.config.OS;
-import org.robovm.compiler.target.LaunchParameters;
-import org.robovm.compiler.target.ios.IOSTarget;
 import org.robovm.compiler.target.ios.IOSDeviceLaunchParameters;
+import org.robovm.compiler.target.ios.IOSTarget;
+import org.robovm.gradle.RoboVMGradleException;
 
 /**
  *
@@ -51,7 +49,7 @@ public class IOSDeviceTask extends AbstractRoboVMTask {
 			}
             compiler.launch(launchParameters);
         } catch (Throwable t) {
-            throw new GradleException("Failed to launch IOS Device", t);
+            throw new RoboVMGradleException("Failed to launch IOS Device", t);
         }
     }
 }


### PR DESCRIPTION
- closed #701
- removed unused license parameter
- suppressed "warning: no comment" when building gradle plugin
- updated README.md
- displaying info message "Checking for RoboVM SDK (downloading if required)..." as getting SDK files from maven could take a while first time
- introduced RoboVMGradleException that aggregates error messages from cause exceptions, allows to have more detailed output:
```
* What went wrong:
Execution failed for task ':launchIPhoneSimulator'.
> Failed to launch simulator
  Failed to read project RoboVM config file in /Users/dkimitsa/IdeaProjects/empty4del2
  ParseError at [row,col]:[17,7]
  Message: The element type "frameworks" must be terminated by the matching end-tag "</frameworks>".
```
instead of
```
* What went wrong:
Execution failed for task ':launchIPhoneSimulator'.
> Failed to launch simulator
```