### PR TITLE
* fixed: compilation failed due swift lib not found (libswiftXPC.dylib is not found in swift paths)

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -851,7 +851,7 @@ public class IOSTarget extends AbstractTarget {
                 }
 
                 swiftSupportDir.mkdirs();
-                copySwiftLibs(Arrays.asList(swiftLibs), swiftSupportDir, false);
+                copySwiftLibs(Arrays.asList(swiftLibs), Collections.emptyList(), swiftSupportDir, false);
             }
         }
 


### PR DESCRIPTION
Recent Facebook FBSDKCoreKit has dependency to `libswiftXPC.dylib`. But it is not present in SDK and cause build to fail with message:

> libswiftXPC.dylib is not found in swift paths

this is happening during copying swift-libraries into App/Frameworks folder. Same time this dependency is declared as weak:

> @rpath/libswiftXPC.dylib (compatibility version 1.0.0, current version 36.100.7, weak)

its seems to an option to skip missing swift libraries that are marked as weak. these changes provided in this PR