### PR TITLE
* fixed: GC wrongly marks classes if Struct is not included into the build

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/clazz/Clazzes.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/clazz/Clazzes.java
@@ -74,7 +74,7 @@ public class Clazzes {
     private void addPaths(List<File> files, List<Path> cp, Set<File> seen, boolean inBootclasspath) throws IOException {
         for (File file : files) {
             if (SourceLocator.DUMMY_CLASSPATH_JDK9_FS.equals(file.getPath()) && !seen.contains(file)) {
-                // java9 runtime: add special mark to allow recognize it latter when providing soot CP
+                // java9 runtime: add special mark to allow to recognize it later when providing soot CP
                 Path p = new Java9RuntimePath(file, this, cp.size(), inBootclasspath);
                 cp.add(p);
                 seen.add(file);

--- a/compiler/vm/core/src/memory.c
+++ b/compiler/vm/core/src/memory.c
@@ -952,8 +952,8 @@ void rvmSetupGcDescriptor(Env* env, Class* clazz) {
         clazz->gcDescriptor = REF_FREE_GC_DESCRIPTOR;
     } else if (clazz == java_lang_Class || CLASS_IS_FINALIZABLE(clazz) || CLASS_IS_REFERENCE(clazz) 
         || (clazz->superclass && clazz->superclass == java_nio_MemoryBlock)
-        || (clazz == java_nio_MemoryBlock) || rvmIsSubClass(java_lang_Throwable, clazz) 
-        || (clazz->superclass && rvmIsSubClass(org_robovm_rt_bro_Struct, clazz))) {
+        || (clazz == java_nio_MemoryBlock) || rvmIsSubClass(java_lang_Throwable, clazz)
+        || (clazz->superclass && org_robovm_rt_bro_Struct && rvmIsSubClass(org_robovm_rt_bro_Struct, clazz))) {
 
         // These types of objects must be marked specially. We could probably
         // do this using GC bitmap descriptors instead.


### PR DESCRIPTION
`org_robovm_rt_bro_Struct` might be not initialized if class is not present (e.g. in pure console app), in this case org_robovm_rt_bro_Struct will be null and GC will recognize generic classes as Structs and apply wrong GC Mark method

code that initialise it:
```
    org_robovm_rt_bro_Struct = rvmFindClassUsingLoader(env, "org/robovm/rt/bro/Struct", NULL);
    if (!org_robovm_rt_bro_Struct) {
        // We don't need Struct if it hasn't been compiled in
        rvmExceptionClear(env);
    } else {
        org_robovm_rt_bro_Struct_handle = rvmGetInstanceField(env, org_robovm_rt_bro_Struct, "handle", "J");
        if (!org_robovm_rt_bro_Struct_handle) return FALSE;
    }

```