### PR TITLE
* reduced number of warnings in build flow

### DIFF
--- a/compiler/cocoatouch/pom.xml
+++ b/compiler/cocoatouch/pom.xml
@@ -43,14 +43,13 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <!-- provide empty bootclass as one from robovm.rt to be used -->
                 <configuration combine.self="override">
-                    <compilerArguments>
-                        <target>1.8</target>
-                        <source>1.8</source>
-                        <bootclasspath>""</bootclasspath>
-                    </compilerArguments>
                     <encoding>UTF-8</encoding>
                     <source>8</source>
                     <target>8</target>
+                    <compilerArgs>
+                        <arg>-bootclasspath</arg>
+                        <arg>""</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
 

--- a/compiler/objc/pom.xml
+++ b/compiler/objc/pom.xml
@@ -35,12 +35,13 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <!-- provide empty bootclass as one from robovm.rt to be used -->
                 <configuration combine.self="override">
-                    <compilerArguments>
-                        <target>1.8</target>
-                        <source>1.8</source>
-                        <bootclasspath>""</bootclasspath>
-                    </compilerArguments>
+                    <source>8</source>
+                    <target>8</target>
                     <encoding>UTF-8</encoding>
+                    <compilerArgs>
+                        <arg>-bootclasspath</arg>
+                        <arg>""</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
 

--- a/compiler/rt/pom.xml
+++ b/compiler/rt/pom.xml
@@ -62,12 +62,13 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <!-- provide empty bootclass its the RT -->
                 <configuration combine.self="override">
-                    <compilerArguments>
-                        <target>1.8</target>
-                        <source>1.8</source>
-                        <bootclasspath>""</bootclasspath>
-                    </compilerArguments>
+                    <source>8</source>
+                    <target>8</target>
                     <encoding>UTF-8</encoding>
+                    <compilerArgs>
+                        <arg>-bootclasspath</arg>
+                        <arg>""</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
 

--- a/compiler/vm/MergeStaticLibObjectFiles.cmake
+++ b/compiler/vm/MergeStaticLibObjectFiles.cmake
@@ -36,7 +36,7 @@ function(merge_static_lib_object_files lib)
 
       string(REPLACE ";" ", " exported_symbols_joined "${exported_symbols}")
       string(REPLACE ";" " " exported_symbols_args_joined "${exported_symbols_args}")
