### PR TITLE
* fixed: debugger crash Cannot read the array length because "interfaces" is null

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-mvn clean install
+mvn -T 10 clean install
 ./plugins/idea/gradlew -b plugins/idea/build.gradle clean buildPlugin
 mvn -f plugins/eclipse/pom.xml clean install
 ./plugins/gradle/gradlew -b plugins/gradle/build.gradle clean assemble validatePlugins publishToMavenLocal

--- a/compiler/vm/core/src/exception.c
+++ b/compiler/vm/core/src/exception.c
@@ -88,7 +88,7 @@ void rvmThrow(Env* env, Object* e) {
             jint index = 0;
             while ((frame = rvmGetNextCallStackMethod(env, callStack, &index)) != NULL) {
                 Method* m = frame->method;
-                TRACEF("    %s.%s%s", m->clazz->name, m->name, m->desc);
+                TRACEF("    %s.%s%s:%d", m->clazz->name, m->name, m->desc, frame->lineNumber);
             }
         }
     }

--- a/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/ClassInfoImpl.java
+++ b/plugins/debugger/src/main/java/org/robovm/debugger/state/classdata/ClassInfoImpl.java
@@ -100,6 +100,10 @@ public class ClassInfoImpl extends ClassInfo {
 //                errorMessage = reader.readStringZ(ptr);
 //            }
 //            System.out.println("!Class " + className + " has error " + errorType + " due " + errorMessage);
+            // debugger might ask this info even if class reported as ClassStatus.ERROR
+            interfaces = new ClassInfo[0];
+            fields = new FieldInfo[0];
+            methods = new MethodInfo[0];
             return;
         }
 


### PR DESCRIPTION

```
 java.lang.NullPointerException: Cannot read the array length because "interfaces" is null
	at org.robovm.debugger.jdwp.handlers.referencetype.JdwpRefTypeInterfacesHandler.handle(JdwpRefTypeInterfacesHandler.java:49)
	at org.robovm.debugger.jdwp.JdwpDebugServer.doSocketWork(JdwpDebugServer.java:200)
	at java.base/java.lang.Thread.run(Thread.java:1583)
	at org.robovm.debugger.utils.DebuggerThread.run(DebuggerThread.java:42)
```

## Root case:
debugger queries interface information for classes that are marked as `ClassStatus.ERROR`.
> java8/util/DelegatingSpliterator$ConsumerDelegate has error 1 due java.util.function.Consumer
and
> Class was Warning: java.util.function.Consumer is a phantom class!

## the fix: initialize fields with empty arrays.

## other changes:
- using 10 threads for maven builds
- printing line numbers in stacktraces in debug output