### PR TITLE
* maintenance: interface builder integration

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -632,7 +632,7 @@ public class Config {
     }
 
     public Tools getTools() {
-        return tools;
+        return tools != null ? tools : Tools.Empty;
     }
 
     public WatchKitApp getWatchKitApp() {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/tools/IBXOptions.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/tools/IBXOptions.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.compiler.config.tools;
+
+import org.simpleframework.xml.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Settings to control Interface Builder/Xcode integration, appears in tools section of config:
+ * <config>
+ *     <tools>
+ *         <ibx>
+ *             <include>MyFramework/MyFramework.h</>
+ *             <include import="true">MyModule</>
+ *             <filter exclude=true>FBLPromises</filter>
+ *         <ibx/>
+ *     </tools>
+ * </config>
+ * @author dkimitsa
+ */
+public class IBXOptions {
+    /**
+     * pre-compiled headers file generation options
+     */
+    @Element(required = false)
+    private PCHOptions pch;
+
+    public PCHOptions getPrecompileHeadersOptions() {
+        return pch;
+    }
+
+    public static class PCHOptions {
+        @ElementList(required = false, entry = "include", inline = true)
+        private ArrayList<IncludeEntry> includes;
+
+        @ElementList(required = false, entry = "filter", inline = true)
+        private ArrayList<FilterEntry> filters;
+
+        public List<IncludeEntry> getIncludes() {
+            return includes != null ? includes : Collections.emptyList();
+        }
+
+        public List<FilterEntry> getFilters() {
+            return filters != null ? filters : Collections.emptyList();
+        }
+    }
+
+    public static class IncludeEntry {
+        @Text
+        String includeText;
+
+        @Attribute(name = "import", required = false)
+        boolean isImport = false;
+
+        /**
+         * @return text to be included into `#include <includeText>` or `@import includeText;`
+         */
+        public String getIncludeText() {
+            return includeText;
+        }
+
+        public boolean isImport() {
+            return isImport;
+        }
+    }
+
+    public static class FilterEntry {
+        @Text
+        String antPathPattern;
+
+        @Attribute(name = "exclude", required = false)
+        boolean exclude = false;
+
+        public String getAntPathPattern() {
+            return antPathPattern;
+        }
+
+        public boolean isExclude() {
+            return exclude;
+        }
+    }
+}

--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/tools/Tools.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/tools/Tools.java
@@ -23,6 +23,8 @@ import org.simpleframework.xml.Element;
  *
  */
 public class Tools {
+    public static Tools Empty = new Tools();
+
     @Element(required = false)
     private TextureAtlas textureAtlas;
 
@@ -31,6 +33,9 @@ public class Tools {
 
     @Element(required = false)
     private ActoolOptions actool;
+
+    @Element(required = false)
+    private IBXOptions ibx;
 
     public TextureAtlas getTextureAtlas() {
         return textureAtlas;
@@ -42,5 +47,9 @@ public class Tools {
 
     public ActoolOptions getActool() {
         return actool;
+    }
+
+    public IBXOptions getIbx() {
+        return ibx;
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -798,7 +798,7 @@ public class IOSTarget extends AbstractTarget {
 
     @Override
     public List<Arch> getDefaultArchs() {
-        return Arrays.asList(new Arch(CpuArch.thumbv7), new Arch(CpuArch.arm64));
+        return List.of(new Arch(CpuArch.arm64));
     }
 
     public void archive() throws IOException {

--- a/plugins/ibxcode/src/main/java/org/robovm/ibxcode/export/FrameworkExportData.java
+++ b/plugins/ibxcode/src/main/java/org/robovm/ibxcode/export/FrameworkExportData.java
@@ -20,9 +20,16 @@ import java.io.File;
 public class FrameworkExportData {
     public final String name;
     public final File path;
+    public final File frameworkPath;
 
-    public FrameworkExportData(String name, File path) {
+    /**
+     * @param name           - name of framework with .framework or .xcframework suffix
+     * @param path           - location of framework: either .xcframework or .framwork folder
+     * @param frameworkPath  - location of framework in case of .xcframwork otherwise same as path
+     */
+    public FrameworkExportData(String name, File path, File frameworkPath) {
         this.name = name;
         this.path = path;
+        this.frameworkPath = frameworkPath;
     }
 }

--- a/plugins/ibxcode/src/main/java/org/robovm/ibxcode/pbxproj/PBXFile.java
+++ b/plugins/ibxcode/src/main/java/org/robovm/ibxcode/pbxproj/PBXFile.java
@@ -59,6 +59,8 @@ public class PBXFile extends PBXNode{
             return "text.plist.strings";
         else if (fileName.endsWith(".framework"))
             return "wrapper.framework";
+        else if (fileName.endsWith(".xcframework"))
+            return "wrapper.xcframework";
         else if (fileName.endsWith(".plist"))
             return "text.plist.xml";
         else if (file != null && file.isDirectory())

--- a/plugins/ibxcode/src/main/java/org/robovm/ibxcode/pbxproj/PBXGroup.java
+++ b/plugins/ibxcode/src/main/java/org/robovm/ibxcode/pbxproj/PBXGroup.java
@@ -1,11 +1,6 @@
 package org.robovm.ibxcode.pbxproj;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class PBXGroup extends PBXNode{
     private final List<PBXNode>children = new ArrayList<>();
@@ -18,7 +13,7 @@ public class PBXGroup extends PBXNode{
         GROUP("PBXGroup"),
         VARIANT_GROUP("PBXVariantGroup");
 
-        private String value;
+        private final String value;
         Type(String s) {
             value = s;
         }
@@ -48,9 +43,8 @@ public class PBXGroup extends PBXNode{
     }
 
     public List<PBXNode> getSortedChildren(Comparator<? super PBXNode> comparator) {
-        List<PBXNode> sortedList = new ArrayList<>();
-        sortedList.addAll(children);
-        Collections.sort(sortedList, comparator);
+        List<PBXNode> sortedList = new ArrayList<>(children);
+        sortedList.sort(comparator);
         return sortedList;
     }
 

--- a/plugins/ibxcode/src/main/java/org/robovm/ibxcode/pbxproj/PBXProject.java
+++ b/plugins/ibxcode/src/main/java/org/robovm/ibxcode/pbxproj/PBXProject.java
@@ -2,18 +2,16 @@ package org.robovm.ibxcode.pbxproj;
 
 import java.io.File;
 import java.io.PrintStream;
-import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.List;
 
 public class PBXProject extends PBXNode {
     private final File projectDir;
 
-    private final PBXGroup rootGroup = new PBXGroup(this, "root");;
-    private final PBXGroup sourcesGroup = rootGroup.addChild(new PBXGroup(this, "sources"));;
+    private final PBXGroup rootGroup = new PBXGroup(this, "root");
+    private final PBXGroup sourcesGroup = rootGroup.addChild(new PBXGroup(this, "sources"));
     private final PBXGroup resourcesGroup = rootGroup.addChild(new PBXGroup(this, "resources"));
     private final PBXGroup frameworksGroup = rootGroup.addChild(new PBXGroup(this, "frameworks"));
-    private final PBXGroup buildFilesGroup = new PBXGroup(this, "buildFileGroup");;
+    private final PBXGroup buildFilesGroup = new PBXGroup(this, "buildFileGroup");
     private final PBXNode buildConfigurationList = new PBXNode(this, "Build configuration list for PBXProject");
     private final PBXNode buildConfigurationRoboVM = new PBXNode(this, "RoboVM");
     private final PBXNode sourcesBuildPhaseRoboVM = new PBXNode(this, "Sources");
@@ -191,8 +189,11 @@ public class PBXProject extends PBXNode {
         bodyPs.println("buildSettings = {");
         childPs.println("SDKROOT = iphoneos;");
         childPs.println("PRODUCT_NAME = \"RoboVM\";");
+        childPs.println("CLANG_ENABLE_MODULES = \"YES\";");
         childPs.println("GCC_PRECOMPILE_PREFIX_HEADER = \"YES\";");
         childPs.println("GCC_PREFIX_HEADER = Prefix.pch;");
+        childPs.println("GENERATE_INFOPLIST_FILE = \"YES\";");
+        childPs.println("INFOPLIST_FILE = Info.plist;");
         bodyPs.println("};");
         bodyPs.println("name = \"" + buildConfigurationRoboVM.getName() +"\";");
         ps.println("};");
@@ -221,7 +222,7 @@ public class PBXProject extends PBXNode {
         bodyPs.println("buildActionMask = 2147483647;");
         bodyPs.println("files = (");
         for (PBXNode node : buildFilesGroup.getChildren())
-            if (node.getName().endsWith(".framework"))
+            if (node.getName().endsWith(".framework") || node.getName().endsWith(".xcframework"))
                 childPs.println(node.uuidWithComment() + ",");
         bodyPs.println(");");
         bodyPs.println("runOnlyForDeploymentPostprocessing = 0;");
@@ -271,20 +272,17 @@ public class PBXProject extends PBXNode {
     }
 
     /** comparator to sort items */
-    private Comparator<PBXNode> PROJECT_ITEM_COMPARATOR = new Comparator<PBXNode>() {
-        @Override
-        public int compare(PBXNode o1, PBXNode o2) {
-            // put groups top
-            boolean g1 = o1 instanceof PBXGroup;
-            boolean g2 = o2 instanceof PBXGroup;
-            if (g1 == g2) {
-                // both are groups or both are not
-                // compare names
-                return o1.getName().compareTo(o2.getName());
-            } else {
-                // node that is group will go top
-                return g1 ? -1 : 1;
-            }
+    private final Comparator<PBXNode> PROJECT_ITEM_COMPARATOR = (o1, o2) -> {
+        // put groups top
+        boolean g1 = o1 instanceof PBXGroup;
+        boolean g2 = o2 instanceof PBXGroup;
+        if (g1 == g2) {
+            // both are groups or both are not
+            // compare names
+            return o1.getName().compareTo(o2.getName());
+        } else {
+            // node that is group will go top
+            return g1 ? -1 : 1;
         }
     };
 

--- a/plugins/idea/src/main/resources/META-INF/plugin.xml
+++ b/plugins/idea/src/main/resources/META-INF/plugin.xml
@@ -63,6 +63,7 @@
                          level="WARNING"
                          implementationClass="org.robovm.idea.inspection.ClassWithProtocolShouldExtendNSObject"
                          cleanupTool="true"/>
+        <notificationGroup id="RoboVM" displayType="BALLOON"/>
 
     </extensions>
 


### PR DESCRIPTION
Main reason -- to be able to compile Stub in Xcode without errors.

What was fixed:
## Cannot code sign because the target does not have an Info.plist file 
Info.plist is now generated and included into xcode project.


## Undefined symbols for architecture arm64: "_main" 
Stub `int main() {}` is now generated and included into xcode project.

## multiple `FrameworkName/FrameworkName.h` not found
Error while compiling pre-compiled header file where all framework are being referenced. XCode doesn't seem to recognise single arch framework. Changes where done:
- propagate XCFrameworks instead of its framework.
- clang modules are enabled now;
- not all frameworks have umbrella header with same name, e.g. `FrameworkName/FrameworkName.h`, logic added to look for Swift umbrellas as well.
- if umbrella header is not found -- framework is not included into pre-compiled headers.

To have manual control over the logic and to be able to add extra imports and filter out not required config was extended with following section:
```xml
<config>
    <tools>
        <ibx>
            <pch>
                <include>MyFramework/MyFramework.h</include>
                <include import="true">MyModule</include>
                <filter exclude="true">*Promises*</filter>
            </pch>
        </ibx>
    </tools>
</config>
```

`pch` section allow to include additional frameworks with `include` tags. if `import` attribute is specified -- `@import` will be used instead of `#import` (works for modules). `filter` tag allows to exclude from pre-compiled header files reference to not required framework. For example `FBLPromises` causes following error:
> fatal error: module 'PromisesObjC' in AST file

## Also thumbv7 removed from default iOS target