### PR TITLE
* device deployment: hotfix -- AFC_E_OBJECT_NOT_FOUND if directory doesn't exist

### DIFF
--- a/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/AfcClient.java
+++ b/compiler/libimobiledevice/src/main/java/org/robovm/libimobiledevice/AfcClient.java
@@ -426,7 +426,10 @@ public class AfcClient implements AutoCloseable {
      * @param path the fully-qualified path to delete.
      */
     public void removePathAndContent(String path) {
-        checkResult(LibIMobileDevice.afc_remove_path_and_contents(getRef(), path));
+        AfcError result = LibIMobileDevice.afc_remove_path_and_contents(getRef(), path);
+        if (result != AfcError.AFC_E_SUCCESS && result != AfcError.AFC_E_OBJECT_NOT_FOUND) {
+            throw new LibIMobileDeviceException(result.swigValue(), result.name());
+        }
     }
 
     /**


### PR DESCRIPTION
introduced by https://github.com/MobiVM/robovm/pull/736
```
[ERROR] 12:45:08.052 AppLauncher failed with an exception:
[ERROR] 12:45:08.052 org.robovm.libimobiledevice.LibIMobileDeviceException: AFC_E_OBJECT_NOT_FOUND
[ERROR] 12:45:08.052 	at org.robovm.libimobiledevice.AfcClient.checkResult(AfcClient.java:627)
[ERROR] 12:45:08.052 	at org.robovm.libimobiledevice.AfcClient.removePathAndContent(AfcClient.java:429)
[ERROR] 12:45:08.052 	at org.robovm.libimobiledevice.AfcClient.upload(AfcClient.java:515)
```