### PR TITLE
* support for os/log

### DIFF
--- a/compiler/cocoatouch/.gitignore
+++ b/compiler/cocoatouch/.gitignore
@@ -1,0 +1,2 @@
+/build/
+/src/main/robopods/META-INF/robovm/ios/libs/RvmCocoaTouch.xcframework

--- a/compiler/cocoatouch/build-natives.sh
+++ b/compiler/cocoatouch/build-natives.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+rm -rf build
+rm -rf src/main/robopods/META-INF/robovm/ios/libs/RvmCocoaTouch.xcframework
+
+# ios device
+cmake -S src/main/native -B build/ios-arm64 \
+  -DCMAKE_SYSTEM_NAME=iOS \
+  -DCMAKE_OSX_ARCHITECTURES=arm64 \
+  -DCMAKE_OSX_SYSROOT=iphoneos \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=8.0
+cmake --build build/ios-arm64 --config Release
+
+# ios simulator
+cmake -S src/main/native -B build/ios-sim \
+  -DCMAKE_SYSTEM_NAME=iOS \
+  -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
+  -DCMAKE_OSX_SYSROOT=iphonesimulator \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=8.0
+cmake --build build/ios-sim --config Release
+
+
+# macos 
+cmake -S src/main/native -B build/macos \
+  -DCMAKE_SYSTEM_NAME=Darwin \
+  -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
+  -DCMAKE_OSX_SYSROOT=macosx \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12
+cmake --build build/macos --config Release
+
+
+# pack to xcframework
+xcodebuild -create-xcframework \
+  -library build/ios-arm64/librvmcocoatouch.a \
+  -library build/ios-sim/librvmcocoatouch.a \
+  -library build/macos/librvmcocoatouch.a \
+  -output src/main/robopods/META-INF/robovm/ios/libs/RvmCocoaTouch.xcframework

--- a/compiler/cocoatouch/pom.xml
+++ b/compiler/cocoatouch/pom.xml
@@ -37,6 +37,13 @@
     </dependencies>
 
     <build>
+        <!-- adds META-INF/robovm.xml where available -->
+        <resources>
+            <resource>
+                <directory>src/main/robopods</directory>
+            </resource>
+        </resources>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -66,6 +73,24 @@
                     <detectJavaApiLink>false</detectJavaApiLink>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>build-binaries</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <workingDirectory>${project.basedir}</workingDirectory>
