### PR TITLE
* dist package re-arrangement: include sources into snapshot, no bin for libs only, warning cleanup

### DIFF
--- a/dist/package/pom.xml
+++ b/dist/package/pom.xml
@@ -16,20 +16,6 @@
         <robovmdir>${basedir}/../../compiler</robovmdir>
     </properties>
 
-    <profiles>
-        <profile>
-            <id>robovm-release</id>
-            <dependencies>
-                <!-- RT sources are build during release only -->
-                <dependency>
-                    <groupId>com.mobidevelop.robovm</groupId>
-                    <artifactId>robovm-rt</artifactId>
-                    <classifier>sources</classifier>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
-
     <dependencies>
         <dependency>
             <groupId>com.mobidevelop.robovm</groupId>
@@ -41,7 +27,17 @@
         </dependency>
         <dependency>
             <groupId>com.mobidevelop.robovm</groupId>
+            <artifactId>robovm-rt</artifactId>
+            <classifier>sources</classifier>
+        </dependency>
+        <dependency>
+            <groupId>com.mobidevelop.robovm</groupId>
             <artifactId>robovm-objc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.mobidevelop.robovm</groupId>
+            <artifactId>robovm-objc</artifactId>
+            <classifier>sources</classifier>
         </dependency>
         <dependency>
             <groupId>com.mobidevelop.robovm</groupId>

--- a/dist/package/src/main/assembly/dist-common.xml
+++ b/dist/package/src/main/assembly/dist-common.xml
@@ -18,14 +18,6 @@
       <outputDirectory>lib/vm</outputDirectory>
     </fileSet>
     <fileSet>
-      <directory>${robovmdir}/bin</directory>
-      <includes>
-        <include>*</include>
-      </includes>
-      <fileMode>755</fileMode>
-      <outputDirectory>bin</outputDirectory>
-    </fileSet>
-    <fileSet>
       <directory>${robovmdir}/compiler</directory>
       <outputDirectory>modules/licenses/dist-compiler/compiler</outputDirectory>
       <includes>

--- a/dist/package/src/main/assembly/dist-full.xml
+++ b/dist/package/src/main/assembly/dist-full.xml
@@ -14,6 +14,18 @@
     <componentDescriptor>src/main/assembly/dist-common.xml</componentDescriptor>
   </componentDescriptors>
 
+  <!-- binaries only needed for compiler package -->
+  <fileSets>
+    <fileSet>
+      <directory>${robovmdir}/bin</directory>
+      <includes>
+        <include>*</include>
+      </includes>
+      <fileMode>755</fileMode>
+      <outputDirectory>bin</outputDirectory>
+    </fileSet>
+  </fileSets>
+
   <dependencySets>
     <dependencySet>
       <includes>
@@ -29,7 +41,7 @@
     <dependencySet>
       <includes>
         <include>*:*:*:sources</include>
-        <include>*:*:*:javadoc</include>
+<!-- there is no javadoc meanwhile, commented out to remove warning       <include>*:*:*:javadoc</include>-->
       </includes>
       <outputDirectory>lib</outputDirectory>
       <unpack>false</unpack>

--- a/dist/package/src/main/assembly/dist-nocompiler.xml
+++ b/dist/package/src/main/assembly/dist-nocompiler.xml
@@ -32,7 +32,7 @@
     <dependencySet>
       <includes>
         <include>*:*:*:sources</include>
-        <include>*:*:*:javadoc</include>
+        <!-- there is no javadoc meanwhile, commented out to remove warning       <include>*:*:*:javadoc</include>-->
       </includes>
       <outputDirectory>lib</outputDirectory>
       <unpack>false</unpack>

--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
                 <artifactId>robovm-rt</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            <!-- FIXME: -->
+            <!-- robovm-rt sources used in dist -->
             <dependency>
                 <groupId>com.mobidevelop.robovm</groupId>
                 <artifactId>robovm-rt</artifactId>
@@ -253,6 +253,13 @@
                 <groupId>com.mobidevelop.robovm</groupId>
                 <artifactId>robovm-objc</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+            <!-- robovm-objc sources used in dist -->
+            <dependency>
+                <groupId>com.mobidevelop.robovm</groupId>
+                <artifactId>robovm-objc</artifactId>
+                <version>${project.version}</version>
+                <classifier>sources</classifier>
             </dependency>
             <dependency>
                 <groupId>com.mobidevelop.robovm</groupId>
@@ -453,7 +460,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.8.0</version>
                     <configuration>
                         <!-- FIXME: this one is to fix "single failed: group id 'SOME BIG ID' is too big" when mac is in NT domain -->
                         <!-- FIXME: this adds PaxHeaders.X in this case, check if it will be adding it for normal user -->


### PR DESCRIPTION

- including RT and OBJC source jars for both release and snapshot (its pain to have no these in idea)
- assembly plugin version updated to 3.8.0 to fix warn: [WARNING]  Parameter 'finalName' is read-only, must not be used in configuration
- fixed warning [WARNING] The following patterns were never triggered in this artifact inclusion filter: '*:*:*:sources' '*:*:*:javadoc'
- removed `bin/` folder with libhfscompressor-arm64.dylib from `-nocompiler` tar.