### PR TITLE
* fixed: shared libraries (dylibs) were not copied into binary

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
@@ -239,8 +239,13 @@ public abstract class AbstractTarget implements Target {
                 } else if (p.endsWith(".dylib") || p.endsWith(".so")) {
                     // dkimitsa: add absolute path only if Config.Lib relative file converter was able to resolve it
                     //           e.g. lib exists, otherwise use it as it is
-                    File f = new File(p);
-                    libs.add(f.isAbsolute() ? f.getAbsolutePath() : p);
+                    if (lib.isForce()) {
+                        // dkimitsa: link with dynamic library only if it is marked as "force" which is
+                        //           by default. if "force" is false -- library has to be loaded with
+                        //           Runtime.getRuntime().loadLibrary(name)
+                        File f = new File(p);
+                        libs.add(f.isAbsolute() ? f.getAbsolutePath() : p);
+                    }
                 } else {
                     // link via -l if suffix is omitted
                     libs.add("-l" + p);
@@ -324,6 +329,26 @@ public abstract class AbstractTarget implements Target {
 
         for (Resource res : config.getResources()) {
             res.walk(walker, destDir);
+        }
+    }
+
+    /**
+     * copies dynamic libraries (.so/.dylibs) to Frameworks folder which is registered as rpath
+     */
+    protected void copyDynamicLibs(File destDir) throws IOException {
+        if (!config.getLibs().isEmpty()) {
+            File frameworksDir = new File(destDir, "Frameworks");
+            for (Config.Lib lib : config.getLibs()) {
+                String p = lib.getValue();
+                if (p != null && (p.endsWith(".dylib") || p.endsWith(".so"))) {
+                    // dkimitsa: copy only if Config.Lib relative file converter was able to resolve it
+                    //           e.g. lib exists
+                    File f = new File(p);
+                    if(f.isAbsolute() && f.isFile() && isDynamicLibrary(f)) {
+                        FileUtils.copyFileToDirectory(f, frameworksDir, true);
+                    }
+                }
+            }
         }
     }
 
@@ -789,6 +814,7 @@ public abstract class AbstractTarget implements Target {
         stripArchives(installDir);
         copyResources(resourcesDir);
         copyDynamicFrameworks(installDir, executable);
+        copyDynamicLibs(installDir);
         copyAppExtensions(installDir);
         copyWatchApp(installDir);
     }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -434,10 +434,10 @@ public class IOSTarget extends AbstractTarget {
         // sign dynamic frameworks first
         File frameworksDir = new File(appDir, "Frameworks");
         if (frameworksDir.exists() && frameworksDir.isDirectory()) {
-            // Sign swift rt libs
-            for (File swiftLib : frameworksDir.listFiles()) {
-                if (swiftLib.getName().endsWith(".dylib")) {
-                    codesignSwiftLib(identity, swiftLib);
+            // Sign swift/dylibs rt libs
+            for (File dylib : frameworksDir.listFiles()) {
+                if (dylib.getName().endsWith(".dylib")) {
+                    codesignDylib(identity, dylib);
                 }
             }
 
@@ -614,8 +614,8 @@ public class IOSTarget extends AbstractTarget {
         codesign(identity, entitlementsPList, false, false, true, appDir);
     }
 
-    private void codesignSwiftLib(SigningIdentity identity, File swiftLib) throws IOException {
-        config.getLogger().info("Code signing swift dylib '%s' using identity '%s' with fingerprint %s", swiftLib.getName(), identity.getName(),
+    private void codesignDylib(SigningIdentity identity, File swiftLib) throws IOException {
+        config.getLogger().info("Code signing dylib '%s' using identity '%s' with fingerprint %s", swiftLib.getName(), identity.getName(),
                 identity.getFingerprint());
         codesign(identity, null, false, true, false, swiftLib);
     }


### PR DESCRIPTION
user provided shared libraries were used during linkage but were not copied.
```xml
    <libs>
        <lib>libs/libsqlitejdbc.dylib</lib>
    </libs>
```
as result application failed at runtime. 

also logic added to allow not link the library and load it dynamically at runtime, force  attribute is used similar to static libs:
```xml
    <libs>
        <lib force="false">libs/libsqlitejdbc.dylib</lib>
    </libs>
```
