### PR TITLE
* fixed: libgdx/7212 -- crash when getting value by pointer, affected by GC

### DIFF
--- a/compiler/vm/core/src/memory.c
+++ b/compiler/vm/core/src/memory.c
@@ -951,9 +951,9 @@ void rvmSetupGcDescriptor(Env* env, Class* clazz) {
         // and will be reachable even if we allocate this using REF_FREE_GC_DESCRIPTOR.
         clazz->gcDescriptor = REF_FREE_GC_DESCRIPTOR;
     } else if (clazz == java_lang_Class || CLASS_IS_FINALIZABLE(clazz) || CLASS_IS_REFERENCE(clazz) 
-        || (clazz->superclass && clazz->superclass == org_robovm_rt_bro_Struct)
         || (clazz->superclass && clazz->superclass == java_nio_MemoryBlock)
-        || (clazz == java_nio_MemoryBlock) || rvmIsSubClass(java_lang_Throwable, clazz)) {
+        || (clazz == java_nio_MemoryBlock) || rvmIsSubClass(java_lang_Throwable, clazz) 
+        || (clazz->superclass && rvmIsSubClass(org_robovm_rt_bro_Struct, clazz))) {
 
         // These types of objects must be marked specially. We could probably
         // do this using GC bitmap descriptors instead.


### PR DESCRIPTION
# Source
https://github.com/libgdx/libgdx/issues/7212 

# root case
GC code was setting up mark handler only for direct subclass of Struct class to mark its native structure content during GC mark phase. As result memory behind native struct area was release and available for allocations. As result this area was taken by next requested object/data. That caused crashed related to ObjC marshalling, like `objc[503]: Attempt to use unknown class 0x104094d80.` But all pointer extended intermediate classes after Struct: in this case NSErrorPtr->Ptr->Struct 

# Fix
Code changed to check for subclass instead direct subclass. 

# Minimal sample to reproduce.
```
void test2() {
   	NSObjectPtr ptr = new NSObjectPtr();
   	NSObject o = new NSObject();
   	ptr.set(o);
   	for (int i = 0; i < 100_000_000;i++) {
   		new NSObject();
   		if (VM.getLong(ptr.getHandle()) != o.getHandle()) {
   			throw new RuntimeException(ptr.getClass() + " " + Long.toHexString(ptr.getHandle()) + "-" + Long.toHexString(VM.getLong(ptr.getHandle())));
   		}
   	}
}
```