### PR TITLE
* actool: support for AltIcons and other options

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/tools/ActoolOptions.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/tools/ActoolOptions.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.compiler.config.tools;
+
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementList;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Settings to provide custom actool arguments
+ * @author dkimitsa
+ */
+public class ActoolOptions {
+    @ElementList(required = false, entry = "arg")
+    private ArrayList<String> args;
+
+    @Element(required = false)
+    private String appIcon;
+
+    @Element(required = false)
+    private String launchImage;
+
+    @Element(required = false)
+    private Boolean includeAllAppIcons;
+
+    public List<String> getArguments() {
+        return args != null ? Collections.unmodifiableList(args) : Collections.emptyList();
+    }
+
+    public String getAppIconName() {
+        return appIcon;
+    }
+
+    public String getLaunchImageName() {
+        return launchImage;
+    }
+
+    public boolean shouldIncludeAllAppIcons() {
+        return includeAllAppIcons != null ? includeAllAppIcons : false;
+    }
+}

--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/tools/Tools.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/tools/Tools.java
@@ -28,12 +28,19 @@ public class Tools {
 
     @Element(required = false)
     private LinkerOptions linker;
-    
+
+    @Element(required = false)
+    private ActoolOptions actool;
+
     public TextureAtlas getTextureAtlas() {
         return textureAtlas;
     }
 
     public LinkerOptions getLinker() {
         return linker;
+    }
+
+    public ActoolOptions getActool() {
+        return actool;
     }
 }


### PR DESCRIPTION
# the issue
- originally was reported in #636 (support for alt icons)
- also if xcassets contain multiple icons -- random one was picked for the app
- also if xcassets contain multiple launch images -- random one was picked for the app 

# the fix
`robovm.xml` was extended with `actool` options:
```
<config>
    <tools>
        <actool>
            <appIcon>AppIcon</appIcon>
            <includeAllAppIcons>true</includeAllAppIcons>
        </actool>
    </tools>
</config>
```

new parameters:
- `appicon` - specifies which icon to use for app (in case of multiple)
- `launchImage` -- specifies which launchImage to use (in case of multiple)
- `includeAllAppIcons` -- will add `--include-all-app-icons` command line argument to include all app icons
- `args` -- allows to add raw arguments for actool