### PR TITLE
* maintenance: XCode16 support (also fixes #795)

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -172,9 +172,6 @@ public class Config {
     @Element(required = false)
     private Tools tools;
 
-    @Element(required = false)
-    private Boolean enableBitcode;
-
     private SigningIdentity iosSignIdentity;
     private ProvisioningProfile iosProvisioningProfile;
     private String iosDeviceType;
@@ -621,14 +618,23 @@ public class Config {
         return iosSkipSigning;
     }
 
-    public boolean isEnableBitcode() {return enableBitcode != null && enableBitcode && shouldEmitBitcode(); }
+    public boolean isEnableBitcode() {
+        // TODO: FIXME: bitcode forced to be disabled as with XCode16 it is deprecated and Apple will not accept
+        //              binaries with it. Infrastructure is kept for a while
+
+        return false;
+    }
 
     public boolean shouldEmitBitcode() {
         // emit bitcode to object file even if it is not enabled.
         // as currently only `__LLVM,__asm` is being added
         // but build should match criteria
-        return !debug && os == OS.ios && sliceArch.getEnv() == Environment.Native &&
-                (sliceArch.getCpuArch() == CpuArch.arm64 || sliceArch.getCpuArch() == CpuArch.thumbv7);
+        // return !debug && os == OS.ios && sliceArch.getEnv() == Environment.Native &&
+        //        (sliceArch.getCpuArch() == CpuArch.arm64 || sliceArch.getCpuArch() == CpuArch.thumbv7);
+
+        // TODO: FIXME: bitcode forced to be disabled as with XCode16 it is deprecated and Apple will not accept
+        //              binaries with it. Infrastructure is kept for a while
+        return false;
     }
 
     public Tools getTools() {
@@ -1653,11 +1659,6 @@ public class Config {
 
         public Builder addTargetPlugin(TargetPlugin plugin) {
             config.plugins.add(plugin);
-            return this;
-        }
-
-        public Builder enableBitcode(boolean enableBitcode) {
-            config.enableBitcode = enableBitcode;
             return this;
         }
 

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/ProvisioningProfile.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/ProvisioningProfile.java
@@ -197,12 +197,27 @@ public class ProvisioningProfile implements Comparable<ProvisioningProfile> {
     }
     
     public static List<ProvisioningProfile> list() {
-        File dir = new File(new File(System.getProperty("user.home")), "Library/MobileDevice/Provisioning Profiles");
+        List<ProvisioningProfile> result = new ArrayList<>();
+        File userHome = new File(System.getProperty("user.home"));
+        listTo(result, new File(userHome, "Library/MobileDevice/Provisioning Profiles"));
+        listTo(result, new File(userHome, "Library/Developer/Xcode/UserData/Provisioning Profiles"));
+
+        Collections.sort(result);
+        return result;
+    }
+
+    /**
+     * Scans for provisioning profiles in given dir
+     * @param result list to add profiles to
+     * @param dir    to scan for profiles
+     */
+    private static void listTo(List<ProvisioningProfile> result, File dir) {
         if (!dir.exists() || !dir.isDirectory()) {
-            return Collections.emptyList();
+            return;
         }
-        List<ProvisioningProfile> result = new ArrayList<ProvisioningProfile>();
-        for (File f : dir.listFiles()) {
+        File[] files = dir.listFiles();
+        if (files == null) return;
+        for (File f : files) {
             if (f.getName().endsWith(".mobileprovision")) {
                 try {
                     // it was wrapped in try-catch instead of just returning null by purpose. With idea to provide information
@@ -216,8 +231,6 @@ public class ProvisioningProfile implements Comparable<ProvisioningProfile> {
                 }
             }
         }
-        Collections.sort(result);
-        return result;
     }
 
     public static ProvisioningProfile find(List<ProvisioningProfile> profiles, String search) {

--- a/compiler/llvm/src/test/java/org/robovm/llvm/ObjectFileTest.java
+++ b/compiler/llvm/src/test/java/org/robovm/llvm/ObjectFileTest.java
@@ -50,7 +50,7 @@ public class ObjectFileTest {
                     List<Symbol> symbols = objectFile.getSymbols();
                     assertEquals(1, symbols.size());
                     assertEquals("_foo", symbols.get(0).getName());
-                    assertTrue(symbols.get(0).getAddress() == 0);
+                    assertEquals(0, symbols.get(0).getAddress());
                     assertTrue(symbols.get(0).getSize() > 0);
                 }
             }
@@ -73,8 +73,8 @@ public class ObjectFileTest {
                         byte[] contents = new byte[(int) it.getSize()];
                         assertEquals(it.getSize(), it.copyContents(contents));
                         long sum = 0;
-                        for (int i = 0; i < contents.length; i++) {
-                            sum += contents[i];
+                        for (byte content : contents) {
+                            sum += content;
                         }
                         assertTrue(sum != 0);
                         
@@ -115,6 +115,7 @@ public class ObjectFileTest {
         executor.setWorkingDirectory(cFile.getParentFile());
         executor.execute(new CommandLine(cc)
             .addArgument("-g")
+            .addArgument("-gdwarf-2")
             .addArgument("-c")
             .addArgument(cFile.getAbsolutePath()));
         

--- a/compiler/vm/CMakeLists.txt
+++ b/compiler/vm/CMakeLists.txt
@@ -103,7 +103,10 @@ endif()
 
 if(DARWIN)
   if(NOT SYSROOT)
-    exec_program(xcode-select ARGS --print-path OUTPUT_VARIABLE XCODE_PATH)
+    execute_process(COMMAND xcode-select --print-path 
+      OUTPUT_VARIABLE XCODE_PATH 
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
     if(MACOSX)
       set(SYSROOT "${XCODE_PATH}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk")
       if(NOT IS_DIRECTORY ${SYSROOT})
@@ -133,7 +136,6 @@ set(C_FLAGS "${C_FLAGS} -std=gnu99 -fPIC")
 set(CXX_FLAGS "${CXX_FLAGS} -std=gnu++11 -fPIC")
 set(C_CXX_FLAGS "${C_CXX_FLAGS} -Wall -fPIC")
 if(NOT IOS)
-  # -fdata-sections -ffunction-sections conflicts with -fembed-bitcode
   set(C_CXX_FLAGS "${C_CXX_FLAGS} -fdata-sections -ffunction-sections")
 endif()
 if(CTARGET)
@@ -148,9 +150,6 @@ if(SYSROOT)
 endif()
 if(IOS)
   set(CMAKE_OSX_DEPLOYMENT_TARGET "") #reset variable for compat with SDK 10.12, see issue #48
-  if (ARM64 OR THUMBV7)
-    set(C_CXX_FLAGS "${C_CXX_FLAGS} -fembed-bitcode")
-  endif()
 endif()
 
 # Linker flags
@@ -191,9 +190,6 @@ if(MACOSX)
 endif()
 if(IOS)
   set(ASM_FLAGS "${ASM_FLAGS} -target ${CTARGET}")
-  if (ARCH STREQUAL "arm64" OR ARCH STREQUAL "thumbv7")
-    set(ASM_FLAGS "${ASM_FLAGS} -fembed-bitcode")
-  endif()
 endif()
 set(CMAKE_ASM_COMPILE_OBJECT "${CMAKE_C_COMPILER} ${ASM_FLAGS} -o <OBJECT> <SOURCE>")
 enable_language(ASM)

--- a/plugins/gradle/README.md
+++ b/plugins/gradle/README.md
@@ -107,12 +107,6 @@ The `robovmInstall` task is very similar to the `robovmArchive` task but doesn't
 gradle -Probovm.archs=x86:x86_64 robovmInstall
 ```
 
-To enable bitcode when running `createIPA`, `robovmArchive` or `robovmInstall` add `-Probovm.enableBitcode=true`:
-
-```
-gradle -Probovm.enableBitcode=true -Probovm.archs=thumbv7:arm64 robovmArchive
-```
-
 ## Headless code signing
 
 When building iOS/tvOS apps on a CI server `codesign` may need a password in order to unlock the keychain where the signing key is located. The Gradle plugin recognizes two properties which can be used to specify this password. If none of these properties have been specified the compiler will also look for a `KEYCHAIN_PASSWORD` environment variable.

--- a/plugins/gradle/src/main/java/org/robovm/gradle/RoboVMPluginExtension.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/RoboVMPluginExtension.java
@@ -39,7 +39,6 @@ public class RoboVMPluginExtension {
     private int debugPort = -1;
     private boolean skipLaunch = false;
     private boolean skipLinking = false;
-    private boolean enableBitcode = false;
     private String archs;
     private String installDir;    
     private String cacheDir;
@@ -173,16 +172,6 @@ public class RoboVMPluginExtension {
         this.skipLinking = skipLinking;
     }
 
-    public boolean isEnableBitcode() {
-        return project.hasProperty("robovm.enableBitcode")
-                ? Boolean.parseBoolean(project.getProperties().get("robovm.enableBitcode").toString())
-                : enableBitcode;
-    }
-
-    public void setEnableBitcode(boolean enableBitcode) {
-        this.enableBitcode = enableBitcode;
-    }
-    
     public int getDebugPort() {
         return project.hasProperty("robovm.debugPort") 
                 ? Integer.parseInt(project.getProperties().get("robovm.debugPort").toString()) 

--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMTask.java
@@ -221,9 +221,6 @@ abstract public class AbstractRoboVMTask extends DefaultTask {
         if (extension.isDumpIntermediates())
             builder.dumpIntermediates(true);
 
-        if (extension.isEnableBitcode())
-            builder.enableBitcode(true);
-
         builder.clearClasspathEntries();
 
         // configure the runtime classpath

--- a/plugins/maven/plugin/src/main/java/org/robovm/maven/plugin/AbstractRoboVMMojo.java
+++ b/plugins/maven/plugin/src/main/java/org/robovm/maven/plugin/AbstractRoboVMMojo.java
@@ -164,12 +164,6 @@ public abstract class AbstractRoboVMMojo extends AbstractMojo {
     @Parameter(property = "robovm.dumpIntermediates")
     protected boolean dumpIntermediates = false;
 
-    /**
-     * Whether the app should be build with bitcode embedded
-     */
-    @Parameter(property = "robovm.enableBitcode")
-    protected boolean enableBitcode = false;
-
     private Logger roboVMLogger;
 
     protected Config.Builder configure(Config.Builder builder) throws MojoExecutionException {
@@ -309,10 +303,6 @@ public abstract class AbstractRoboVMMojo extends AbstractMojo {
 
         if (dumpIntermediates) {
             builder.dumpIntermediates(true);
-        }
-
-        if (enableBitcode) {
-            builder.enableBitcode(true);
         }
 
         builder.clearClasspathEntries();


### PR DESCRIPTION
- bitcode is disabled as deprecated, causes binary verification fail at apple side, also causes VM natives compilation to fail
- added `Library/Developer/Xcode/UserData/Provisioning Profiles` folder for provisioning profiles
- fixed ObjectFileTest. Recent clang includes dwarf v5 debug info and it is not compatible with our implementation (affects only test)
- CMAKE -- fixed warning that `exec_program should not be used`