+                            <executable>${project.basedir}/build-natives.sh</executable>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/compiler/cocoatouch/src/main/bro-gen/oslog2.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/oslog2.yaml
@@ -1,0 +1,70 @@
+# OS log api from os/log.h
+package: org.robovm.apple.oslog
+include: [foundation]
+header: /usr/include/os/log.h
+path_match: ^.*/usr/include/os/log.*$
+clang_args: ['-x', 'objective-c']
+
+typedefs:
+    os_log_s: OSLog
+    
+enums:
+    os_log_type_t: { name: Type } # will me moved manually inside OSLog!
+
+categories:
+
+classes:
+
+protocols:
+    OS_os_log:
+        name: OSLog
+        class: true
+        protocols: []
+        annotations: ['@NativeClass("NSObject")']
+        visibility: 'public final'
+        skip_adapter: true
+
+functions:
+    os_log_create:
+        name: create
+        class: OSLog
+        parameters:
+            0:
+                marshaler: StringMarshalers.AsAsciiZMarshaler
+                type: String
+            1:
+                marshaler: StringMarshalers.AsAsciiZMarshaler
+                type: String
+    os_log_type_enabled:
+        name: isEnabled
+        class: OSLog
+    os_log_is_enabled:
+        exclude: true # deprecated !
+    os_log_is_debug_enabled:
+        exclude: true # deprecated !
+
+    # Make sure we don't miss any functions if new ones are introduced in a later version
+    (os_.*):
+        class: FIXME
+        name: 'Function__#{g[0]}'
+
+values:
+    RVM_OS_LOG_DISABLED:
+        name: DISABLED
+        class: OSLog
+        readonly: true
+    RVM_OS_LOG_DEFAULT:
+        name: DEFAULT
+        class: OSLog
+        readonly: true
+
+    # Make sure we don't miss any values if new ones are introduced in a later version
+    (os_.*):
+        class: FIXME
+        name: 'Value__#{g[0]}'
+
+constants:
+    # Make sure we don't miss any constants if new ones are introduced in a later version
+    (os_.*):
+        class: FIXME
+        name: 'Constant__#{g[0]}'

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/oslog/OSLog.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/oslog/OSLog.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.oslog;
+
+
+/*<imports>*/
+
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+
+/*</javadoc>*/
+/*<annotations>*/
+@Library(Library.INTERNAL)
+@NativeClass("NSObject")/*</annotations>*/
+/*<visibility>*/ public final/*</visibility>*/ class /*<name>*/OSLog/*</name>*/
+        extends /*<extends>*/NSObject/*</extends>*/
+        /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class OSLogPtr extends Ptr<OSLog, OSLogPtr> {
+    }/*</ptr>*/
+
+    /*<bind>*/static {
+        ObjCRuntime.bind(OSLog.class);
+    }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+
+    /*</constructors>*/
+    /*<properties>*/
+
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Bridge(symbol = "os_log_create", optional = true)
+    public static native OSLog create(@org.robovm.rt.bro.annotation.Marshaler(StringMarshalers.AsAsciiZMarshaler.class) String subsystem, @org.robovm.rt.bro.annotation.Marshaler(StringMarshalers.AsAsciiZMarshaler.class) String category);
+
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Bridge(symbol = "os_log_type_enabled", optional = true)
+    public native boolean isEnabled(Type type);
+
+
+    /*</methods>*/
+
+    ///
+    /// dkimitsa: manually added code bellow
+    ///
+    @org.robovm.rt.bro.annotation.Marshaler(ValuedEnum.AsUnsignedByteMarshaler.class)
+    public enum Type implements ValuedEnum {
+        DEFAULT(0L),
+        INFO(1L),
+        DEBUG(2L),
+        ERROR(16L),
+        FAULT(17L);
+        private final long n;
+
+        Type(long n) {
+            this.n = n;
+        }
+
+        public long value() {
+            return n;
+        }
+
+        public static Type valueOf(long n) {
+            for (Type v : values()) {
+                if (v.n == n) {
+                    return v;
+                }
+            }
+            throw new IllegalArgumentException("No constant with value " + n + " found in "
+                    + Type.class.getName());
+        }
+    }
+
+    ///
+    /// Bindings for rvm_oslog.m
+    ///
+
+    /// TODO: fixme, static XCFrameworks doesn't support "forced" parameter
+    ///       and symbols are got dead-stripped, using ObjC wrapper to make
+    ///       API available
+    @NativeClass
+    private final static class RvmOSLog extends NSObject {
+        static { ObjCRuntime.bind(RvmOSLog.class); }
+
+        @Method(selector = "DISABLED")
+        static native OSLog DISABLED();
+
+        @Method(selector = "DEFAULT")
+        static native OSLog DEFAULT();
+
+        @Method(selector = "logPublic:withType:message:")
+        static native void publicLog(OSLog log, Type type, @org.robovm.rt.bro.annotation.Marshaler(StringMarshalers.AsAsciiZMarshaler.class) String msg);
+
+        @Method(selector= "logPrivate:withType:message:")
+        static native void privateLog(OSLog log, Type type, @org.robovm.rt.bro.annotation.Marshaler(StringMarshalers.AsAsciiZMarshaler.class) String msg);
+    }
+
+
+    ///
+    /// macro implementations
+    ///
+    public static OSLog DISABLED() {
+        return RvmOSLog.DISABLED();
+    }
+
+    public static OSLog DEFAULT() {
+        return RvmOSLog.DEFAULT();
+    }
+
+    public void publicLog(Type type, String msg) {
+        RvmOSLog.publicLog(this, type, msg);
+    }
+
+    public void privateLog(OSLog log, Type type, String msg) {
+        RvmOSLog.privateLog(this, type, msg);
+    }
+
+    /**
+     * public log to default logger
+     */
+    public static void log(String msg) {
+        RvmOSLog.publicLog(DEFAULT(), Type.DEFAULT, msg);
+    }
+
+    public static void log(boolean isPrivate, String msg) {
+        OSLog log = DEFAULT();
+        if (isPrivate) RvmOSLog.privateLog(log, Type.DEFAULT, msg);
+        else RvmOSLog.publicLog(log, Type.DEFAULT, msg);
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/oslog/OSLogPrintStream.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/oslog/OSLogPrintStream.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2025 The MobiVM Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.oslog;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+public class OSLogPrintStream extends PrintStream {
+
+    final StringBuffer st = new StringBuffer();
+    final OSLog.Type type;
+    final OSLog log;
+
+    public OSLogPrintStream(OSLog log, OSLog.Type type) {
+        super(new OutputStream() {
+            @Override
+            public void write(int arg0) throws IOException {
+            }
+        });
+        this.type = type;
+        this.log = log;
+    }
+
+    public OSLogPrintStream(OSLog.Type type) {
+        this(OSLog.DEFAULT(), type);
+    }
+
+    public void write(char ch) {
+        if (ch == 0xa) {
+        } else {
+            st.append(ch);
+        }
+    }
+
+    @Override
+    public void flush() {
+        if (st.length() > 0) {
+            log.publicLog(type, st.toString());
+            st.setLength(0);
+        }
+    }
+
+    @Override
+    public void print(char[] s) {
+        for (char ch : s) {
+            write(ch);
+        }
+    }
+
+    @Override
+    public void print(boolean b) {
+        print(b + "");
+    }
+
+    @Override
+    public void print(char c) {
+        write(c);
+    }
+
+    @Override
+    public void print(double d) {
+        print(d + "");
+    }
+
+    @Override
+    public void print(float f) {
+        print(f + "");
+    }
+
+    @Override
+    public void print(int i) {
+        print(i + "");
+    }
+
+    @Override
+    public void print(long l) {
+        print(l + "");
+    }
+
+    @Override
+    public void print(Object obj) {
+        print((obj + "").toCharArray());
+    }
+
+    @Override
+    public void print(String s) {
+        print((s + "").toCharArray());
+    }
+
+    @Override
+    public void println() {
+        flush();
+    }
+
+    @Override
+    public void println(boolean x) {
+        print(x);
+        flush();
+    }
+
+    @Override
+    public void println(char x) {
+        print(x);
+        flush();
+    }
+
+    @Override
+    public void println(char[] x) {
+        print(x);
+        flush();
+    }
+
+    @Override
+    public void println(double x) {
+        print(x);
+        flush();
+    }
+
+    @Override
+    public void println(float x) {
+        print(x);
+        flush();
+    }
+
+    @Override
+    public void println(int x) {
+        print(x);
+        flush();
+    }
+
+    @Override
+    public void println(long x) {
+        print(x);
+        flush();
+    }
+
+    @Override
+    public void println(Object x) {
+        print(x);
+        flush();
+    }
+
+    @Override
+    public void println(String x) {
+        print(x);
+        flush();
+    }
+
+}

--- a/compiler/cocoatouch/src/main/native/CMakeLists.txt
+++ b/compiler/cocoatouch/src/main/native/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.22)
+project(rvmcocoatouch LANGUAGES C OBJC)
+
+add_library(rvmcocoatouch STATIC rvm_oslog.m)

