### PR TITLE
* fix: eclipse build JAXP00010003: The length of entity "[xml]" is "100001" that exceeds the "100000"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,5 +2,5 @@
 set -e
 mvn -T 10 clean install
 ./plugins/idea/gradlew -p plugins/idea/ clean buildPlugin
-mvn -T 10 -f plugins/eclipse/pom.xml clean install
+MAVEN_OPTS="-Djdk.xml.maxGeneralEntitySizeLimit=0 -Djdk.xml.totalEntitySizeLimit=0" mvn -T 10 -f plugins/eclipse/pom.xml clean install
 ./plugins/gradle/gradlew -b plugins/gradle/build.gradle clean assemble validatePlugins publishToMavenLocal


### PR DESCRIPTION

constraints were introduced by JDK-8343004 and JDK-8343006, but seems like P2 repo has long xmls. temporally disabling this check for Eclipse build