### PR TITLE
* Idea Plugin: fix for IllegalStateException reported in review

### DIFF
--- a/plugins/idea/src/main/java/org/robovm/idea/components/setupwizard/JdkSetupDialog.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/components/setupwizard/JdkSetupDialog.java
@@ -12,6 +12,7 @@ import com.intellij.openapi.projectRoots.JavaSdk;
 import com.intellij.openapi.projectRoots.JdkUtil;
 import com.intellij.openapi.projectRoots.ProjectJdkTable;
 import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 
@@ -22,6 +23,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 public class JdkSetupDialog extends JDialog {
@@ -40,7 +42,10 @@ public class JdkSetupDialog extends JDialog {
         setTitle("RoboVM Setup");
         infoText.setText("<html>RoboVM requires Java Development Kit (JDK) 8.0 or higher.<br><br>Please specify the location of your JDK.");
 
-        for (String jdkLocation : JavaSdk.getInstance().suggestHomePaths()) {
+        final Collection<String> existingSdks = ApplicationManager.getApplication().runWriteAction(
+                (Computable<Collection<String>>) () -> JavaSdk.getInstance().suggestHomePaths()
+        );
+        for (String jdkLocation : existingSdks) {
             jdkHome.setText(jdkLocation);
             break;
         }


### PR DESCRIPTION
Note: from the log it seems like the test is being running in WSL on Windows machine. So it should not affect Mac users

> After performing an additional automated check, we have found that this plugin version causes the freeze on the IDE startup:

```
java.lang.IllegalStateException: This method is forbidden on EDT because it does not pump the event queue. Switch to a BGT, or use com.intellij.openapi.progress.TasksKt.runWithModalProgressBlocking.
 at com.intellij.openapi.progress.CoroutinesKt.assertBackgroundThreadOrWriteAction(coroutines.kt:448)
 at com.intellij.openapi.progress.CoroutinesKt.runBlockingCancellable(coroutines.kt:125)
 at com.intellij.openapi.progress.CoroutinesKt.runBlockingCancellable(coroutines.kt:121)
 at com.intellij.execution.wsl.WslIjentUtil.fetchLoginShellEnv(WslIjentUtil.kt:34)
 at com.intellij.execution.wsl.WSLDistribution.getEnvironmentVariable(WSLDistribution.java:794)
 at com.intellij.openapi.projectRoots.impl.JavaHomeFinderWsl$WslSystemInfoProvider.getEnvironmentVariable(JavaHomeFinderWsl.java:59)
 at com.intellij.openapi.projectRoots.impl.JavaHomeFinderBasic.findInPATH(JavaHomeFinderBasic.java:122)
 at com.intellij.openapi.projectRoots.impl.JavaHomeFinderBasic.findExistingJdks(JavaHomeFinderBasic.java:102)
 at com.intellij.openapi.projectRoots.impl.JavaHomeFinderWindows._init_$lambda$0(JavaHomeFinderWindows.kt:71)
 at com.intellij.openapi.projectRoots.impl.JavaHomeFinderBasic.findExistingJdks(JavaHomeFinderBasic.java:102)
 at com.intellij.openapi.projectRoots.impl.JavaHomeFinder.suggestHomePaths(JavaHomeFinder.java:73)
 at com.intellij.openapi.projectRoots.impl.JavaHomeFinder.suggestHomePaths(JavaHomeFinder.java:61)
 at com.intellij.openapi.projectRoots.impl.JavaSdkImpl.suggestHomePaths(JavaSdkImpl.java:196)
 at org.robovm.idea.components.setupwizard.JdkSetupDialog.<init>(JdkSetupDialog.java:43)
 at org.robovm.idea.components.RoboVmApplicationComponent.displaySetupWizard(RoboVmApplicationComponent.java:65)
 at org.robovm.idea.components.RoboVmApplicationComponent.initComponent(RoboVmApplicationComponent.java:47)
Today

```