### PR TITLE
* @CustomClass: allowing dots in custom name, full class file name by default

### DIFF
--- a/compiler/objc/src/main/java/org/robovm/objc/ObjCClass.java
+++ b/compiler/objc/src/main/java/org/robovm/objc/ObjCClass.java
@@ -371,12 +371,17 @@ public final class ObjCClass extends ObjCObject {
     private static String getCustomClassName(Class<? extends ObjCObject> type) {
         CustomClass customClassAnno = type.getAnnotation(CustomClass.class);
         String name = type.getName();
-        if (customClassAnno != null && customClassAnno.value().length() > 0) {
-            name = customClassAnno.value();
+        if (customClassAnno != null) {
+            // if there is name provided in annotation (e.g. @CustomClass("TestClass")) -- use it directly
+            // otherwise use fully qualified name with package (e.g. com.test.TestClass) and replace `$`
+            // for inner classes with `.`
+            if (customClassAnno.value().length() > 0)
+                name = customClassAnno.value();
+            else
+                name = name.replace('$', '.');
         } else {
-            name = CUSTOM_CLASS_NAME_PREFIX + name;
+            name = CUSTOM_CLASS_NAME_PREFIX + name.replace('.', '_');
         }
-        name = name.replace('.', '_');
         return name;
     }
 


### PR DESCRIPTION
What's changed:
1) if used without custom name `@CustomClass`, it will be exposed to ObjC with fully qualified class name (similar to swift). Previously it exposed it as linker-mangled symbols: now:  `com.test.Main.Delegate` -> `com.test.Main.Delegate` was:  `com.test.Main.Delegate` -> `j_com_test_Main$Delegate`

2) if used with custom name `@CustomClass("launcher.Delegate")` -- preserve dots, previously it was forced replaced with '-'. now:  -> `launcher.Delegate`
was:  -> `launcher_Delegate`

3) for classes that were extended from native ObjC and have no `@CustomClass` behaviour left same as before: `com.test.Main.Delegate` -> `j_com_test_Main$Delegate`