### PR TITLE
* fixed: gradle plugin failed to be deployed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,4 @@ set -e
 mvn clean install
 ./plugins/idea/gradlew -b plugins/idea/build.gradle clean buildPlugin
 mvn -f plugins/eclipse/pom.xml clean install
-./plugins/gradle/gradlew -b plugins/gradle/build.gradle clean assemble publishToMavenLocal
+./plugins/gradle/gradlew -b plugins/gradle/build.gradle clean assemble validatePlugins publishToMavenLocal

--- a/plugins/gradle/build.gradle
+++ b/plugins/gradle/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    id "com.github.johnrengelman.shadow" version "8.1.0"
+    id "com.github.johnrengelman.shadow" version "8.1.1"
     id "com.gradle.plugin-publish" version "1.2.1"
-    id 'java'
+    id 'java-gradle-plugin'
     id 'groovy'
     id 'maven-publish'
     id 'signing'
@@ -60,11 +60,7 @@ gradlePlugin {
 
 publishing {
     publications {
-        mavenJava(MavenPublication) {
-            groupId = 'com.mobidevelop.robovm'
-            artifactId = 'robovm-gradle-plugin'
-            from components.java
-
+        pluginMaven(MavenPublication) {
             pom {
                 name = 'RoboVM Gradle Plugin'
                 packaging = 'jar'
@@ -118,9 +114,6 @@ java {
 
 shadowJar {
     archiveClassifier.set('')
-    dependencies {
-        exclude(dependency("com.mobidevelop.robovm:robovm-compiler:${roboVMVersion}"));
-    }
     relocate 'org.apache.http', 'com.mobidevelop.robovm.org.apache.http'
     relocate 'org.apache.commons.io', 'com.mobidevelop.robovm.org.apache.commons.io'
     relocate 'org.objectweb.asm', 'com.mobidevelop.robovm.asm'
@@ -133,7 +126,7 @@ tasks.withType(Javadoc) {
 
 signing {
     required { !version.endsWith('SNAPSHOT') && gradle.taskGraph.hasTask("publish") }
-    sign publishing.publications.mavenJava
+    sign publishing.publications.pluginMaven
 }
 
 assemble.dependsOn('shadowJar')

--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractSimulatorTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractSimulatorTask.java
@@ -94,7 +94,6 @@ public abstract class AbstractSimulatorTask extends AbstractRoboVMTask {
     @Internal
     protected abstract Arch getArch();
 
-    @Internal
     protected DeviceType getDeviceType(DeviceType.DeviceFamily family) {
         String deviceName = (String) project.getProperties().get("robovm.device.name");
         String sdkVersion = (String) project.getProperties().get("robovm.sdk.version");


### PR DESCRIPTION
it discovered a set of issue:

## Issue 1. plugin wasn't deployed in several last builds from master branch.
```
 Execution failed for task ':validatePlugins'.
  > Plugin validation failed with 1 problem:
      - Error: Type 'org.robovm.gradle.tasks.AbstractSimulatorTask' method 'getDeviceType()' should not be annotated with: @Internal.
```
fix: annotation was removed (method doesn't look as pure getter) and `validatePlugins` option was added to build invocation

## Issue 2. its discovered that after #766 applied build failed with:
```
* What went wrong:
A problem occurred configuring project ':facebook-share-kit'.
> Could not create task ':facebook-share-kit:launchIPhoneSimulator'.
   > Could not create task of type 'IPhoneSimulatorTask'.
      > Could not generate a decorated class for type IPhoneSimulatorTask.
         > org/robovm/compiler/log/Logger
Caused by: java.lang.NoClassDefFoundError: org/robovm/compiler/log/Logger
```
root case of it: `robovm-compiler` dependency was excluded from shadowJar (thats a bug). But it was working as previously pom.xml contained runtime dependency to `robovm-compiler` (that's another bug as we produce shadowJar with merged dependencies)

## Issue 3: pom.xml for gradle plugin is empty
```
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <!-- This module was also published with a richer model, Gradle metadata,  -->
  <!-- which should be used instead. Do not delete the following line which  -->
  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
  <!-- that they should prefer consuming it instead. -->
  <!-- do_not_remove: published-with-gradle-metadata -->
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.mobidevelop.robovm</groupId>
  <artifactId>robovm-gradle-plugin</artifactId>
  <version>2.3.22-SNAPSHOT</version>
</project>
```
it happens as `plugin-publish` uses `pluginMaven` publication but we set metadata for `mavenJava`, due another bug both `pluginMaven` and `mavenJava` are being deployed and `pluginMaven` overrides first  (thats another issues)

## Issue 4: two artifacts are being deployed under same id:   `pluginMaven` and `mavenJava`
it can be observer as following warning:
> Multiple publications with coordinates 'com.mobidevelop.robovm:robovm-gradle-plugin:2.3.22-SNAPSHOT' are published to repository 'mavenLocal'. The publications 'mavenJava' in root project 'robovm-gradle-plugin' and 'pluginMaven' in root project 'robovm-gradle-plugin' will overwrite each other!

Fixes:
1. To have single prorely configured artifact `mavenJava` to be removed and `pluginMaven` used as described in `plugin-publish` docs;
2. `Caused by: java.lang.NoClassDefFoundError: org/robovm/compiler/log/Logger` is fixed by removing 'exclude(dependency' -- compiler has to be packed into shadowJar