### PR TITLE
* reduced javadocs footprint 243M -> 180M

### DIFF
--- a/compiler/cocoatouch/pom.xml
+++ b/compiler/cocoatouch/pom.xml
@@ -58,12 +58,19 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration combine.self="override">
+                    <quiet>true</quiet>
                     <maxmemory>2g</maxmemory>
                     <!-- docs for RT: no lint, no bootclass and api 8 -->
                     <doclint>none</doclint>
                     <source>8</source>
                     <bootclasspath>""</bootclasspath>
                     <detectJavaApiLink>false</detectJavaApiLink>
+                    <additionalOptions>
+                        <additionalOption>--no-fonts</additionalOption>
+                        <additionalOption>-notree</additionalOption>
+                        <additionalOption>-noindex</additionalOption>
+                        <additionalOption>-nodeprecatedlist</additionalOption>
+                    </additionalOptions>
                 </configuration>
             </plugin>
         </plugins>

--- a/compiler/cocoatouch/pom.xml
+++ b/compiler/cocoatouch/pom.xml
@@ -65,12 +65,9 @@
                     <source>8</source>
                     <bootclasspath>""</bootclasspath>
                     <detectJavaApiLink>false</detectJavaApiLink>
-                    <additionalOptions>
-                        <additionalOption>--no-fonts</additionalOption>
-                        <additionalOption>-notree</additionalOption>
-                        <additionalOption>-noindex</additionalOption>
-                        <additionalOption>-nodeprecatedlist</additionalOption>
-                    </additionalOptions>
+                    <notree>true</notree>
+                    <noindex>true</noindex>
+                    <nodeprecated>true</nodeprecated>
                 </configuration>
             </plugin>
         </plugins>

--- a/compiler/objc/pom.xml
+++ b/compiler/objc/pom.xml
@@ -55,12 +55,9 @@
                     <source>8</source>
                     <bootclasspath>""</bootclasspath>
                     <detectJavaApiLink>false</detectJavaApiLink>
-                    <additionalOptions>
-                        <additionalOption>--no-fonts</additionalOption>
-                        <additionalOption>-notree</additionalOption>
-                        <additionalOption>-noindex</additionalOption>
-                        <additionalOption>-nodeprecatedlist</additionalOption>
-                    </additionalOptions>
+                    <notree>true</notree>
+                    <noindex>true</noindex>
+                    <nodeprecated>true</nodeprecated>
                 </configuration>
             </plugin>
         </plugins>

--- a/compiler/objc/pom.xml
+++ b/compiler/objc/pom.xml
@@ -48,12 +48,19 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration combine.self="override">
+                    <quiet>true</quiet>
                     <maxmemory>2g</maxmemory>
                     <!-- docs for RT: no lint, no bootclass and api 8 -->
                     <doclint>none</doclint>
                     <source>8</source>
                     <bootclasspath>""</bootclasspath>
                     <detectJavaApiLink>false</detectJavaApiLink>
+                    <additionalOptions>
+                        <additionalOption>--no-fonts</additionalOption>
+                        <additionalOption>-notree</additionalOption>
+                        <additionalOption>-noindex</additionalOption>
+                        <additionalOption>-nodeprecatedlist</additionalOption>
+                    </additionalOptions>
                 </configuration>
             </plugin>
         </plugins>

--- a/compiler/rt/pom.xml
+++ b/compiler/rt/pom.xml
@@ -125,12 +125,9 @@
                     <source>8</source>
                     <bootclasspath>""</bootclasspath>
                     <detectJavaApiLink>false</detectJavaApiLink>
-                    <additionalOptions>
-                        <additionalOption>--no-fonts</additionalOption>
-                        <additionalOption>-notree</additionalOption>
-                        <additionalOption>-noindex</additionalOption>
-                        <additionalOption>-nodeprecatedlist</additionalOption>
-                    </additionalOptions>
+                    <notree>true</notree>
+                    <noindex>true</noindex>
+                    <nodeprecated>true</nodeprecated>
                 </configuration>
             </plugin>
 

--- a/compiler/rt/pom.xml
+++ b/compiler/rt/pom.xml
@@ -118,12 +118,19 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration combine.self="override">
+                    <quiet>true</quiet>
                     <maxmemory>2g</maxmemory>
                     <!-- docs for RT: no lint, no bootclass and api 8 -->
                     <doclint>none</doclint>
                     <source>8</source>
                     <bootclasspath>""</bootclasspath>
                     <detectJavaApiLink>false</detectJavaApiLink>
