### PR TITLE
Add support for putDouble and getDouble from Unsafe.

### DIFF
--- a/compiler/rt/libcore/libdvm/src/main/java/sun/misc/Unsafe.java
+++ b/compiler/rt/libcore/libdvm/src/main/java/sun/misc/Unsafe.java
@@ -261,6 +261,15 @@ public final class Unsafe {
     public native byte getByte(Object obj, long offset);
 
     /**
+     * Gets a <code>double</code> field from the given object.
+     *
+     * @param obj non-null; object containing the field
+     * @param offset offset to the field within <code>obj</code>
+     * @return the retrieved value
+     */
+    public native double getDouble(Object obj, long offset);
+
+    /**
      * Stores an <code>int</code> field into the given object.
      *
      * @param obj non-null; object containing the field
@@ -286,6 +295,15 @@ public final class Unsafe {
      * @param newValue the value to store
      */
     public native void putByte(Object obj, long offset, byte newValue);
+
+    /**
+     * Stores a <code>double</code> field into the given object.
+     *
+     * @param obj non-null; object containing the field
+     * @param offset offset to the field within <code>obj</code>
+     * @param newValue the value to store
+     */
+    public native void putDouble(Object obj, long offset, double newValue);
 
     /**
      * Gets an <code>float</code> field from the given object.

--- a/compiler/vm/rt/robovm/sun_misc_Unsafe.c
+++ b/compiler/vm/rt/robovm/sun_misc_Unsafe.c
@@ -110,6 +110,12 @@ jbyte Java_sun_misc_Unsafe_getByte(Env* env, Object* unsafe, Object* obj, jlong 
     return *address;
 }
 
+jdouble Java_sun_misc_Unsafe_getDouble(Env* env, Object* unsafe, Object* obj, jlong offset) {
+    if (!checkNull(env, obj)) return 0;
+    jdouble* address = (jdouble*) getFieldAddress(obj, offset);
+    return *address;
+}
+
 jint Java_sun_misc_Unsafe_getIntVolatile(Env* env, Object* unsafe, Object* obj, jlong offset) {
     if (!checkNull(env, obj)) return 0;
     jint* address = (jint*) getFieldAddress(obj, offset);
@@ -161,6 +167,12 @@ void Java_sun_misc_Unsafe_putBoolean(Env* env, Object* unsafe, Object* obj, jlon
 void Java_sun_misc_Unsafe_putByte(Env* env, Object* unsafe, Object* obj, jlong offset, jbyte newValue) {
     if (!checkNull(env, obj)) return;
     jbyte* address = (jbyte*) getFieldAddress(obj, offset);
+    *address = newValue;
+}
+
+void Java_sun_misc_Unsafe_putDouble(Env* env, Object* unsafe, Object* obj, jlong offset, jdouble newValue) {
+    if (!checkNull(env, obj)) return;
+    jdouble* address = (jdouble*) getFieldAddress(obj, offset);
     *address = newValue;
 }
 


### PR DESCRIPTION
As seen in 9d99692f785588dc18c63f7cbad2ed628e97fc3d , I add a support for double too. I spot this while using Kryo library, quite popular in libGDX world (https://github.com/EsotericSoftware/kryo/blob/master/src/com/esotericsoftware/kryo/serializers/UnsafeField.java#L214).

The change should be quite harmless, but someone more expert then me should really look at it carefully. I'm just proposing a fix, maybe it's wrong, but I'd really appreciate to get this fixed in a way or another... Seems a small feature but has a huge impact in my use case.

Many thanks!