### PR TITLE
* gradle plugin: arguments support for launch* tasks

### DIFF
--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractSimulatorTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractSimulatorTask.java
@@ -15,7 +15,9 @@
  */
 package org.robovm.gradle.tasks;
 
+import org.apache.tools.ant.types.Commandline;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.options.Option;
 import org.robovm.compiler.AppCompiler;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
@@ -25,11 +27,18 @@ import org.robovm.compiler.target.ios.IOSSimulatorLaunchParameters;
 import org.robovm.gradle.RoboVMGradleException;
 
 import java.io.File;
+import java.util.Arrays;
 
 /**
  *
  */
 public abstract class AbstractSimulatorTask extends AbstractRoboVMTask {
+    private String[] args;
+
+    @Option(option = "args", description = "Command line arguments passed to app.")
+    public void setArgs(String args) {
+        this.args = Commandline.translateCommandline(args);
+    }
 
     protected void launch(DeviceType type) {
         try {
@@ -42,6 +51,9 @@ public abstract class AbstractSimulatorTask extends AbstractRoboVMTask {
             Config config = compiler.getConfig();
             IOSSimulatorLaunchParameters launchParameters = (IOSSimulatorLaunchParameters) config.getTarget().createLaunchParameters();
             launchParameters.setDeviceType(type);
+            if (args != null) {
+                launchParameters.setArguments(Arrays.asList(args));
+            }
 
             if (extension.getStdoutFifo() != null) {
                 File stdoutFifo = new File(extension.getStdoutFifo());

--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/ConsoleTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/ConsoleTask.java
@@ -15,6 +15,8 @@
  */
 package org.robovm.gradle.tasks;
 
+import org.apache.tools.ant.types.Commandline;
+import org.gradle.api.tasks.options.Option;
 import org.robovm.compiler.AppCompiler;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
@@ -23,10 +25,18 @@ import org.robovm.compiler.target.ConsoleTarget;
 import org.robovm.compiler.target.LaunchParameters;
 import org.robovm.gradle.RoboVMGradleException;
 
+import java.util.Arrays;
+
 /**
  *
  */
 public class ConsoleTask extends AbstractRoboVMTask {
+    private String[] args;
+
+    @Option(option = "args", description = "Command line arguments passed to app.")
+    public void setArgs(String args) {
+        this.args = Commandline.translateCommandline(args);
+    }
 
     @Override
     public void invoke() {
@@ -39,6 +49,9 @@ public class ConsoleTask extends AbstractRoboVMTask {
             AppCompiler compiler = build(OS.getDefaultOS(), arch, ConsoleTarget.TYPE);
             Config config = compiler.getConfig();
             LaunchParameters launchParameters = config.getTarget().createLaunchParameters();
+            if (args != null) {
+                launchParameters.setArguments(Arrays.asList(args));
+            }
             compiler.launch(launchParameters);
         } catch (Throwable t) {
             throw new RoboVMGradleException("Failed to launch console application", t);

--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/IOSDeviceTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/IOSDeviceTask.java
@@ -15,6 +15,8 @@
  */
 package org.robovm.gradle.tasks;
 
+import org.apache.tools.ant.types.Commandline;
+import org.gradle.api.tasks.options.Option;
 import org.robovm.compiler.AppCompiler;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
@@ -23,11 +25,20 @@ import org.robovm.compiler.target.ios.IOSDeviceLaunchParameters;
 import org.robovm.compiler.target.ios.IOSTarget;
 import org.robovm.gradle.RoboVMGradleException;
 
+import java.util.Arrays;
+
 /**
  *
  * @author Junji Takakura
  */
 public class IOSDeviceTask extends AbstractRoboVMTask {
+
+    private String[] args;
+
+    @Option(option = "args", description = "Command line arguments passed to app.")
+    public void setArgs(String args) {
+        this.args = Commandline.translateCommandline(args);
+    }
 
     @Override
     public void invoke() {
@@ -47,6 +58,9 @@ public class IOSDeviceTask extends AbstractRoboVMTask {
 			if(udid != null && !udid.isEmpty()){
 				launchParameters.setDeviceId(udid);
 			}
+            if (args != null) {
+                launchParameters.setArguments(Arrays.asList(args));
+            }
             compiler.launch(launchParameters);
         } catch (Throwable t) {
             throw new RoboVMGradleException("Failed to launch IOS Device", t);


### PR DESCRIPTION
These changes allows to pass arguments to application, when launching it on device/simulator similar to arguments field in Idea run/debug configuration. Beside debug/specific cases this is also required to enable debug mode of Crashlytics: https://firebase.google.com/docs/crashlytics/test-implementation?platform=ios

Custom commands are supported since Gradle v5.
Usage as simple as: `./gradlew  launchIPhoneSimulator --info --args "'hello world'"`

String passed in `--args` is then tokenized into individual arguments, e.g. `--args="one two"` will produce two arguments in args array ["one", "two"], if spaces to be considered as part of argument, quotation to be used.

Gradle also propagate option description to help command:
```
./gradlew help --task launchIPhoneSimulator

> Task :help
Detailed task information for launchIPhoneSimulator

Path
     :launchIPhoneSimulator

Type
     IPhoneSimulatorTask (org.robovm.gradle.tasks.IPhoneSimulatorTask)

Options
     --args     Command line arguments passed to app.

Description
     Runs your iOS app in the iPhone simulator

Group
     MobiVM

```