### PR TITLE
* fixed: ObjCProtocol to NSObject promoter in case of private classes and multiple constructors

### DIFF
--- a/plugins/idea/src/main/java/org/robovm/idea/inspection/ClassWithProtocolShouldExtendNSObject.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/inspection/ClassWithProtocolShouldExtendNSObject.java
@@ -1,0 +1,109 @@
+package org.robovm.idea.inspection;
+
+import com.intellij.codeInspection.*;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.JavaPsiFacade;
+import com.intellij.psi.PsiAnonymousClass;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiIdentifier;
+import org.jetbrains.annotations.NotNull;
+import org.robovm.idea.inspection.quickfix.ChangeSuperClassFix;
+import org.robovm.idea.inspection.quickfix.NavigateToClassFix;
+
+import java.util.*;
+
+/**
+ * Simple inspection that check Java objects that implement NSObjectProtocol and
+ * doesn't extend NSObject
+ * @see #checkClass(PsiClass, InspectionManager, boolean)  for comments
+ * @author dkimitsa
+ */
+public class ClassWithProtocolShouldExtendNSObject extends AbstractBaseJavaLocalInspectionTool {
+    @Override
+    public ProblemDescriptor[] checkClass(@NotNull PsiClass cls, @NotNull InspectionManager manager, boolean isOnTheFly) {
+        try {
+            // ignore: annotations, interfaces and anonymous classes
+            if (cls instanceof PsiAnonymousClass || cls.isInterface() || cls.isAnnotationType())
+                return null;
+
+            // skip if unable to get class name identifier and build the message
+            PsiIdentifier classNameIdentifier = cls.getNameIdentifier();
+            if (classNameIdentifier == null)
+                return null;
+
+            // if extends from NSObject -- do nothing
+            LinkedList<PsiClass> clsHierarchy = new LinkedList<>();
+            if (RvmCommonUtils.clsExtends(cls, RvmCommonClassNames.NSObject, clsHierarchy))
+                return null;
+
+            // check hierarchy and if there is any class with @Marshaler annotation -- skip case
+            for (PsiClass c : clsHierarchy)
+                if (c.getAnnotation(RvmCommonClassNames.Marshaler) != null)
+                    return null;
+
+            // move from bottom of hierarchy to find first class that implements NSObjectProtocol
+            PsiClass clsWithProtocol = null;
+            ListIterator<PsiClass> it = clsHierarchy.listIterator(clsHierarchy.size());
+            while (it.hasPrevious()) {
+                PsiClass c = it.previous();
+                if (RvmCommonUtils.clsImplements(c, RvmCommonClassNames.NSObjectProtocol, true)) {
+                    clsWithProtocol = c;
+                    break;
+                }
+            }
+
+            //  if class doesn't implement NSProtocol -- do nothing
+            if (clsWithProtocol == null || clsWithProtocol.getName() == null)
+                return null;
+
+
+            ProblemDescriptor[] problemDescriptors = null;
+            if (clsWithProtocol == clsHierarchy.getLast()) {
+                // class implements protocol and directly extends from java.lang.Object
+                // this class will be promoted to NSObject. Attach warning.
+                if (clsWithProtocol == cls) {
+                    // its same class under analyze, propose switch to NSObject supper as a quick-fix
+                    // show as warning
+                    Project project = cls.getProject();
+                    PsiClass NSObjectCls = JavaPsiFacade.getInstance(project).findClass(RvmCommonClassNames.NSObject,
+                            cls.getResolveScope());
+                    if (NSObjectCls != null) {
+                        LocalQuickFix fix = new ChangeSuperClassFix(NSObjectCls);
+                        String description = RvmInspectionBundle.message("robovm.inspection.objcprotocol.shouldbe.in.nsobject");
+                        ProblemDescriptor p = manager.createProblemDescriptor(classNameIdentifier,
+                                description, fix, ProblemHighlightType.WARNING, false);
+                        problemDescriptors = new ProblemDescriptor[]{p};
+                    }
+                } else {
+                    // protocol was declared in one of the supers, but its fixable, propose navigate to
+                    // that super as quick fix
+                    // show as warning
+                    LocalQuickFix fix = new NavigateToClassFix(clsWithProtocol, clsWithProtocol.getName());
+                    String description = RvmInspectionBundle.message("robovm.inspection.objcprotocol.parent.should.extend.nsobject",
+                            cls.getName(), clsWithProtocol.getName());
+                    ProblemDescriptor p = manager.createProblemDescriptor(classNameIdentifier,
+                            description, fix, ProblemHighlightType.WARNING, false);
+                    problemDescriptors = new ProblemDescriptor[]{p};
+                }
+            } else {
+                // class has intermediate super between it and java.lang.Object and can't be promoted
+                // the class can't be promoted and will cause error runtime
+                String description;
+                if (cls == clsWithProtocol) {
+                    description = RvmInspectionBundle.message("robovm.inspection.objcprotocol.should.extend.object.or.nsobject.error",
+                            cls.getName(), clsWithProtocol.getName());
+                } else {
+                    description = RvmInspectionBundle.message("robovm.inspection.objcprotocol.parent.should.extend.object.or.nsobject.error",
+                            cls.getName(), clsWithProtocol.getName());
+                }
+                ProblemDescriptor p = manager.createProblemDescriptor(classNameIdentifier,
+                        description, (LocalQuickFix) null, ProblemHighlightType.ERROR, false);
+                problemDescriptors = new ProblemDescriptor[]{p};
+            }
+
+            return problemDescriptors;
+        } catch (Exception e) {
+            throw e;
+        }
+    }
+}

