### PR TITLE
* option to customize arguments passed to linker

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/tools/LinkerOptions.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/tools/LinkerOptions.java
@@ -1,6 +1,4 @@
 /*
- * Copyright (C) 2013-2015 RoboVM AB
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,25 +13,21 @@
  */
 package org.robovm.compiler.config.tools;
 
-import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementList;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
- * 
- * @author blueriverteam
- *
+ * Settings to provide custom linker arguments
+ * @author dkimitsa
  */
-public class Tools {
-    @Element(required = false)
-    private TextureAtlas textureAtlas;
+public class LinkerOptions {
+    @ElementList(required = false, entry = "flag")
+    private ArrayList<String> flags;
 
-    @Element(required = false)
-    private LinkerOptions linker;
-    
-    public TextureAtlas getTextureAtlas() {
-        return textureAtlas;
-    }
-
-    public LinkerOptions getLinker() {
-        return linker;
+    public List<String> getLinkerFlags() {
+        return flags != null ? flags : Collections.emptyList();
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
@@ -261,6 +261,10 @@ public abstract class AbstractTarget implements Target {
             }
         }
 
+        if (config.getTools() != null && config.getTools().getLinker() != null) {
+            ccArgs.addAll(config.getTools().getLinker().getLinkerFlags());
+        }
+
         doBuild(outFile, ccArgs, objectFiles, libs);
         return outFile;
     }


### PR DESCRIPTION
this is being asked time-to-time. usually is is not required as can be covered by robovm, however it might be required for custom builds. 
to be configured using robovm.xml, sample config:
```
<config>

    <tools>
        <linker>
            <flags>
                <flag>-fembed-bitcode</flag>
                <flag>--other-flag</flag>
            </flags>
        </linker>
    </tools>
</config>
```