### PR TITLE
* idea: fixed -- manual adding of RoboVM SDK from File/Project structure

### DIFF
--- a/plugins/idea/src/main/java/org/robovm/idea/sdk/RoboVmSdkType.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/sdk/RoboVmSdkType.java
@@ -75,6 +75,13 @@ public class RoboVmSdkType extends SdkType implements JavaSdkType {
         return SDK_NAME + " " + Version.getCompilerVersion();
     }
 
+    @Override
+    public @Nullable String getVersionString(@NotNull String sdkHome) {
+        if (sdkHome.equals(suggestHomePath()))
+            return Version.getCompilerVersion();
+        else return null;
+    }
+
     @Nullable
     @Override
     public AdditionalDataConfigurable createAdditionalDataConfigurable(@NotNull SdkModel sdkModel, @NotNull SdkModificator sdkModificator) {
@@ -123,7 +130,9 @@ public class RoboVmSdkType extends SdkType implements JavaSdkType {
         sdkModificator.setHomePath(RoboVmPlugin.getSdkHome().getAbsolutePath());
 
         // commit changes and let IDEA handle the rest
-        sdkModificator.commitChanges();
+        ApplicationManager.getApplication().invokeAndWait(() ->
+                ApplicationManager.getApplication().runWriteAction(sdkModificator::commitChanges)
+        );
     }
 
     public static void createSdkIfNotExists() {


### PR DESCRIPTION
## intro
We use several components with Idea plugin that were marked deprecated for several years already. And seems in recent IDEA version 2024.1.1 we have an issue with RoboVM SDK being added and then removed. (check video)

As workaround while code is not migrated SDK should be added manually. But it wasn't working as well. This PR fixed it, 

https://github.com/MobiVM/robovm/assets/24827357/41b6102c-47c1-4bd9-ab49-95c506625580


## Fix:
- It was failing due version was not returned
- SDK paths were configured not on Writable scope