### PR TITLE
* libmobiledevice maintenance: waiting for device and error handling

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/ResolvedLocations.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/ResolvedLocations.java
@@ -94,7 +94,7 @@ final class ResolvedLocations {
             }
 
             if (xcFrameworks != null && !xcFrameworks.isEmpty()) {
-                // there is xcframeworks, expand them
+                // there are xcframeworks, expand them
                 handleXCFrameworks();
             }
 

--- a/compiler/compiler/src/main/java/org/robovm/compiler/plugin/debug/DebuggerLaunchPlugin.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/plugin/debug/DebuggerLaunchPlugin.java
@@ -252,10 +252,20 @@ public class DebuggerLaunchPlugin extends LaunchPlugin {
         @Override
         public void connect() {
             try {
+                // FIXME: waiting for app to be deployed and prepared, its should not use TARGET_WAIT_TIMEOUT time
+                //        and it has to be moved to pre-launch sequence
                 long ts = System.currentTimeMillis();
+                while (launchInfo == null) {
+                    if (System.currentTimeMillis() - ts > DebuggerConfig.TARGET_DEPLOY_TIMEOUT)
+                        throw new DebuggerException("Timeout while waiting app is deployed");
+                    Thread.sleep(200);
+                }
+
+                // waiting for target to start and hooks are available
+                ts = System.currentTimeMillis();
                 while (hooksPort == null) {
                     if (System.currentTimeMillis() - ts > DebuggerConfig.TARGET_WAIT_TIMEOUT)
-                        throw new DebuggerException("Timeout while waiting simulator port file");
+                        throw new DebuggerException("Timeout while waiting app is responding on device");
                     Thread.sleep(200);
                 }
 

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/AppLauncherProcess.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/AppLauncherProcess.java
@@ -59,11 +59,11 @@ public class AppLauncherProcess extends Process implements Launcher {
 
     @Override
     public Process execAsync() throws IOException {
-        launcher.install();
         this.launcherThread = new Thread("AppLauncherThread-" + threadCounter.getAndIncrement()) {
             @Override
             public void run() {
                 try {
+                    // install and launch
                     exitCode = launcher.launch();
                 } catch (Throwable t) {
                     log.error("AppLauncher failed with an exception:", t.getMessage());

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -94,6 +94,7 @@ public class IOSTarget extends AbstractTarget {
     private File entitlementsPList;
     private SigningIdentity signIdentity;
     private ProvisioningProfile provisioningProfile;
+    @Deprecated
     private IDevice device;
     private File partialPListDir;
 
@@ -175,21 +176,24 @@ public class IOSTarget extends AbstractTarget {
             throws IOException {
 
         IOSDeviceLaunchParameters deviceLaunchParameters = (IOSDeviceLaunchParameters) launchParameters;
-        String deviceId = deviceLaunchParameters.getDeviceId();
+        String deviceUdid = deviceLaunchParameters.getDeviceId();
         int forwardPort = deviceLaunchParameters.getForwardPort();
-        AppLauncherCallback callback = deviceLaunchParameters.getAppPathCallback();
-        if (deviceId == null || deviceId.isEmpty()) {
-            String[] udids = IDevice.listUdids();
-            if (udids.length == 0) {
-                throw new RuntimeException("No devices connected");
+
+        // TODO: FIXME: proxy AppLauncherCallback here: device to be captured as it is being used in junit client
+        //              its a subject for future rework
+        AppLauncherCallback callback = deviceLaunchParameters.getAppPathCallback() != null ? new AppLauncherCallback() {
+            final AppLauncherCallback delegate = deviceLaunchParameters.getAppPathCallback();
+            @Override
+            public void setAppLaunchInfo(AppLauncherInfo info) {
+                device = info.getDevice();
+                delegate.setAppLaunchInfo(info);
             }
-            if (udids.length > 1) {
-                config.getLogger().warn("More than 1 device connected (%s). "
-                        + "Using %s.", Arrays.asList(udids), udids[0]);
+
+            @Override
+            public byte[] filterOutput(byte[] data) {
+                return delegate.filterOutput(data);
             }
-            deviceId = udids[0];
-        }
-        device = new IDevice(deviceId);
+        } : null;
 
         OutputStream out = null;
         if (launchParameters.getStdoutFifo() != null) {
@@ -205,7 +209,7 @@ public class IOSTarget extends AbstractTarget {
         //Fix for #71, see http://stackoverflow.com/questions/37800790/hide-strange-unwanted-xcode-8-logs
         env.put("OS_ACTIVITY_DT_MODE", "");
 
-        AppLauncher launcher = new AppLauncher(device, getAppDir()) {
+        AppLauncher launcher = new AppLauncher(deviceUdid, getAppDir()) {
             protected void log(String s, Object... args) {
                 config.getLogger().info(s, args);
             }

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/LockdowndClient.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/LockdowndClient.java
@@ -34,6 +34,7 @@ import com.dd.plist.NSObject;
  */
 public class LockdowndClient implements AutoCloseable {
     protected LockdowndClientRef ref;
+    private IDevice device;
 
     LockdowndClient(LockdowndClientRef ref) {
         this.ref = ref;
@@ -58,6 +59,7 @@ public class LockdowndClient implements AutoCloseable {
                     LibIMobileDevice.lockdownd_client_new_with_handshake(device.getRef(), refOut, label) :
                     LibIMobileDevice.lockdownd_client_new(device.getRef(), refOut, label));
             this.ref = refOut.getValue();
+            this.device = device;
         } finally {
             refOut.delete();
         }
@@ -67,7 +69,11 @@ public class LockdowndClient implements AutoCloseable {
         checkDisposed();
         return ref;
     }
-    
+
+    public IDevice getDevice() {
+        return device;
+    }
+
     /**
      * Requests to start a service.
      * 

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/util/AppLauncherCallback.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/util/AppLauncherCallback.java
@@ -24,11 +24,11 @@ import org.robovm.libimobiledevice.IDevice;
  *
  */
 public interface AppLauncherCallback {
-    public void setAppLaunchInfo(AppLauncherInfo info);
+    void setAppLaunchInfo(AppLauncherInfo info);
+
+    byte[] filterOutput(byte[] data);
     
-    public byte[] filterOutput(byte[] data);
-    
-    static class AppLauncherInfo {
+    class AppLauncherInfo {
         final IDevice device;
         final String remoteAppPath;
         final String productVersion;

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/util/DeveloperImageResolver.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/util/DeveloperImageResolver.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2013 RoboVM AB
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/gpl-2.0.html>.
+ */
+package org.robovm.libimobiledevice.util;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class DeveloperImageResolver {
+    private static String xcodePath;
+
+    static File getXcodePath() throws Exception {
+        if (xcodePath != null) {
+            return new File(xcodePath);
+        }
+
+        File tmpFile = File.createTempFile("DeveloperImageResolver", ".tmp");
+        try {
+            int ret = new ProcessBuilder("xcode-select", "-print-path")
+                    .redirectErrorStream(true)
+                    .redirectOutput(ProcessBuilder.Redirect.to(tmpFile))
+                    .start().waitFor();
+            if (ret != 0) {
+                throw new IOException("xcode-select failed with error code: " + ret);
+            }
+
+            return new File(new String(Files.readAllBytes(tmpFile.toPath()), StandardCharsets.UTF_8).trim());
+        } finally {
+            tmpFile.delete();
+        }
+    }
+
+    static File getDeviceSupportPath() throws Exception {
+        return new File(getXcodePath(), "Platforms/iPhoneOS.platform/DeviceSupport");
+    }
+
+    /**
+     * Value object to provide information about resolved developer image
+     */
+    static class Response {
+        final Version version;
+        final File dmg;
+        final File signature;
+
+        Response(Version version, File dmg, File signature) {
+            this.version = version;
+            this.dmg = dmg;
+            this.signature = signature;
+        }
+    }
+
+    static Response findDeveloperImage(File dsDir, Version deviceVersion) throws FileNotFoundException {
+        // Find the DeveloperDiskImage.dmg path that best matches the current device. Here's what
+        // the paths look like:
+        // Platforms/iPhoneOS.platform/DeviceSupport/5.0/DeveloperDiskImage.dmg
+        // Platforms/iPhoneOS.platform/DeviceSupport/6.0/DeveloperDiskImage.dmg
+        // Platforms/iPhoneOS.platform/DeviceSupport/6.1/DeveloperDiskImage.dmg
+        // Platforms/iPhoneOS.platform/DeviceSupport/7.0/DeveloperDiskImage.dmg
+        // Platforms/iPhoneOS.platform/DeviceSupport/7.0 (11A465)/DeveloperDiskImage.dmg
+        // Platforms/iPhoneOS.platform/DeviceSupport/7.0.3 (11B508)/DeveloperDiskImage.dmg
+
+        // capturing patter: version + optional buildNumber e.g. "16.0.0 (16A123)"
+        Pattern pattern = Pattern.compile("(\\d+(?:\\.\\d+)*)(?:\\s*\\((.*)\\))?");
+
+        Version bestMatchVersion= null;
+        File bestMatchDmgFile= null;
+        File bestMatchSignatureFile= null;
+        File[] dirs = dsDir.listFiles();
+        for (File dir : dirs) {
+            if (dir.isDirectory()) {
+                Matcher matcher = pattern.matcher(dir.getName());
+                if (matcher.matches()) {
+                    File dmg = new File(dir, "DeveloperDiskImage.dmg");
+                    File sig = new File(dir, dmg.getName() + ".signature");
+                    if (dmg.isFile() && sig.isFile()) {
+                        Version dmgVersion = Version.parse(matcher.group(1));
+                        if (dmgVersion.getMajor() == deviceVersion.getMajor()) {
+                            int diff = dmgVersion.compareTo(deviceVersion);
+                            if (diff == 0) {
+                                // exact match
+                                bestMatchVersion = dmgVersion;
+                                bestMatchDmgFile = dmg;
+                                bestMatchSignatureFile = sig;
+                                // found the one
+                                break;
+                            } else if (diff < 0 && (bestMatchVersion == null || bestMatchVersion.compareTo(dmgVersion) < 0)) {
+                                // version is older than device one and version is never than best one
+                                bestMatchVersion = dmgVersion;
+                                bestMatchDmgFile = dmg;
+                                bestMatchSignatureFile = sig;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if (bestMatchDmgFile == null) {
+            throw new FileNotFoundException("No DeveloperDiskImage.dmg found in "
+                    + dsDir.getAbsolutePath() + " for iOS version " + deviceVersion);
+        }
+
+        return new Response(bestMatchVersion, bestMatchDmgFile, bestMatchSignatureFile);
+    }
+}

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/util/Lambdas.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/util/Lambdas.java
@@ -1,0 +1,21 @@
+package org.robovm.libimobiledevice.util;
+
+/**
+ * Collection of lambda interface definitions that throws exception
+ */
+public final class Lambdas {
+    @FunctionalInterface
+    public interface CheckedConsumer<T> {
+        void accept(T t) throws Exception;
+    }
+
+    @FunctionalInterface
+    public interface CheckedSupplier<T> {
+        T get() throws Exception;
+    }
+
+    @FunctionalInterface
+    public interface CheckedFunction<T, R> {
+        R apply(T t) throws Exception;
+    }
+}

--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/util/Version.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/util/Version.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2013 RoboVM AB
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/gpl-2.0.html>.
+ */
+package org.robovm.libimobiledevice.util;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * Another simple version class, local withing libmobiledevice
+ */
+class Version implements Comparable<Version> {
+    // parts of version -- parsed dot separated values "1.2.3" -> [1,2,3]
+    public final int[] parts;
+
+    public Version(int... parts) {
+        this.parts = parts;
+    }
+
+    @Override
+    public int compareTo(Version other) {
+        // walk by shortest common part
+        int commonPart = Math.min(parts.length, other.parts.length);
+        for (int i = 0; i < commonPart; i++) {
+            int diff = parts[i] - other.parts[i];
+            if (diff != 0)
+                return diff;
+        }
+
+        // same common part, longer wins
+        return this.parts.length - other.parts.length;
+    }
+
+    public int getMajor() {
+        return parts[0];
+    }
+
+    public static Version parse(String v) {
+        String[] tokens = v.split("\\.");
+        int[] parts = new int[tokens.length];
+        for (int i = 0; i < tokens.length; i++)
+            parts[i] = Integer.parseInt(tokens[i]);
+        return new Version(parts);
+    }
+
+    @Override
+    public String toString() {
+        return Arrays.stream(parts).mapToObj(Integer::toString).collect(Collectors.joining("."));
+    }
+}

--- a/compiler/libimobiledevice/src/test/java/org/robovm/libimobiledevice/util/DeveloperImageResolverTest.java
+++ b/compiler/libimobiledevice/src/test/java/org/robovm/libimobiledevice/util/DeveloperImageResolverTest.java
@@ -16,18 +16,18 @@
  */
 package org.robovm.libimobiledevice.util;
 
-import static org.junit.Assert.*;
-
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+
 /**
- * Tests {@link AppLauncher}.
+ * Tests {@link DeveloperImageResolver}.
  */
-public class AppLauncherTest {
+public class DeveloperImageResolverTest {
 
     private File createDeveloperImage(Path dsDir, String version) throws Exception {
         return createDeveloperImage(dsDir, version, true);
@@ -56,19 +56,19 @@ public class AppLauncherTest {
         File f92 = createDeveloperImage(dsDir, "9.2");
         File f102 = createDeveloperImage(dsDir, "10.2 (14D123)");
 
-        assertEquals(f703_11B508, AppLauncher.findDeveloperImage(dsDir.toFile(), "7.0.3", "11B508"));
-        assertEquals(f61, AppLauncher.findDeveloperImage(dsDir.toFile(), "6.1.3", "10A123"));
-        assertEquals(f61, AppLauncher.findDeveloperImage(dsDir.toFile(), "6.1.1", "10A123"));
-        assertEquals(f612, AppLauncher.findDeveloperImage(dsDir.toFile(), "6.1.2", "10A123"));
-        assertEquals(f703_11B508, AppLauncher.findDeveloperImage(dsDir.toFile(), "7.0.3", "12C123"));
-        assertEquals(f70_11A465, AppLauncher.findDeveloperImage(dsDir.toFile(), "7.0.2", "12C123"));
+        assertEquals(f703_11B508, DeveloperImageResolver.findDeveloperImage(dsDir.toFile(), new Version(7, 0, 3)).dmg);
+        assertEquals(f612, DeveloperImageResolver.findDeveloperImage(dsDir.toFile(), new Version(6, 1, 2)).dmg);
+        assertEquals(f703_11B508, DeveloperImageResolver.findDeveloperImage(dsDir.toFile(), new Version(7, 0, 3)).dmg);
         // finding not exact match
-        assertEquals(f812_13B812, AppLauncher.findDeveloperImage(dsDir.toFile(), "8.1.3", "14C710"));
-        assertEquals(f812_13B812, AppLauncher.findDeveloperImage(dsDir.toFile(), "8.2", "14C710"));
-        assertEquals(f92, AppLauncher.findDeveloperImage(dsDir.toFile(), "9.3.3", "15C710"));
-        assertEquals(f92, AppLauncher.findDeveloperImage(dsDir.toFile(), "9.3", "15C710"));
-        assertEquals(f102, AppLauncher.findDeveloperImage(dsDir.toFile(), "10.3.5", "15C710"));
-        assertEquals(f102, AppLauncher.findDeveloperImage(dsDir.toFile(), "10.3", "15C710"));
+        assertEquals(f612, DeveloperImageResolver.findDeveloperImage(dsDir.toFile(), new Version(6, 1, 3)).dmg);
+        assertEquals(f61, DeveloperImageResolver.findDeveloperImage(dsDir.toFile(), new Version(6, 1, 1)).dmg);
+        assertEquals(f70_11A465, DeveloperImageResolver.findDeveloperImage(dsDir.toFile(), new Version(7, 0, 2)).dmg);
+        assertEquals(f812_13B812, DeveloperImageResolver.findDeveloperImage(dsDir.toFile(), new Version(8, 1, 3)).dmg);
+        assertEquals(f812_13B812, DeveloperImageResolver.findDeveloperImage(dsDir.toFile(), new Version(8, 2)).dmg);
+        assertEquals(f92, DeveloperImageResolver.findDeveloperImage(dsDir.toFile(), new Version(9, 3, 3)).dmg);
+        assertEquals(f92, DeveloperImageResolver.findDeveloperImage(dsDir.toFile(), new Version(9, 3)).dmg);
+        assertEquals(f102, DeveloperImageResolver.findDeveloperImage(dsDir.toFile(), new Version(10, 3, 5)).dmg);
+        assertEquals(f102, DeveloperImageResolver.findDeveloperImage(dsDir.toFile(), new Version(10, 3)).dmg);
     }
 
 }

--- a/plugins/debugger/src/main/java/org/robovm/debugger/Debugger.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/Debugger.java
@@ -92,7 +92,7 @@ public class Debugger implements DebuggerThread.Catcher, IHooksEventsHandler, IJ
         // start JDWP server
         this.jdwpServer.start();
 
-        // start hoocks channel
+        // start hooks channel
         this.hooksChannel.start();
     }
 

--- a/plugins/debugger/src/main/java/org/robovm/debugger/DebuggerConfig.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/DebuggerConfig.java
@@ -34,7 +34,8 @@ import java.util.function.IntSupplier;
  * Configuration file that is to start debugger
  */
 public class DebuggerConfig {
-    public final static int TARGET_WAIT_TIMEOUT = 60000;
+    public final static int TARGET_WAIT_TIMEOUT = 60_000;
+    public final static int TARGET_DEPLOY_TIMEOUT = 120_000;
 
     /**
      * debugger local arch list, corresponds one from compiler

--- a/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmRunProfileState.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmRunProfileState.java
@@ -82,7 +82,6 @@ public class RoboVmRunProfileState extends CommandLineState {
             }
             process = new ProcessProxy(process, pipedOut, stdoutStream, stderrStream, compiler);
         }
-        RoboVmPlugin.logInfo(getEnvironment().getProject(), "Launch done");
 
         final OSProcessHandler processHandler = new ColoredProcessHandler(process, null);
         ProcessTerminatedListener.attach(processHandler);

--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
                     <configuration>
-                        <release>8</release>
+                        <release>9</release>
                         <debug>true</debug>
                         <optimize>true</optimize>
                         <encoding>UTF-8</encoding>
@@ -504,7 +504,7 @@
                 </executions>
                 <configuration>
                     <doclint>none</doclint>
-                    <release>8</release>
+                    <release>9</release>
                     <detectJavaApiLink>false</detectJavaApiLink>
                 </configuration>
             </plugin>


### PR DESCRIPTION
# reason
(also possibly fixes part of #721 issues)
 libmobiledevice was failing on every situation then: device is not connected, blocked or pairing not complete. considering build process and deployment might take minutes its sad to fail just due to blocked device. changes: mitigation for these cases done by allowing 20 seconds for user to act to solve the situation:
- if no device connected -- waiting for device
- if device is locked -- waiting for unlock
- if pairing in progress -- waiting to complete

now it looks as bellow in RoboVM log window:
```
[INFO] 19:26:28.376 Build done
[INFO] 19:26:28.377 Launching executable
[INFO] 19:26:28.387 Waiting for device: No devices connected. (retry 1 of 20)...
[INFO] 19:26:29.393 Waiting for device: No devices connected. (retry 2 of 20)...
[INFO] 19:26:30.399 Waiting for device: No devices connected. (retry 3 of 20)...
[INFO] 19:26:31.405 Waiting for device: No devices connected. (retry 4 of 20)...
[INFO] 19:26:32.410 Waiting for device: No devices connected. (retry 5 of 20)...
[INFO] 19:26:33.616 Device is locked. Please unlock to proceed. (retry 1 of 20)...
[INFO] 19:26:34.832 Device is locked. Please unlock to proceed. (retry 2 of 20)...
[INFO] 19:26:36.023 Device is locked. Please unlock to proceed. (retry 3 of 20)...
[INFO] 19:26:37.121 Device is locked. Please unlock to proceed. (retry 4 of 20)...
[INFO] 19:26:38.262 Device is locked. Please unlock to proceed. (retry 5 of 20)...
[INFO] 19:26:39.459 Pairing in progress. Please choose to trust this computer. (retry 6 of 20)...
[INFO] 19:26:40.588 Pairing in progress. Please choose to trust this computer. (retry 7 of 20)...
[INFO] 19:26:41.791 Pairing in progress. Please choose to trust this computer. (retry 8 of 20)...
[INFO] 19:26:42.883 Pairing in progress. Please choose to trust this computer. (retry 9 of 20)...
[INFO] 19:26:44.006 Pairing in progress. Please choose to trust this computer. (retry 10 of 20)...
[INFO] 19:26:45.187 Pairing in progress. Please choose to trust this computer. (retry 11 of 20)...
[INFO] 19:26:46.882 [  0%] Beginning upload...
```

# other changes
- changed logic for picking dev image -- all version are parsed and picked exact or lower (fix for #517)
- idea plugin: install was moved inside Run process. As before it was happening on UI thread and entire Idea was frozen (there was no update or locked device retries message);
- using Java9 language level for RoboVM compiler/plugins.
- amount for TODO added to point for code fragments that to be refactored (like Launchers, junit client depends on old structure)