--- a/compiler/cocoatouch/src/main/native/rvm_oslog.m
+++ b/compiler/cocoatouch/src/main/native/rvm_oslog.m
@@ -1,0 +1,24 @@
+#include <os/log.h>
+#include <stdio.h>
+
+///
+/// RoboVM wrapper arround 
+///
+@interface RvmOSLog: NSObject
+@end
+@implementation RvmOSLog
++(os_log_t) DISABLED { return OS_LOG_DISABLED; }
++(os_log_t) DEFAULT { return OS_LOG_DEFAULT; }
++(void) logPublic:(os_log_t) log withType:(os_log_type_t) type message:(const char*) msg {
+    if (@available(iOS 10.0, macOS 10.12, *)) {
+        os_log_with_type(log, type, "%{public}s", msg);
+    }
+}
+
++(void) logPrivate:(os_log_t) log withType:(os_log_type_t) type message:(const char*) msg {
+    if (@available(iOS 10.0, macOS 10.12, *)) {
+        os_log_with_type(log, type, "%{private}s", msg);
+    }
+}
+
+@end

--- a/compiler/cocoatouch/src/main/robopods/META-INF/robovm/ios/robovm.xml
+++ b/compiler/cocoatouch/src/main/robopods/META-INF/robovm/ios/robovm.xml
@@ -1,0 +1,8 @@
+<config>
+    <frameworks>
+        <framework>RvmCocoaTouch</framework>
+    </frameworks>
+    <frameworkPaths>
+        <path>libs/</path>
+    </frameworkPaths>
+</config>


### PR DESCRIPTION
also fixes #826 iOS 26.1 no log output in console

os/log uses macro that wrap implementation API and it can't be bound directly. instead wrapper with clear api to be used (RvmOSLog). CocoaTouch bindings hadn't native component before and it was introduced with this PR. It contains simple rvm_oslog.m now. objc class `RvmOSLog` was used instead of function wrapper as RoboVM doesn't support -force_load linkage with static xcframework that causes symbols not being linked and not available runtime.

usage: 
1. directly 
> OSLog.log("Hello Default Log");

2. redirect all stdout/err to it:
```java
        System.setOut(new OSLogPrintStream(OSLog.create("robovm", "stdout"), OSLog.Type.DEFAULT));
        System.setErr(new OSLogPrintStream(OSLog.create("robovm", "stderr"), OSLog.Type.ERROR));
        System.out.println("Hello STDOUT");
        System.err.println("Hello STDERR");

```

IMPORTANT: `os_log prints` are not `STDOUT` prints and not available in tty/console. 
these can be accessed using Console application, Xcode  or log command line tool. E.g. 
> log stream 
> log stream --predicate 'subsystem == "robovm"'