-      add_custom_command(TARGET ${lib}
+      add_custom_command(TARGET ${lib} POST_BUILD
         COMMAND echo Merging object files in $<TARGET_FILE:${lib}> with exported symbols: ${exported_symbols_joined}
         COMMAND echo ld -arch ${CARCH} -platform_version ${CPLATFORM} ${CPLATFORM_MIN_VERSION} ${CPLATFORM_MIN_VERSION} -r ${exported_symbols_args} -all_load $<TARGET_FILE:${lib}> -o ${CMAKE_CURRENT_BINARY_DIR}/merged.o
         COMMAND ld -arch ${CARCH} -platform_version ${CPLATFORM} ${CPLATFORM_MIN_VERSION} ${CPLATFORM_MIN_VERSION} -r ${exported_symbols_args} -all_load $<TARGET_FILE:${lib}> -o ${CMAKE_CURRENT_BINARY_DIR}/merged.o
@@ -59,7 +59,7 @@ function(merge_static_lib_object_files lib)
 
       string(REPLACE ";" ", " exported_symbols_joined "${exported_symbols}")
       string(REPLACE ";" " " exported_symbols_args_joined "${exported_symbols_args}")
-      add_custom_command(TARGET ${lib}
+      add_custom_command(TARGET ${lib} POST_BUILD
         COMMAND echo Merging object files in $<TARGET_FILE:${lib}> with exported symbols: ${exported_symbols_joined}
         COMMAND echo ld -m ${EMULATION_MODE} -r --whole-archive $<TARGET_FILE:${lib}> -o ${CMAKE_CURRENT_BINARY_DIR}/tmp.o
         COMMAND ld -m ${EMULATION_MODE} -r --whole-archive $<TARGET_FILE:${lib}> -o ${CMAKE_CURRENT_BINARY_DIR}/tmp.o

--- a/compiler/vm/rt/android/external/fdlibm/CMakeLists.txt
+++ b/compiler/vm/rt/android/external/fdlibm/CMakeLists.txt
@@ -9,7 +9,6 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_IEEE_LIBM")
 # library (see their own admission in 'readme'). Without this, we
 # fail StrictMath tests on x86.
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-strict-aliasing")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ffloat-store")
 
 # fdlibm expects __LITTLE_ENDIAN to be defined for little endian targets but
 # clang defines __LITTLE_ENDIAN__.

--- a/plugins/eclipse/pom.xml
+++ b/plugins/eclipse/pom.xml
@@ -63,7 +63,6 @@
                 <configuration>
                     <release>8</release>
                     <debug>true</debug>
-                    <optimize>true</optimize>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>

--- a/plugins/eclipse/pom.xml
+++ b/plugins/eclipse/pom.xml
@@ -31,6 +31,7 @@
         <robovm.version>2.3.26-SNAPSHOT</robovm.version>
         <tycho.version>4.0.7</tycho.version>
         <eclipse-site>https://download.eclipse.org/releases/2024-06/</eclipse-site>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <repositories>

--- a/plugins/idea/pom.xml
+++ b/plugins/idea/pom.xml
@@ -84,7 +84,6 @@
                 <configuration>
                     <release>17</release>
                     <debug>true</debug>
-                    <optimize>true</optimize>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>

--- a/plugins/maven/plugin/pom.xml
+++ b/plugins/maven/plugin/pom.xml
@@ -43,12 +43,21 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>3.6.1</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>3.6.1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>3.6.1</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -67,7 +76,7 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-compat</artifactId>
             <version>3.6.1</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 
@@ -103,7 +112,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.6.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/plugins/maven/pom.xml
+++ b/plugins/maven/pom.xml
@@ -37,8 +37,8 @@
         <url>https://github.com/MobiVM/robovm</url>
         <connection>scm:git:git://github.com/MobiVM/robovm.git</connection>
         <developerConnection>scm:git:git@github.com:mobidevelop/robovm.git</developerConnection>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <issueManagement>
         <system>GitHub</system>

--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,6 @@
                     <configuration>
                         <release>9</release>
                         <debug>true</debug>
-                        <optimize>true</optimize>
                         <encoding>UTF-8</encoding>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
* fixed warning: [WARNING]  Parameter 'compilerArguments' is deprecated: use {@link #compilerArgs} instead.
* fixed warning: while building maven plugin
```
Some dependencies of Maven Plugins are expected to be in provided scope.
Please make sure that dependencies listed below declared in POM
have set '<scope>provided</scope>' as well.

The following dependencies are in wrong scope:
* org.apache.maven:maven-plugin-api:jar:3.6.1:compile
* org.apache.maven:maven-model:jar:3.6.1:compile
* org.apache.maven:maven-artifact:jar:3.6.1:compile
* org.apache.maven:maven-core:jar:3.6.1:compile
* org.apache.maven:maven-settings:jar:3.6.1:compile
* org.apache.maven:maven-settings-builder:jar:3.6.1:compile
* org.apache.maven:maven-builder-support:jar:3.6.1:compile
* org.apache.maven:maven-repository-metadata:jar:3.6.1:compile
* org.apache.maven:maven-model-builder:jar:3.6.1:compile
* org.apache.maven:maven-resolver-provider:jar:3.6.1:compile
* org.apache.maven:maven-compat:jar:3.6.1:compile
```
* fixed warning:  Parameter 'optimize' (user property 'maven.compiler.optimize') is deprecated: This property is a no-op in {@code javac}
* fixed warning: Policy CMP0175 is not set: add_custom_command() rejects invalid arguments.
* fixed warning: clang: warning: optimization flag '-ffloat-store' is not supported, as clang doesn't support this gcc flag
* fixed warning: [WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources