### PR TITLE
* simctl launch: switched to `--console-pty` to workaround 16Kb PIPE buffer limitation on MacOSx

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/SimLauncherProcess.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/SimLauncherProcess.java
@@ -142,7 +142,7 @@ public class SimLauncherProcess extends Process implements Launcher {
                     List<Object> args = new ArrayList<>();
                     args.add("simctl");
                     args.add("launch");
-                    args.add("--console");
+                    args.add("--console-pty");
                     args.add(deviceType.getUdid());
                     args.add(bundleId);
                     args.addAll(arguments);


### PR DESCRIPTION

fixed #798

Code to reproduce:
```
        StringBuilder sb = new StringBuilder();
        for (int i = 0; i < 16384; i++)
            sb.append('c');
        System.out.println(sb);
```