--- a/plugins/idea/src/main/java/org/robovm/idea/inspection/RvmCommonClassNames.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/inspection/RvmCommonClassNames.java
@@ -1,0 +1,12 @@
+package org.robovm.idea.inspection;
+
+/**
+ * set of RoboVM specific class names used for inspection
+ */
+public final class RvmCommonClassNames {
+    private RvmCommonClassNames() {}
+
+    public static final String NSObject = "org.robovm.apple.foundation.NSObject";
+    public static final String NSObjectProtocol = "org.robovm.apple.foundation.NSObjectProtocol";
+    public static final String Marshaler = "org.robovm.rt.bro.annotation.Marshaler";
+}

--- a/plugins/idea/src/main/java/org/robovm/idea/inspection/RvmCommonUtils.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/inspection/RvmCommonUtils.java
@@ -1,0 +1,71 @@
+package org.robovm.idea.inspection;
+
+import com.intellij.psi.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public final class RvmCommonUtils {
+    private RvmCommonUtils() {
+    }
+
+    /**
+     * Checks if class extends specified class
+     *
+     * @param cls     to test
+     * @param classQN qualified name of class to check if extended
+     */
+    public static boolean clsExtends(@NotNull PsiClass cls, @NotNull String classQN) {
+        return clsExtends(cls, classQN, null);
+    }
+
+    /**
+     * Checks if class extends specified class
+     *
+     * @param cls           to test
+     * @param classQN       qualified name of class to check if extended
+     * @param outHierarchy  if specified -- hierarchy of inheritance will be returned
+     *                      excluding java.lang.Object and including cls itself
+     */
+    public static boolean clsExtends(@NotNull PsiClass cls, @NotNull String classQN, @Nullable List<PsiClass> outHierarchy) {
+        if (outHierarchy != null) outHierarchy.add(cls);
+
+        PsiClass superCls = cls.getSuperClass();
+        while (superCls != null && !CommonClassNames.JAVA_LANG_OBJECT.equals(superCls.getQualifiedName())) {
+            if (outHierarchy != null) outHierarchy.add(superCls);
+            if (classQN.equals(superCls.getQualifiedName()))
+                return true;
+            superCls = superCls.getSuperClass();
+        }
+        return false;
+    }
+
+    /**
+     * checks if class implements Interface
+     * @param cls to check
+     * @param interfaceQN fully qualified name of interface
+     * @param checkSubInterfaces deep check -- super of each interface will be chcekd
+     * @return true if implements
+     */
+    public static boolean clsImplements(@NotNull PsiClass cls, @NotNull String interfaceQN, boolean checkSubInterfaces) {
+        PsiClassType[] implementsList = cls.isInterface() ? cls.getExtendsListTypes() : cls.getImplementsListTypes();
+        for (PsiClassType implType : implementsList) {
+            if (implType.equalsToText(interfaceQN)) {
+                return true;
+            }
+            if (checkSubInterfaces) {
+                // check sub-interfaces
+                PsiClass el = implType.resolve();
+                if (el != null && clsImplements(el, interfaceQN, true))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static PsiJavaCodeReferenceElement[] getReferences(PsiReferenceList list) {
+        return list == null ? PsiJavaCodeReferenceElement.EMPTY_ARRAY : list.getReferenceElements();
+    }
+}

--- a/plugins/idea/src/main/java/org/robovm/idea/inspection/RvmInspectionBundle.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/inspection/RvmInspectionBundle.java
@@ -1,0 +1,28 @@
+package org.robovm.idea.inspection;
+
+import com.intellij.DynamicBundle;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.PropertyKey;
+
+import java.util.function.Supplier;
+
+public final class RvmInspectionBundle extends DynamicBundle {
+        public static final @NonNls String BUNDLE = "robovm.RvmInspectionBundle";
+
+        private RvmInspectionBundle() {
+            super(BUNDLE);
+        }
+
+        private static final DynamicBundle INSTANCE = new RvmInspectionBundle();
+
+        public static @NotNull
+        @Nls String message(@NotNull @PropertyKey(resourceBundle = BUNDLE) String key, Object ... params) {
+            return INSTANCE.getMessage(key, params);
+        }
+
+        public static @NotNull Supplier<String> messagePointer(@NotNull @PropertyKey(resourceBundle = BUNDLE) String key, Object ... params) {
+            return INSTANCE.getLazyMessage(key, params);
+        }
+    }

--- a/plugins/idea/src/main/java/org/robovm/idea/inspection/quickfix/ChangeSuperClassFix.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/inspection/quickfix/ChangeSuperClassFix.java
@@ -1,0 +1,108 @@
+package org.robovm.idea.inspection.quickfix;
+
+import com.intellij.codeInsight.FileModificationService;
+import com.intellij.codeInsight.intention.HighPriorityAction;
+import com.intellij.codeInspection.LocalQuickFix;
+import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.openapi.application.WriteAction;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.*;
+import com.intellij.psi.codeStyle.JavaCodeStyleManager;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.jetbrains.annotations.NotNull;
+import org.robovm.idea.inspection.RvmInspectionBundle;
+
+import java.util.Objects;
+
+import static org.robovm.idea.inspection.RvmCommonUtils.getReferences;
+
+/**
+ * dkimitsa: code based on com.intellij.compiler.inspection as direct use of it not
+ * possible as it seems to be internal class with unstable API
+ */
+public class ChangeSuperClassFix implements LocalQuickFix, HighPriorityAction {
+    @NotNull
+    private final SmartPsiElementPointer<PsiClass> myNewSuperClass;
+    @NotNull
+    private final String myNewSuperName;
+
+    public ChangeSuperClassFix(
+            @NotNull PsiClass newSuperClass
+    ) {
+        final SmartPointerManager smartPointerManager = SmartPointerManager.getInstance(newSuperClass.getProject());
+        myNewSuperName = Objects.requireNonNull(newSuperClass.getQualifiedName());
+        myNewSuperClass = smartPointerManager.createSmartPsiElementPointer(newSuperClass);
+    }
+
+    @NotNull
+    @Override
+    public String getName() {
+        return RvmInspectionBundle.message("robovm.quickfix.make.extends", myNewSuperName);
+    }
+
+    @NotNull
+    @Override
+    public String getFamilyName() {
+        return RvmInspectionBundle.message("robovm.inspection.group");
+    }
+
+    @Override
+    public boolean startInWriteAction() {
+        return false;
+    }
+
+    @Override
+    public void applyFix(@NotNull final Project project, @NotNull final ProblemDescriptor problemDescriptor) {
+        final PsiClass newSuperClass = myNewSuperClass.getElement();
+        if (newSuperClass == null) return;
+        PsiClass aClass = PsiTreeUtil.getParentOfType(problemDescriptor.getPsiElement(), PsiClass.class, false);
+        if (aClass == null || !FileModificationService.getInstance().preparePsiElementsForWrite(aClass)) return;
+        changeSuperClass(aClass, newSuperClass);
+    }
+
+    /**
+     * newSuperClass can be interfaces or classes in any combination
+     * <p/>
+     * 1. does not check that newSuperClass not exists in currently existed supers
+     */
+    private static void changeSuperClass(@NotNull final PsiClass aClass,
+                                         @NotNull final PsiClass newSuperClass) {
+        WriteAction.run(() -> addSuperClass(aClass, newSuperClass));
+    }
+
+    private static void addSuperClass(
+            @NotNull final PsiClass aClass,
+            @NotNull final PsiClass newSuperClass
+    ) {
+        JavaPsiFacade psiFacade = JavaPsiFacade.getInstance(aClass.getProject());
+        final PsiClass oldSuperClass = aClass.getSuperClass();
+        if (oldSuperClass == null || aClass instanceof PsiAnonymousClass)
+            return;
+
+        PsiElementFactory factory = psiFacade.getElementFactory();
+        PsiReferenceList extendsList = Objects.requireNonNull(aClass.getExtendsList());
+        PsiJavaCodeReferenceElement[] refElements = getReferences(extendsList);
+        for (PsiJavaCodeReferenceElement refElement : refElements) {
+            if (refElement.isReferenceTo(oldSuperClass)) {
+                refElement.delete();
+            }
+        }
+
+        PsiReferenceList list;
+        if (newSuperClass.isInterface() && !aClass.isInterface()) {
+            list = aClass.getImplementsList();
+        } else {
+            list = extendsList;
+            PsiJavaCodeReferenceElement[] elements = list.getReferenceElements();
+            if (elements.length == 1) {
+                PsiClass objectClass = psiFacade.findClass(CommonClassNames.JAVA_LANG_OBJECT, aClass.getResolveScope());
+                if (objectClass != null && elements[0].isReferenceTo(objectClass)) {
+                    elements[0].delete();
+                }
+            }
+        }
+        assert list != null;
+        PsiElement ref = list.add(factory.createClassReferenceElement(newSuperClass));
+        JavaCodeStyleManager.getInstance(aClass.getProject()).shortenClassReferences(ref);
+    }
+}

--- a/plugins/idea/src/main/java/org/robovm/idea/inspection/quickfix/NavigateToClassFix.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/inspection/quickfix/NavigateToClassFix.java
@@ -1,0 +1,44 @@
+package org.robovm.idea.inspection.quickfix;
+
+import com.intellij.codeInspection.LocalQuickFix;
+import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.codeInspection.util.IntentionFamilyName;
+import com.intellij.codeInspection.util.IntentionName;
+import com.intellij.openapi.project.Project;
+import com.intellij.pom.Navigatable;
+import org.jetbrains.annotations.NotNull;
+import org.robovm.idea.inspection.RvmInspectionBundle;
+
+/**
+ * Navigate to class QuickFix
+ * @author dkimitsa
+ */
+public class NavigateToClassFix implements LocalQuickFix {
+    @NotNull
+    private final Navigatable element;
+    @NotNull
+    private final String elementName;
+
+    public NavigateToClassFix(@NotNull Navigatable element, @NotNull String elementName) {
+        this.element = element;
+        this.elementName = elementName;
+    }
+
+    @Override
+    public @IntentionName
+    @NotNull String getName() {
+        return RvmInspectionBundle.message("robovm.quickfix.navigate.tofix", elementName);
+    }
+
+    @Override
+    public @IntentionFamilyName
+    @NotNull String getFamilyName() {
+        return RvmInspectionBundle.message("robovm.inspection.group");
+    }
+
+    @Override
+    public void applyFix(@NotNull Project project, @NotNull ProblemDescriptor descriptor) {
+        if (element.canNavigateToSource())
+            element.navigate(true);
+    }
+}

--- a/plugins/idea/src/main/resources/META-INF/plugin.xml
+++ b/plugins/idea/src/main/resources/META-INF/plugin.xml
@@ -6,7 +6,7 @@
     <depends optional="true" config-file="com.mobidevelop.robovm.intellij-maven.xml">org.jetbrains.idea.maven</depends>
     <depends>org.jetbrains.plugins.gradle</depends>
     <depends>com.intellij.modules.java</depends>
-    <idea-version since-build="193.1"/>
+    <idea-version since-build="221"/>
 
     <name>MobiVM</name>
     <description>
@@ -61,6 +61,19 @@
         <!--<applicationConfigurable implementation="org.robovm.idea.config.RoboVmGlobalConfig"></applicationConfigurable>-->
         <toolWindow id="RoboVM" anchor="bottom" icon="org.robovm.idea.RoboVmIcons.ROBOVM_SMALL" secondary="true"
                     factoryClass="org.robovm.idea.components.RoboVmToolWindowFactory"/>
+
+        <!--group.names.language.level.specific.issues.and.migration.aids-->
+        <localInspection language="JAVA"
+                         shortName="ClassWithProtocolShouldExtendNSObject"
+                         bundle="robovm.RvmInspectionBundle"
+                         key="robovm.inspection.objcprotocol.shouldbe.in.nsobject"
+                         groupBundle="robovm.RvmInspectionBundle"
+                         groupKey="robovm.inspection.group"
+                         enabledByDefault="true"
+                         level="WARNING"
+                         implementationClass="org.robovm.idea.inspection.ClassWithProtocolShouldExtendNSObject"
+                         cleanupTool="true"/>
+
     </extensions>
 
     <application-components>

--- a/plugins/idea/src/main/resources/inspectionDescriptions/ClassWithProtocolShouldExtendNSObject.html
+++ b/plugins/idea/src/main/resources/inspectionDescriptions/ClassWithProtocolShouldExtendNSObject.html
@@ -1,0 +1,22 @@
+<html>
+<body>
+Reports classes that implements <code>NSObjectProtocol</code> and doesn't extend from NSObject
+
+Objc/Bro code will not be able to marshal such pure Java object to ObjC/Native side.
+(and will crash with message: <code>CLASSNAME cannot be cast to org.robovm.objc.ObjCObject</code>)
+While there is Object to NSObject promoter plugin that will replace super with NSObject
+during RoboVM compilation phase, it's always better to have it clearly specified in source code.
+<p><b>Example:</b></p>
+<pre><code>
+    // will be reported as warning with option to extend from NSObject
+    class Foo implements NSObjectProtocol {}
+
+    // will be reported as error as Foo doesn't extend from java.lang.Object directly
+    class Foo extends ArrayList implements NSObjectProtocol {}
+</code></pre>
+<!-- tooltip end -->
+<p>
+    This inspection is intended for RoboVM application that use ObjC bindings.
+</p>
+</body>
+</html>

--- a/plugins/idea/src/main/resources/robovm/RvmInspectionBundle.properties
+++ b/plugins/idea/src/main/resources/robovm/RvmInspectionBundle.properties
@@ -1,0 +1,8 @@
+
+robovm.inspection.group=RoboVM inspections
+robovm.inspection.objcprotocol.shouldbe.in.nsobject=Class that implements any NSObjectProtocol should extend NSObject
+robovm.inspection.objcprotocol.parent.should.extend.nsobject=Class ''{0}'' extends ''{1}'' that implements NSObjectProtocol but does not extend NSObject
+robovm.inspection.objcprotocol.parent.should.extend.object.or.nsobject.error=Class ''{0}'' extends ''{1}'' that implements NSObjectProtocol but does not extend NSObject or Object directly and can not be promoted to NSObject during RoboVM compilation. It will cause runtime crash when object is used with ObjC code.
+robovm.inspection.objcprotocol.should.extend.object.or.nsobject.error=Class ''{0}'' that implements NSObjectProtocol (or its subclass) but does not extend NSObject or Object directly and can not be promoted to NSObject during RoboVM compilation. It will cause runtime crash when object is used with ObjC code.
+robovm.quickfix.make.extends=Extend from ''{0}''
+robovm.quickfix.navigate.tofix=Navigate to ''{0}''


### PR DESCRIPTION
## Fix
it fixes following case 
```java
public class Test {
    public void test() {
        new Delegate();
    }

    private static class Delegate implements NSObjectProtocol {
        
    }
}
``` 

causes compilation warning:  
> ObjCProtocol to NSObject failed: too many public constructors

and runtime crash if this class is used as `NSObjectProtocol` with `ObjC`:
> Delegate cannot be cast to org.robovm.objc.ObjCObject at org.robovm.objc.ObjCObject$Marshaler.protocolToNative

## Promoter was working only in case one constructor is present. 
But in case of private classes there is additional synthetic public constructor is created. Code updated to ignore synthetic constructors and allow multiple constructors to be available

## Inspection
Added Intellij Idea ispections to highlight following cases:
- if class implements NSObjectProtocol and extends `java.lang.Object` -- warning with quick fix to extend from NSObject (actually this class will be promoted)
- if class extends some class that implements NSObjectProtocol and extends `java.lang.Object` -- warning for both classes and quick fix to navigate to supper that can be updated with NSObject super.
- if class implements protocol but extends class that has some hierarchy behind -- mark as error as this class will not be handled by promoter and will cause Runtime crash

<img width="904" alt="image" src="https://github.com/MobiVM/robovm/assets/24827357/897a95c6-b934-4637-8622-9673e0cd4d7a">
