### PR TITLE
* idea plugin: maintenance, migration to platform plugin v2, fixes for crashes/failures due SDK missing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
           distribution: temurin
           cache: 'maven'
-          java-version: '17'
+          java-version: '21'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release-idea.yml
+++ b/.github/workflows/release-idea.yml
@@ -27,12 +27,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.targetBranch }}
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
           distribution: temurin
           cache: 'maven'
-          java-version: '17'
+          java-version: '21'
           server-id: sonatype-nexus-snapshots
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.targetBranch }}
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
           distribution: temurin
           cache: 'maven'
-          java-version: '17'
+          java-version: '21'
           server-id: sonatype-nexus-snapshots
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
           distribution: temurin
           cache: 'maven'
-          java-version: '17'
+          java-version: '21'
           server-id: sonatype-nexus-snapshots
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
 mvn -T 10 clean install
-./plugins/idea/gradlew -b plugins/idea/build.gradle clean buildPlugin
+./plugins/idea/gradlew -p plugins/idea/ clean buildPlugin
 mvn -T 10 -f plugins/eclipse/pom.xml clean install
 ./plugins/gradle/gradlew -b plugins/gradle/build.gradle clean assemble validatePlugins publishToMavenLocal

--- a/plugins/idea/build.gradle
+++ b/plugins/idea/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id "org.jetbrains.kotlin.jvm" version "2.3.10"
+    id "org.jetbrains.kotlin.jvm" version "2.1.20"
     id "org.jetbrains.intellij" version "1.13.2"
 }
 

