### PR TITLE
* fixed: crash on remote debug to target

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/LaunchParameters.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/LaunchParameters.java
@@ -54,7 +54,9 @@ public class LaunchParameters {
     }
 
     public void setArguments(List<String> arguments) {
-        this.arguments = arguments;
+        // copy arguments as provided list might be immutable
+        this.arguments.clear();
+        this.arguments.addAll(arguments);
     }
     
     public Map<String, String> getEnvironment() {

--- a/compiler/vm/build.sh
+++ b/compiler/vm/build.sh
@@ -4,7 +4,7 @@ SELF=$(basename $0)
 BASE=$(cd $(dirname $0); pwd -P)
 CLEAN=0
 VERBOSE=
-WORKERS=6
+WORKERS=8
 
 function usage {
   cat <<EOF

--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMTask.java
@@ -183,12 +183,18 @@ abstract public class AbstractRoboVMTask extends DefaultTask {
         }
         temporaryDirectory.mkdirs();
 
-        builder.home(new Config.Home(extractSdk()))
+        Config.Home home = Config.Home.suggestDevHome();
+        if (home == null) home = new Config.Home(extractSdk());
+        builder.home(home)
                 .tmpDir(temporaryDirectory)
                 .skipInstall(true)
                 .installDir(installDir)
                 .cacheDir(cacheDir);
-
+	    if (home.isDev()) {
+            builder.useDebugLibs(true);
+            builder.dumpIntermediates(true);
+            builder.addPluginArgument("debug:logconsole=true");
+        }
         if (project.hasProperty("mainClassName")) {
             builder.mainClass((String) project.property("mainClassName"));
         }

--- a/plugins/idea/README.md
+++ b/plugins/idea/README.md
@@ -10,6 +10,7 @@ Not supported any more due removed `-extdir` in Java9+
 
 ### Development with Maven 
 * Install recent *Intellij IDEA Community Edition * under /Applications/Intellij IDEA CE.app/ (https://download.jetbrains.com/idea/)
+* Install Swing UI Designer plugin
 * Install this plugin, it allows us to use [Maven for plugin development](https://plugins.jetbrains.com/plugin/7127?pr=). *Note*: outdated and might not work for recent versions of Idea, open source alternative is available at [dkimitsa/support-maven-devkit-plugins](https://github.com/dkimitsa/support-maven-devkit-plugins).   
 * Clone this repo https://github.com/JetBrains/intellij-community.git
 * Checkout the branch that corresponds to the respective IDEA version you installed, e.g. 139 for Idea 14.0.x, see http://www.jetbrains.org/pages/viewpage.action?pageId=983225


### PR DESCRIPTION
Steps to reproduce:
- launch using gradle in debug mode: `./gradlew  -Probovm.debug=true -Probovm.debugPort=7777 launchIPhoneSimulator`
- attach as to remote JVM target using Idea.

Root case:
Debugger tries to suspend main thread while it is still waiting for JVM resume command. Probably in new JVMs/Idea something changed and now in it tries to suspend Main thread once debugger attached (previously VM resume command was sent). And this correct behaviour as from debugger POV target to attach could be running. In case RoboVM thread 0 is still not entered JVM frame and waiting resume VM command from debugger. Instead SUSPEND thread command is received that fails on building stacktrace on line:
> fakeFrame = *(Frame*) env->gatewayFrames->frameAddress

as there is no any env->gatewayFrames specified: Fix: in case there is no `env->gatewayFrames` (thread detached or not started yet main) -- return empty stack trace.

Other fixes:
- debugger not started due crash when arguments were passed to application using gradle options, --args="'-rvm:log=trace'". Root case: gradle is passing immutable list.
- gradle plugin extended to respect dev mode of libraries (`-DROBOVM_DEV_ROOT=`)
- using 8 workers to build native libs