### PR TITLE
* fix: mirror os_log and NSLog messages to stderr when launching from robovm plugins 

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/libimobiledevice/AppLauncherDelegate.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/libimobiledevice/AppLauncherDelegate.java
@@ -50,8 +50,10 @@ public class AppLauncherDelegate {
         if (env == null) {
             env = new HashMap<>();
         }
-        //Fix for #71, see http://stackoverflow.com/questions/37800790/hide-strange-unwanted-xcode-8-logs
-        env.put("OS_ACTIVITY_DT_MODE", "");
+        // from LLVM project:
+        //    We want to make sure that OS_ACTIVITY_DT_MODE is set so that we get
+        //    os_log and NSLog messages mirrored to the target process stderr.
+        env.put("OS_ACTIVITY_DT_MODE", "enabled");
 
         OutputStream outStream = launchParameters.getStdoutChain().getInbound();
         AppLauncher launcher = new AppLauncher(deviceUdid, appDir) {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/simulator/IOSSimLauncher.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/simulator/IOSSimLauncher.java
@@ -25,6 +25,7 @@ import org.robovm.compiler.util.Executor.ExecuteException;
 
 import java.io.*;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -77,6 +78,13 @@ public class IOSSimLauncher implements Launcher {
         String watchAppName = launchParameters.getPairedWatchAppName();
         List<String> arguments = new ArrayList<>(launchParameters.getArguments(true));
         Map<String, String> env = launchParameters.getEnvironment();
+        if (env == null) {
+            env = new HashMap<>();
+        }
+        // from LLVM project:
+        //    We want to make sure that OS_ACTIVITY_DT_MODE is set so that we get
+        //    os_log and NSLog messages mirrored to the target process stderr.
+        env.put("OS_ACTIVITY_DT_MODE", "enabled");
 
         // preparation: booting simulator if required, deploying app to it and to paired watch if required
         try {


### PR DESCRIPTION

https://github.com/llvm/llvm-project/blob/7ad854c41e2b08b8cd6aae1d3b6f22125512585b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp#L1719-L1721

thx Berstanio