--- a/plugins/idea/build.gradle
+++ b/plugins/idea/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id "org.jetbrains.kotlin.jvm" version "2.1.20"
-    id "org.jetbrains.intellij" version "1.13.2"
+    id "org.jetbrains.intellij.platform" version "2.16.0"
 }
 
 ext {
@@ -16,6 +16,9 @@ repositories {
     mavenCentral()
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     maven { url 'https://central.sonatype.com/repository/maven-snapshots'}
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
 
 configurations {
@@ -40,16 +43,31 @@ dependencies {
     robovm_dist "com.mobidevelop.robovm:robovm-dist:${roboVMVersion}:nocompiler@tar.gz"
 
     implementation 'org.apache.commons:commons-compress:1.25.0'
+
+    intellijPlatform {
+        intellijIdeaCommunity('2025.2')
+        bundledPlugins('com.intellij.java', 'org.jetbrains.idea.maven', 'com.intellij.gradle')
+
+        pluginVerifier()
+    }
 }
 
 kotlin {
-  jvmToolchain(17)
+    jvmToolchain(21)
 }
 
-intellij {
-    version = '2025.2'   // we are compiles against this API version
-    plugins = ['java', 'maven', 'gradle']
-    updateSinceUntilBuild = false
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+intellijPlatform {
+    pluginConfiguration {
+        ideaVersion {
+            // allow to run on any recent version of IntelliJ IDEA since version specified in intellijIdeaCommunity
+            untilBuild = provider { null }
+        }
+    }
 }
 
 def copyRoboVmDist = tasks.register("copyRoboVmDist", Copy) {
@@ -58,9 +76,6 @@ def copyRoboVmDist = tasks.register("copyRoboVmDist", Copy) {
     rename "robovm-dist-${roboVMVersion}-nocompiler.tar.gz", "robovm-dist"
 }
 
-
-sourceCompatibility = 17
-targetCompatibility = 17
 tasks.named("patchPluginXml").configure {
     dependsOn copyRoboVmDist
 }

--- a/plugins/idea/gradle/wrapper/gradle-wrapper.properties
+++ b/plugins/idea/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugins/idea/gradle/wrapper/gradle-wrapper.properties
+++ b/plugins/idea/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugins/idea/src/main/java/org/robovm/idea/RoboVmPlugin.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/RoboVmPlugin.java
@@ -23,9 +23,7 @@ import com.intellij.facet.FacetManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.ui.MessageType;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener;
@@ -254,7 +252,8 @@ public class RoboVmPlugin {
             try {
                 libs.addAll(Arrays.asList(RoboFileUtils.listFiles(libsDir, (dir, name) -> name.endsWith(".jar") && !name.contains("cacerts"))));
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                logError(null, "RoboVM SDK is not installed, re-sync project to install.");
+                throw new RuntimeException("RoboVM SDK is not installed", e);
             }
         }
         return libs;

--- a/plugins/idea/src/main/java/org/robovm/idea/sdk/RoboVmSdkType.kt
+++ b/plugins/idea/src/main/java/org/robovm/idea/sdk/RoboVmSdkType.kt
@@ -79,12 +79,15 @@ class RoboVmSdkType : SdkType(SDK_NAME) {
             }
 
             // return SDK if valid was found
-            candidate?.let { return it }
+            candidate?.let {
+                // make sure SDK files are present
+                service<RoboVmSdkUnpackService>().extractSdkIfNeeded(project)
+                return it
+            }
 
             // adding new sdk
             val sdkToAdd: Sdk
-            val unpacker = service<RoboVmSdkUnpackService>()
-            val roboVmHome = unpacker.extractSdkIfNeeded(project)
+            val roboVmHome = service<RoboVmSdkUnpackService>().extractSdkIfNeeded(project)
             // configure
             val newSdkName = SdkConfigurationUtil.createUniqueSdkName(INSTANCE, roboVmHome.homeDir.absolutePath,
                 ProjectJdkTable.getInstance().allJdks.toList())

--- a/plugins/idea/src/main/java/org/robovm/idea/sdk/RoboVmSdkUnpackService.kt
+++ b/plugins/idea/src/main/java/org/robovm/idea/sdk/RoboVmSdkUnpackService.kt
@@ -42,55 +42,56 @@ import java.util.zip.GZIPInputStream
  */
 @Service(Service.Level.APP)
 class RoboVmSdkUnpackService(private val scope: CoroutineScope) {
-    private val sdkUnpackDeferred: Deferred<Home> by lazy {
-        scope.async(Dispatchers.IO) {
-            val sdkHome = RoboVmLocations.roboVmHome
-            if (!sdkHome.isDev) {
-                // in case of Dev environment no need to unpack SDK
-                // using parent here as:
-                // - sdkHome.homeDir points to final destination (e.g. .robovm-sdks/robovm-2.3.23)
-                // - but `robovm-dist` contains `robovm-2.3.23` directory inside
-                val homeDir = sdkHome.homeDir.parentFile
-                if (!homeDir.exists() && !homeDir.mkdirs()) {
-                    throw RuntimeException("Couldn't create sdk dir in " + homeDir.absolutePath)
-                }
-
-                // drop cache if files were changed
-                val filesWereUpdated = extractSdk(homeDir)
-                if (filesWereUpdated) {
-                    RoboVmPlugin.logInfo(null, "Clearing ~/.robovm/cache folder due SDK files changed.")
-                    try {
-                        FileUtils.deleteDirectory(RoboVmLocations.cacheDir)
-                    } catch (ignored: IOException) {
-                    }
-                }
-            }
-            sdkHome
+    private var activeJob: Deferred<Home>? = null
+    private fun startUnpackJob(sdkHome: Home): Deferred<Home> = scope.async(Dispatchers.IO) {
+        // using parent here as:
+        // - sdkHome.homeDir points to final destination (e.g. .robovm-sdks/robovm-2.3.23)
+        // - but `robovm-dist` contains `robovm-2.3.23` directory inside
+        val homeDir = sdkHome.homeDir.parentFile
+        if (!homeDir.exists() && !homeDir.mkdirs()) {
+            throw RuntimeException("Couldn't create sdk dir in " + homeDir.absolutePath)
         }
+
+        // drop cache if files were changed
+        val filesWereUpdated = extractSdk(homeDir)
+        if (filesWereUpdated) {
+            RoboVmPlugin.logInfo(null, "Clearing ~/.robovm/cache folder due SDK files changed.")
+            try {
+                FileUtils.deleteDirectory(RoboVmLocations.cacheDir)
+            } catch (_: IOException) {
+            }
+        }
+        sdkHome
     }
 
     fun extractSdkIfNeeded(project: Project): Home {
         // wait till unpack task is complete
+        val sdkHome = RoboVmLocations.roboVmHome
+        if (sdkHome.isDev) return sdkHome
+        runCatching { sdkHome.validate() }.onSuccess { return sdkHome }
+
         return runBlocking {
-            if (sdkUnpackDeferred.isActive) {
+            val (job, started) = synchronized(this@RoboVmSdkUnpackService) {
+                activeJob?.takeIf { it.isActive }?.let { return@let it to false }
+                startUnpackJob(sdkHome).also { activeJob = it } to true
+            }
+            if (started) {
                 withBackgroundProgress(project, "Unpacking RoboVm SDK...", cancellable = false) {
                     try {
-                        val roboVmHome = sdkUnpackDeferred.await()
-                        if (!roboVmHome.isDev) {
-                            RoboVmPlugin.logInfo(
-                                project,
-                                "Installed RoboVM SDK %s to %s",
-                                Version.getCompilerVersion(),
-                                roboVmHome.homeDir.absolutePath
-                            )
-                        }
-                        roboVmHome
+                        val roboVmHome = job.await()
+                        RoboVmPlugin.logInfo(
+                            project,
+                            "Installed RoboVM SDK %s to %s",
+                            Version.getCompilerVersion(),
+                            roboVmHome.homeDir.absolutePath
+                        )
                     } catch (e: Exception) {
                         RoboVmPlugin.logError(project, e.message)
                         throw e
                     }
                 }
-            } else sdkUnpackDeferred.await()
+            } else job.await()
+            sdkHome
         }
     }
 


### PR DESCRIPTION
1. Migrated to `platform` gradle plugin v2 as v1 is deprecated and cause issue with K1/K2 compilers:
> error: Invalid plugin descriptor 'plugin.xml': failed to resolve <xi:include>. Not found document 'kotlin.plugin.k1.xml' referenced in <xi:include href="kotlin.plugin.k1.xml", includeUnless="idea.kotlin.plugin.use.k2"/>. <xi:fallback> element is not provided. (at plugin.xml)

also migrated to Gradle9 as required. 

2. 2025.2 ships with kotline 2.1
```
Exception in thread "ApplicationImpl pooled thread 4" kotlinx.coroutines.CoroutinesInternalError: Fatal exception in coroutines machinery for AwaitContinuation(DispatchedContinuation[BlockingEventLoop@38722215, org.robovm.idea.sdk.RoboVmSdkUnpackService$extractSdkIfNeeded$3$2@2f934f6b]){Completed}@15d7991d. Please read KDoc to 'handleFatalException' method and report this incident to maintainers
        at kotlinx.coroutines.DispatchedTask.handleFatalException$kotlinx_coroutines_core(DispatchedTask.kt:130)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:107)
```

3. if SDK was deleted from disk, it wasn't re-installed. That caused exception:
```
java.lang.RuntimeException: java.io.IOException: listFiles failed on /Users/niagara/.robovm-sdks/robovm-2.3.25/lib
	at org.robovm.idea.RoboVmPlugin.getSdkLibraries(RoboVmPlugin.java:257)
	at org.robovm.idea.RoboVmPlugin.getSdkLibrariesWithoutSources(RoboVmPlugin.java:267)
	at org.robovm.idea.compilation.RoboVmCompileTask.configureClassAndSourcepaths(RoboVmCompileTask.java:360)
```