### PR TITLE
* fixed: #608 NSAttributedString causes crash on next GC

### DIFF
--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSAttributedString.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSAttributedString.java
@@ -275,7 +275,7 @@ import org.robovm.apple.dispatch.*;
     public NSAttributedString(NSURL url, NSAttributedStringDocumentAttributes options) throws NSErrorException {
         super((SkipInit) null);
         long h = NSObject.alloc(ObjCClass.getByType(NSAttributedString.class));
-        initObject(NSAttributedStringExtensions.init(ObjCObject.toObjCObject(NSAttributedString.class, h, NSObject.FLAG_NO_RETAIN), url, options, null));
+        initObject(NSAttributedStringExtensions.init(h, url, options, null));
     }
     /**
      * 
@@ -289,7 +289,7 @@ import org.robovm.apple.dispatch.*;
     public NSAttributedString(NSData data, NSAttributedStringDocumentAttributes options) throws NSErrorException {
         super((SkipInit) null);
         long h = NSObject.alloc(ObjCClass.getByType(NSAttributedString.class));
-        initObject(NSAttributedStringExtensions.init(ObjCObject.toObjCObject(NSAttributedString.class, h, NSObject.FLAG_NO_RETAIN), data, options, null));
+        initObject(NSAttributedStringExtensions.init(h, data, options, null));
     }
     /**
      * 

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSAttributedStringExtensions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSAttributedStringExtensions.java
@@ -66,7 +66,7 @@ import org.robovm.apple.linkpresentation.*;
     /**
      * @since Available in iOS 9.0 and later.
      */
-    public static @Pointer long init(NSAttributedString thiz, NSURL url, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr<?, ?> dict) throws NSErrorException {
+    public static @Pointer long init(@Pointer long thiz, NSURL url, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr<?, ?> dict) throws NSErrorException {
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
        long result = init(thiz, url, options, dict, ptr);
        if (ptr.get() != null) { throw new NSErrorException(ptr.get()); }
@@ -76,15 +76,15 @@ import org.robovm.apple.linkpresentation.*;
      * @since Available in iOS 9.0 and later.
      */
     @Method(selector = "initWithURL:options:documentAttributes:error:")
-    private static native @Pointer long init(NSAttributedString thiz, NSURL url, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr<?, ?> dict, NSError.NSErrorPtr error);
-    public static @Pointer long init(NSAttributedString thiz, NSData data, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr<?, ?> dict) throws NSErrorException {
+    private static native @Pointer long init(@Pointer long thiz, NSURL url, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr<?, ?> dict, NSError.NSErrorPtr error);
+    public static @Pointer long init(@Pointer long thiz, NSData data, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr<?, ?> dict) throws NSErrorException {
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
        long result = init(thiz, data, options, dict, ptr);
        if (ptr.get() != null) { throw new NSErrorException(ptr.get()); }
        return result;
     }
     @Method(selector = "initWithData:options:documentAttributes:error:")
-    private static native @Pointer long init(NSAttributedString thiz, NSData data, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr<?, ?> dict, NSError.NSErrorPtr error);
+    private static native @Pointer long init(@Pointer long thiz, NSData data, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr<?, ?> dict, NSError.NSErrorPtr error);
     public static NSData getData(NSAttributedString thiz, @ByVal NSRange range, NSAttributedStringDocumentAttributes dict) throws NSErrorException {
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
        NSData result = getData(thiz, range, dict, ptr);
@@ -110,7 +110,7 @@ import org.robovm.apple.linkpresentation.*;
      * @deprecated Deprecated in iOS 9.0. Use initWithURL:options:documentAttributes:error:
      */
     @Deprecated
-    public static @Pointer long initWithFileURL(NSAttributedString thiz, NSURL url, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr<?, ?> dict) throws NSErrorException {
+    public static @Pointer long initWithFileURL(@Pointer long thiz, NSURL url, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr<?, ?> dict) throws NSErrorException {
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
        long result = initWithFileURL(thiz, url, options, dict, ptr);
        if (ptr.get() != null) { throw new NSErrorException(ptr.get()); }
@@ -121,7 +121,7 @@ import org.robovm.apple.linkpresentation.*;
      */
     @Deprecated
     @Method(selector = "initWithFileURL:options:documentAttributes:error:")
-    private static native @Pointer long initWithFileURL(NSAttributedString thiz, NSURL url, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr<?, ?> dict, NSError.NSErrorPtr error);
+    private static native @Pointer long initWithFileURL(@Pointer long thiz, NSURL url, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr<?, ?> dict, NSError.NSErrorPtr error);
     @Method(selector = "size")
     public static native @ByVal CGSize getSize(NSAttributedString thiz);
     @Method(selector = "drawAtPoint:")


### PR DESCRIPTION
this fixes #608

## root case is following code:
```
    public NSAttributedString(NSURL url, NSAttributedStringDocumentAttributes options) throws NSErrorException {
        super((SkipInit) null);
        long h = NSObject.alloc(ObjCClass.getByType(NSAttributedString.class));
        initObject(NSAttributedStringExtensions.init(ObjCObject.toObjCObject(NSAttributedString.class, h, NSObject.FLAG_NO_RETAIN), url, options, null));
    }
```

it creates two java object for same handle:
- one with ObjCObject.toObjCObject.toObjCObject(ObjCObject() with option FLAG_NO_RETAIN (so it doesn't own native part)
- and second NSAttributedString itself

but both of these do release a handle on dispose() that causes the crash

## fix:
 no need in creating intermediate Java object, `-init` like selectors should operate on pointer level