### PR TITLE
* device deployment: clean up destination folder in staging location before uploading

### DIFF
--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/AfcClient.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/AfcClient.java
@@ -422,6 +422,14 @@ public class AfcClient implements AutoCloseable {
     }
 
     /**
+     * Same as removePath(recursive = true) but provided by lib itself
+     * @param path the fully-qualified path to delete.
+     */
+    public void removePathAndContent(String path) {
+        checkResult(LibIMobileDevice.afc_remove_path_and_contents(getRef(), path));
+    }
+
+    /**
      * Renames a file or directory on the device.
      * 
      * @param from the fully-qualified path of the file or directory to rename.
@@ -500,9 +508,12 @@ public class AfcClient implements AutoCloseable {
      */
     public void upload(File localFile, final String targetPath, 
             final UploadProgressCallback callback) throws IOException {
-        
-        makeDirectory(targetPath);
         final Path root = localFile.toPath().getParent();
+
+        // remove recursively destination folder as it might contain previous data
+        // due failed attempt
+        removePathAndContent(toAbsoluteDevicePath(targetPath, root.relativize(localFile.toPath())));
+        makeDirectory(targetPath);
 
         // 64k seems to be a good buffer size. If smaller we will not get
         // acceptable write speeds.


### PR DESCRIPTION


as due intercepted previous upload it might contain files that might cause different side effect. or even will block upload due AFC_E_OBJECT_EXISTS errors