### PR TITLE
Upgrade eclipse tycho and update site

### DIFF
--- a/plugins/eclipse/pom.xml
+++ b/plugins/eclipse/pom.xml
@@ -29,8 +29,8 @@
 
     <properties>
         <robovm.version>2.3.22-SNAPSHOT</robovm.version>
-        <tycho.version>3.0.3</tycho.version>
-        <eclipse-site>https://download.eclipse.org/releases/2021-09/</eclipse-site>
+        <tycho.version>4.0.7</tycho.version>
+        <eclipse-site>https://download.eclipse.org/releases/2024-06/</eclipse-site>
     </properties>
 
     <repositories>


### PR DESCRIPTION
# Context

When i build `MobiVM/robovm` i get a build error with the Eclipse plugin:

```sh
$ ./build.sh
...
[INFO] RoboVM for Eclipse Core and UI ..................... FAILURE [  0.500 s]
[INFO] RoboVM for Eclipse Feature ......................... SKIPPED
[INFO] RoboVM for Eclipse Update Site ..................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  9.255 s
[INFO] Finished at: 2024-03-30T18:01:06+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.eclipse.tycho:tycho-compiler-plugin:3.0.3:validate-classpath \
 (default-validate-classpath) on project org.robovm.eclipse.ui: \
Execution default-validate-classpath of goal org.eclipse.tycho:tycho-compiler-plugin:3.0.3:validate-classpath failed: \
bundleLocation not found: /Users/lmaitre/.m2/repository/p2/osgi/bundle/org.apache.batik.css/1.14.0.v20210324-0332/org.apache.batik.css-1.14.0.v20210324-0332.jar \
-> [Help 1]
```

Upgrading Eclipse Tycho plugin to a newer version makes it compiling.

## Implementation

Update Eclipse Tycho plugin to `4.0.7` and the update site to `2024-06`.

## Tests

The whole project compile ok (with also the patch from https://github.com/MobiVM/robovm/pull/773 ).

The plugin install inside Eclipse and i can create a RoboVM project.

I have not tested further as i don't use Eclipse so much nowadays (or at least i don't create my libgdx project with Eclipse).

Will update if i do more tests, but at least it is a tips for people who would have issue building the full robovm project nowadays i hope.