### PR TITLE
Implement static hashcode functions for scalar types

### DIFF
--- a/compiler/rt/libcore/luni/src/main/java/java/lang/Double.java
+++ b/compiler/rt/libcore/luni/src/main/java/java/lang/Double.java
@@ -221,6 +221,11 @@ public final class Double extends Number implements Comparable<Double> {
         return (int) (v ^ (v >>> 32));
     }
 
+    public static int hashCode(double value) {
+        long v = doubleToLongBits(value);
+        return (int) (v ^ (v >>> 32));
+    }
+
     @Override
     public int intValue() {
         return (int) value;

--- a/compiler/rt/libcore/luni/src/main/java/java/lang/Float.java
+++ b/compiler/rt/libcore/luni/src/main/java/java/lang/Float.java
@@ -224,6 +224,10 @@ public final class Float extends Number implements Comparable<Float> {
         return floatToIntBits(value);
     }
 
+    public static int hashCode(float value) {
+        return floatToIntBits(value);
+    }
+
     /**
      * Returns the <a href="http://en.wikipedia.org/wiki/IEEE_754-1985">IEEE 754</a>
      * single precision float corresponding to the given {@code bits}.

--- a/compiler/rt/libcore/luni/src/main/java/java/lang/Integer.java
+++ b/compiler/rt/libcore/luni/src/main/java/java/lang/Integer.java
@@ -302,6 +302,10 @@ public final class Integer extends Number implements Comparable<Integer> {
         return value;
     }
 
+    public static int hashCode(int value) {
+        return value;
+    }
+
     /**
      * Gets the primitive value of this int.
      *

--- a/compiler/rt/libcore/luni/src/main/java/java/lang/Long.java
+++ b/compiler/rt/libcore/luni/src/main/java/java/lang/Long.java
@@ -289,6 +289,10 @@ public final class Long extends Number implements Comparable<Long> {
         return (int) (value ^ (value >>> 32));
     }
 
+    public static int hashCode(long value) {
+        return (int) (value ^ (value >>> 32));
+    }
+
     @Override
     public int intValue() {
         return (int) value;

--- a/compiler/rt/libcore/luni/src/main/java/java/lang/Short.java
+++ b/compiler/rt/libcore/luni/src/main/java/java/lang/Short.java
@@ -169,6 +169,10 @@ public final class Short extends Number implements Comparable<Short> {
         return value;
     }
 
+    public static int hashCode(short value) {
+        return value;
+    }
+
     @Override
     public int intValue() {
         return value;


### PR DESCRIPTION
It seems recent Kotlin versions are generating code that relies on the Java 1.8 static `hashCode(x)` functions which are not present in the libcore implementation, which results in "method not found" errors e.g. when using a data class with double members in a hashed collection.

This PR adds those functions for Double, Float, Long, Integer and Short.