### PR TITLE
* fixed 744: delete existing IPA when packaging new one

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -814,6 +814,8 @@ public class IOSTarget extends AbstractTarget {
 
     private void packageApplication(File appDir) throws IOException {
         File ipaFile = new File(config.getInstallDir(), getExecutable() + ".ipa");
+        // remove ipa otherwise its content will get updated
+        FileUtils.deleteQuietly(ipaFile);
         config.getLogger().info("Packaging IPA %s from %s", ipaFile.getName(), appDir.getName());
 
         File tmpDir = new File(config.getInstallDir(), "ipabuild");


### PR DESCRIPTION
otherwise existing ZIP's content is being updated as result it receives extra files (like debug symbols) that cause size increase. Also it might cause CodeSign to be invalid as it might contain not covered files