### PR TITLE
* clinit accessor for private static field: to support JEP181(java11)

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/ClassCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/ClassCompiler.java
@@ -826,7 +826,10 @@ public class ClassCompiler {
             Function setter = createFieldSetter(f, classFields, classType, instanceFields, instanceType);
             mb.addFunction(getter);
             mb.addFunction(setter);
-            if (f.isStatic() && !f.isPrivate()) {
+            // generate cinit wrapper even for private fields
+            // as with java11 JEP181 there will be no access$$$ wrappers
+            // to access these fields from inner classes
+            if (f.isStatic() /* && !f.isPrivate() */ ) {
                 mb.addFunction(createClassInitWrapperFunction(getter.ref()));
                 if (!f.isFinal()) {
                     mb.addFunction(createClassInitWrapperFunction(setter.ref()));


### PR DESCRIPTION
In case of Java11 there is no accessor for private static fields are being generated and Nested classes access fields of Nested host directly. #653 added support for this but it fails for static fields as corresponding clinit wrapper wasn't generated. It cased linker failure with message:
> [ERROR] 11:52:48.616 Undefined symbols for architecture arm64:
>  [ERROR] 11:52:48.616   "_[j]org.package.ImportDialog.lastScrollY(F)[set][clinit]", referenced from: