### PR TITLE
* readme: badge changed to show status of snapshot build and not pullrequest testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RoboVM 
 
-![Build Status](https://github.com/MobiVM/robovm/actions/workflows/build.yml/badge.svg)
+![Build Status](https://github.com/MobiVM/robovm/actions/workflows/snapshot.yml/badge.svg)
 
 
 [**Website**](https://mobivm.github.io) -


### PR DESCRIPTION
Status of master branch matters not PRs (these can fail and there are multiple of these opened). Failing PR status should not be displayed on root README.md
![sample](https://github.com/MobiVM/robovm/actions/workflows/snapshot.yml/badge.svg)