### PR TITLE
* workaround: idea debugger doesn't stop in Inner classes that extends from ObjCObject

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/util/generic/SootClassUtils.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/util/generic/SootClassUtils.java
@@ -1,0 +1,51 @@
+package org.robovm.compiler.util.generic;
+
+import soot.SootClass;
+import soot.SootMethod;
+import soot.SootResolver;
+import soot.tagkit.EnclosingMethodTag;
+import soot.tagkit.InnerClassTag;
+import soot.tagkit.Tag;
+
+public final class SootClassUtils {
+    private SootClassUtils() {
+    }
+
+    public static String getDeclaringClassName(SootClass sootClass) {
+        for (Tag tag : sootClass.getTags()) {
+            if (tag instanceof InnerClassTag) {
+                InnerClassTag icTag = (InnerClassTag) tag;
+                if (icTag.getInnerClass() != null && icTag.getOuterClass() != null) {
+                    String innerName = icTag.getInnerClass().replace('/', '.');
+                    if (sootClass.getName().equals(innerName)) {
+                        return icTag.getOuterClass().replace('/', '.');
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    public static String getEnclosingClassName(SootClass sootClass) {
+        EnclosingMethodTag emTag = (EnclosingMethodTag) sootClass.getTag("EnclosingMethodTag");
+        if (emTag != null) {
+            return emTag.getEnclosingClass();
+        }
+        return null;
+    }
+
+    /**
+     * checks if sootClass can be assigned with subSootClass (e.g. if subSootClass extends sootClass)
+     */
+    public static boolean isAssignableFrom(SootClass subSootClass, SootClass sootClass) {
+        if (sootClass.equals(subSootClass)) {
+            return true;
+        }
+
+        if (subSootClass.hasSuperclass()) {
+            return isAssignableFrom(subSootClass.getSuperclass(), sootClass);
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Root case:
ObjCClass preloads all instances of ObjCObject to find out if these have NativeObject annotations. As result inner class might be loaded before hosting class. This makes Idea debugger not happy and it ignores CLASS_PREPARE event and doesn't apply breakpoints to it. https://youtrack.jetbrains.com/issue/IDEA-332794

## Workaround
Lets preload host classes before all ObjCObject classes.

NB: affects only debug builds