### PR TITLE
* gradle plugin: propagating gradle properties to config.properties

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -1577,6 +1577,11 @@ public class Config {
             return this;
         }
 
+        public Builder addProperties(Map<String, ?> properties) {
+            config.properties.putAll(properties);
+            return this;
+        }
+
         public Builder addProperties(File file) throws IOException {
             Properties props = new Properties();
             try (Reader reader = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8)) {

--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMTask.java
@@ -58,10 +58,8 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
 /**
@@ -135,6 +133,13 @@ abstract public class AbstractRoboVMTask extends DefaultTask {
                                 + project.getProjectDir().getAbsolutePath(), e);
             }
         }
+
+        // add project properties on top of one read from property file
+        // leave only not nullable string values
+        Map<String, String> gradleProperties = project.getProperties().entrySet().stream()
+                .filter( e -> e.getValue() instanceof String)
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString()));
+        builder.addProperties(gradleProperties);
 
         if (extension.getConfigFile() != null) {
             File configFile = new File(extension.getConfigFile());


### PR DESCRIPTION
It allows to specify/override properties that are used in property file, as long as Info.plist etc

Usage:
```
./gradlew help launchIPhoneSimulator --info  -Papp.name=test
```