### PR TITLE
* fixed: wrong `os.name` on arm64 simulator

### DIFF
--- a/compiler/vm/CMakeLists.txt
+++ b/compiler/vm/CMakeLists.txt
@@ -215,8 +215,10 @@ set(INSTALL_DIR ${CMAKE_SOURCE_DIR}/target/binaries/${OS}/${ARCH})
 # at this point convert remove "-simulator" suffix as it will conflict as sub-modules
 if (ARCH STREQUAL "arm64-simulator")
   set(ARCH arm64)
+  add_definitions(-DRVM_SIMULATOR)
 elseif (ARCH STREQUAL "x86_64-simulator")
   set(ARCH x86_64)
+  add_definitions(-DRVM_SIMULATOR)
 endif()
 
 if (ARCH STREQUAL "x86_64")

--- a/compiler/vm/rt/robovm/java_lang_System.c
+++ b/compiler/vm/rt/robovm/java_lang_System.c
@@ -48,7 +48,7 @@ ObjectArray* Java_java_lang_System_robovmSpecialProperties(Env* env, Class* c) {
 
 #if defined(DARWIN)
     char* osName = NULL;
-#   if defined(IOS) && (defined(RVM_X86) || defined(RVM_X86_64))
+#   if defined(IOS) && defined(RVM_SIMULATOR)
     osName = "os.name=iOS Simulator";
 #   elif defined(IOS)
     osName = "os.name=iOS";


### PR DESCRIPTION
was `iOS` instead of `iOS Simulator`
reported on [gitter](https://matrix.to/#/!mqUEluorTjXZPncMfe:gitter.im/$gVM8XjXRPOAvmiAb4Wpog8Rpf8p7ChGyyEtG1q51-xA?via=gitter.im&via=matrix.org)