### PR TITLE
* fixed: #834 MobiVM plugin breaks IDE on newer Intellij/Android Studio versions

### DIFF
--- a/plugins/idea/src/main/java/org/robovm/idea/RoboVmPlugin.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/RoboVmPlugin.java
@@ -290,13 +290,14 @@ public class RoboVmPlugin {
     public static List<Module> getRoboVmModules(Project project, Predicate<String> predicate) {
         List<Module> validModules = new ArrayList<>();
         for (Module module : ModuleManager.getInstance(project).getModules()) {
-            if (!isRoboVmModule(module))
+            RoboVmFacet facet = getRoboVmFacet(module);
+            if (facet == null)
                 continue;
 
             // dkimitsa: if target type is specified return only matching modules. E.g. don't allow to run Framework
             // target in Console runner
             if (predicate != null) {
-                Config config = loadRawModuleConfig(module);
+                Config config = loadRawModuleConfig(facet);
                 if (config == null)
                     continue;
                 if (!predicate.test(config.getTargetType()))
@@ -308,22 +309,28 @@ public class RoboVmPlugin {
     }
 
 
+    public static RoboVmFacet getRoboVmFacet(Module module) {
+        return FacetManager.getInstance(module).getFacetByType(RoboVmFacetType.TYPE_ID);
+    }
+
     /**
      * Only if RoboVM facet is attached
      */
     public static boolean isRoboVmModule(Module module) {
-        return FacetManager.getInstance(module).getFacetByType(RoboVmFacetType.TYPE_ID) != null;
+        return getRoboVmFacet(module) != null;
     }
 
     public static Config loadRawModuleConfig(Module module) {
-        for (VirtualFile file : ModuleRootManager.getInstance(module).getContentRoots()) {
-            if (file.findChild("robovm.xml") != null) {
-                try {
-                    File contentRoot = new File(file.getPath());
-                    return Config.loadRawConfig(contentRoot);
-                } catch (IOException ignored) {
-                }
-            }
+        RoboVmFacet facet = getRoboVmFacet(module);
+        return facet != null ? loadRawModuleConfig(facet) : null;
+    }
+
+    public static Config loadRawModuleConfig(RoboVmFacet facet) {
+        String contentRoot = facet.getConfiguration().getSettings().getContentRoot();
+        try {
+            if (contentRoot != null)
+                return Config.loadRawConfig(new File(contentRoot));
+        } catch (IOException ignored) {
         }
 
         return null;

--- a/plugins/idea/src/main/java/org/robovm/idea/gradle/sync/RoboVMGradleProjectResolver.kt
+++ b/plugins/idea/src/main/java/org/robovm/idea/gradle/sync/RoboVMGradleProjectResolver.kt
@@ -17,15 +17,18 @@ package org.robovm.idea.gradle.sync
 import com.intellij.openapi.externalSystem.model.DataNode
 import com.intellij.openapi.externalSystem.model.project.ModuleData
 import com.intellij.openapi.externalSystem.model.project.ProjectData
+import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
 import com.intellij.openapi.externalSystem.util.ExternalSystemConstants
 import com.intellij.openapi.externalSystem.util.Order
 import org.gradle.tooling.model.idea.IdeaModule
+import org.jetbrains.plugins.gradle.model.data.GradleSourceSetData
 import org.jetbrains.plugins.gradle.service.project.AbstractProjectResolverExtension
 import org.robovm.compiler.model.RoboVMGradleModel
 import org.robovm.idea.facet.RoboVmFacetConfiguration
 
 /**
- * gradle project resolver to detect RoboVM gradle module and disable module per source set for it
+ * gradle project resolver to detect RoboVM gradle module and attach RoboVmGradleModelKey so
+ * RoboVmModuleDataService will be able to create facet for it
  * @author dkimitsa
  */
 @Order(ExternalSystemConstants.UNORDERED)
@@ -33,29 +36,21 @@ class RoboVMGradleProjectResolver : AbstractProjectResolverExtension() {
     override fun getExtraProjectModelClasses() = setOf(RoboVMGradleModel::class.java)
 
     override fun createModule(gradleModule: IdeaModule, projectDataNode: DataNode<ProjectData>): DataNode<ModuleData>? {
-        val model = resolverCtx.getExtraProject(gradleModule, RoboVMGradleModel::class.java)
-        if (model != null) {
-            // settings are nullable till 2024.3
-            val saved = resolverCtx.settings?.isResolveModulePerSourceSet
-            // robovm module (uses robovm plugin in build.gradle)
-            try {
-                // disable modules per source set for RoboVM module
-                resolverCtx.settings?.run { isResolveModulePerSourceSet = false }
-                return super.createModule(gradleModule, projectDataNode)?.also { moduleDataNode ->
-                    val externalSettings = RoboVmFacetConfiguration.Settings(
-                        buildSystem = RoboVmFacetConfiguration.BuildSystem.Gradle,
-                        contentRoot = moduleDataNode.data.linkedExternalProjectPath,
-                        externalVersion = model.version
-                    )
-                    moduleDataNode.createChild(RoboVmGradleModelKey, externalSettings)
-                }
-            } catch (e: Exception) {
-                if (saved != null)
-                    resolverCtx.settings?.run { isResolveModulePerSourceSet = saved }
-                throw e
-            }
-        } else {
-            return super.createModule(gradleModule, projectDataNode)
-        }
+        val moduleNode = super.createModule(gradleModule, projectDataNode) ?: return null
+        val model = resolverCtx.getExtraProject(gradleModule, RoboVMGradleModel::class.java) ?: return  moduleNode
+
+        // RoboVm node, modules per source set might be active, in this case look for :main source set to attach
+        // facet to.
+        val externalSettings = RoboVmFacetConfiguration.Settings(
+            buildSystem = RoboVmFacetConfiguration.BuildSystem.Gradle,
+            contentRoot = moduleNode.data.linkedExternalProjectPath,
+            externalVersion = model.version
+        )
+        val sourceSetNodes = ExternalSystemApiUtil.findAll(moduleNode, GradleSourceSetData.KEY)
+        val nodeForFacet = sourceSetNodes.find { it.data.id.endsWith(":main") }
+            ?: moduleNode
+        nodeForFacet.createChild(RoboVmGradleModelKey, externalSettings)
+
+        return moduleNode
     }
 }

--- a/plugins/idea/src/main/java/org/robovm/idea/gradle/sync/RoboVmModuleDataService.kt
+++ b/plugins/idea/src/main/java/org/robovm/idea/gradle/sync/RoboVmModuleDataService.kt
@@ -18,7 +18,7 @@ package org.robovm.idea.gradle.sync
 import com.intellij.facet.ModifiableFacetModel
 import com.intellij.openapi.externalSystem.model.DataNode
 import com.intellij.openapi.externalSystem.model.Key
-import com.intellij.openapi.externalSystem.model.ProjectKeys
+import com.intellij.openapi.externalSystem.model.project.ModuleData
 import com.intellij.openapi.externalSystem.model.project.ProjectData
 import com.intellij.openapi.externalSystem.service.project.IdeModifiableModelsProvider
 import com.intellij.openapi.externalSystem.service.project.manage.AbstractProjectDataService
@@ -54,22 +54,22 @@ class RoboVmModuleDataService : AbstractProjectDataService<RoboVmFacetConfigurat
 
         // for each module with RoboVMGradleModel attached just add RoboVM facet
         toImport.forEach { nodeToImport ->
-            ExternalSystemApiUtil.findParent(nodeToImport, ProjectKeys.MODULE)?.let { moduleNode ->
-                val module = modelsProvider.findIdeModule(moduleNode.data) ?: return@let
-                val externalModel = nodeToImport.data
-                val facetModel = modelsProvider.getModifiableFacetModel(module)
-                facetModel.getFacetByType(RoboVmFacetType.TYPE_ID)?.let {
-                    // facet already attached, replace its settings
-                    it.configuration.replaceSettings(externalModel)
-                } ?: run {
-                    // create new facet
-                    module.attachRoboVmFacet(facetModel, externalModel)
-                }
-
-                // setup sdk
-                val moduleModel = modelsProvider.getModifiableRootModel(module)
-                moduleModel.sdk = RoboVmSdkType.setUpSdkIfNeeded(project)
+            val parentNode = nodeToImport.parent ?: return@forEach
+            val moduleData = parentNode.data as? ModuleData ?: return@forEach
+            val module = modelsProvider.findIdeModule(moduleData) ?: return@forEach
+            val externalModel = nodeToImport.data
+            val facetModel = modelsProvider.getModifiableFacetModel(module)
+            facetModel.getFacetByType(RoboVmFacetType.TYPE_ID)?.let {
+                // facet already attached, replace its settings
+                it.configuration.replaceSettings(externalModel)
+            } ?: run {
+                // create new facet
+                module.attachRoboVmFacet(facetModel, externalModel)
             }
+
+            // setup sdk
+            val moduleModel = modelsProvider.getModifiableRootModel(module)
+            moduleModel.sdk = RoboVmSdkType.setUpSdkIfNeeded(project)
         }
     }
 


### PR DESCRIPTION
root case: RoboVM gradle project resolver was forcing disabled "module per source set" while importing the modules. But it also affected other module import (probably was happening in concurrently)

fix: let RoboVM support modules-per-source set (already have Facet so it is not big effort). Only :main source set got Facet attached