+                    <additionalOptions>
+                        <additionalOption>--no-fonts</additionalOption>
+                        <additionalOption>-notree</additionalOption>
+                        <additionalOption>-noindex</additionalOption>
+                        <additionalOption>-nodeprecatedlist</additionalOption>
+                    </additionalOptions>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.12.0</version>
                 </plugin>
 
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -516,12 +516,9 @@
                     <doclint>none</doclint>
                     <release>9</release>
                     <detectJavaApiLink>false</detectJavaApiLink>
-                    <additionalOptions>
-                        <additionalOption>--no-fonts</additionalOption>
-                        <additionalOption>-notree</additionalOption>
-                        <additionalOption>-noindex</additionalOption>
-                        <additionalOption>-nodeprecatedlist</additionalOption>
-                    </additionalOptions>
+                    <notree>true</notree>
+                    <noindex>true</noindex>
+                    <nodeprecated>true</nodeprecated>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -512,9 +512,16 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <quiet>true</quiet>
                     <doclint>none</doclint>
                     <release>9</release>
                     <detectJavaApiLink>false</detectJavaApiLink>
+                    <additionalOptions>
+                        <additionalOption>--no-fonts</additionalOption>
+                        <additionalOption>-notree</additionalOption>
+                        <additionalOption>-noindex</additionalOption>
+                        <additionalOption>-nodeprecatedlist</additionalOption>
+                    </additionalOptions>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
still the biggest one is:
> 144M	./compiler/cocoatouch/target/robovm-cocoatouch-2.3.26-SNAPSHOT-javadoc.jar

```
find . -name '*-javadoc.jar' -exec du -ch {} +
4.0K	./dist/compiler/target/robovm-dist-compiler-2.3.26-SNAPSHOT-javadoc.jar
 56K	./plugins/junit/server/target/robovm-junit-server-2.3.26-SNAPSHOT-javadoc.jar
 68K	./plugins/junit/protocol/target/robovm-junit-protocol-2.3.26-SNAPSHOT-javadoc.jar
 56K	./plugins/junit/client/target/robovm-junit-client-2.3.26-SNAPSHOT-javadoc.jar
 48K	./plugins/maven/surefire/target/robovm-surefire-provider-2.3.26-SNAPSHOT-javadoc.jar
108K	./plugins/maven/plugin/target/robovm-maven-plugin-2.3.26-SNAPSHOT-javadoc.jar
172K	./plugins/ibxcode/target/robovm-ibxcode-2.3.26-SNAPSHOT-javadoc.jar
4.0M	./plugins/gradle/build/libs/robovm-gradle-plugin-2.3.26-SNAPSHOT-javadoc.jar
1.4M	./plugins/debugger/target/robovm-debugger-2.3.26-SNAPSHOT-javadoc.jar
4.0K	./plugins/templates/ios-framework/target/robovm-templates-ios-framework-2.3.26-SNAPSHOT-javadoc.jar
 48K	./plugins/templates/templater/target/robovm-templater-2.3.26-SNAPSHOT-javadoc.jar
4.0K	./plugins/templates/ios-single-view-no-ib/target/robovm-templates-ios-single-view-no-ib-2.3.26-SNAPSHOT-javadoc.jar
4.0K	./plugins/templates/console/target/robovm-templates-console-2.3.26-SNAPSHOT-javadoc.jar
 56K	./plugins/resolver/target/robovm-maven-resolver-2.3.26-SNAPSHOT-javadoc.jar
508K	./compiler/libimobiledevice/target/robovm-libimobiledevice-2.3.26-SNAPSHOT-javadoc.jar
144M	./compiler/cocoatouch/target/robovm-cocoatouch-2.3.26-SNAPSHOT-javadoc.jar
580K	./compiler/llvm/target/robovm-llvm-2.3.26-SNAPSHOT-javadoc.jar
 26M	./compiler/rt/target/robovm-rt-2.3.26-SNAPSHOT-javadoc.jar
4.0K	./compiler/cacerts/full/target/robovm-cacerts-full-2.3.26-SNAPSHOT-javadoc.jar
344K	./compiler/objc/target/robovm-objc-2.3.26-SNAPSHOT-javadoc.jar
2.3M	./compiler/compiler/target/robovm-compiler-2.3.26-SNAPSHOT-javadoc.jar
180M	total
```