### PR TITLE
* fixed: LOCKDOWN_E_INVALID_SERVICE when starting DebugServerService

### DIFF
--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/util/AppLauncher.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/util/AppLauncher.java
@@ -619,7 +619,8 @@ public class AppLauncher {
             NSDictionary result = retrying.perform((mimClient) -> {
                 return mimClient.lookupImage(null);
             });
-            if (result.objectForKey("ImageSignature") != null) {
+            NSArray imageSignature = (NSArray) result.objectForKey("ImageSignature");
+            if (imageSignature != null && imageSignature.count() > 0) {
                 // already mounted
                 log("Developer disk image is already mounted.");
                 return null;


### PR DESCRIPTION
this happens when running app on freshly booted device. iOS 16.5 return success status even if dev image is not mounted. In this case  ImageSignature field is empty. fix: consider as not mounted if ImageSignature is not provided