### PR TITLE
* idea plugin: removing RoboVM facet leftovers from `ios` module, when adding to `ios-main`

### DIFF
--- a/plugins/idea/src/main/java/org/robovm/idea/gradle/sync/RoboVMGradleProjectResolver.kt
+++ b/plugins/idea/src/main/java/org/robovm/idea/gradle/sync/RoboVMGradleProjectResolver.kt
@@ -54,7 +54,12 @@ class RoboVMGradleProjectResolver : AbstractProjectResolverExtension() {
         val sourceSetNodes = ExternalSystemApiUtil.findAll(moduleNode, GradleSourceSetData.KEY)
         val nodeForFacet = sourceSetNodes.find { it.data.id.endsWith(":main") }
             ?: moduleNode
-        nodeForFacet.createChild(RoboVmGradleModelKey, externalSettings)
+        nodeForFacet.createChild(RoboVmGradleModelKey, RoboVmModuleDataService.ServiceData.FacetSettings(externalSettings))
+        if (moduleNode !== nodeForFacet) {
+            // attaching facet to "ios-main" module. while "ios" module might
+            // still contain RoboVM facet, inspect it in service and remove if present
+            moduleNode.createChild(RoboVmGradleModelKey, RoboVmModuleDataService.ServiceData.InspectionRequest)
+        }
 
         // configure build folder as ignored so it doesn't appear in project view and doesn't cause indexing
         externalSettings.contentRoot?.let { contentRoot ->

--- a/plugins/idea/src/main/java/org/robovm/idea/gradle/sync/RoboVmModuleDataService.kt
+++ b/plugins/idea/src/main/java/org/robovm/idea/gradle/sync/RoboVmModuleDataService.kt
@@ -34,18 +34,25 @@ import org.robovm.idea.sdk.RoboVmSdkType
  * Key identifies as RoboVM module being imported by gradle.
  * Being set in RoboVMGradleProjectResolver. Using facet setting class here as data
  */
-internal val RoboVmGradleModelKey = Key.create(RoboVmFacetConfiguration.Settings::class.java, 1)
+internal val RoboVmGradleModelKey = Key.create(RoboVmModuleDataService.ServiceData::class.java, 1)
 
 /**
  * Attaches RoboVM facet to modules imported by gradle.
  * (triggered by RoboVmModelKey in DataNode, attached by RoboVMGradleProjectResolver)
  */
-class RoboVmModuleDataService : AbstractProjectDataService<RoboVmFacetConfiguration.Settings, Module>() {
+class RoboVmModuleDataService : AbstractProjectDataService<RoboVmModuleDataService.ServiceData, Module>() {
+    sealed interface ServiceData {
+        /// special tag for modules that are part of RoboVM module but where facet to be removed
+        /// e.g. `ios-main` should have it attached, but `ios` not.
+        /// module `ios` will be marked with this tag and checked for facet for removal
+        data object InspectionRequest: ServiceData
+        data class FacetSettings(val settings: RoboVmFacetConfiguration.Settings): ServiceData
+    }
 
-    override fun getTargetDataKey(): Key<RoboVmFacetConfiguration.Settings> = RoboVmGradleModelKey
+    override fun getTargetDataKey(): Key<ServiceData> = RoboVmGradleModelKey
 
     override fun postProcess(
-        toImport: Collection<DataNode<RoboVmFacetConfiguration.Settings>>,
+        toImport: Collection<DataNode<ServiceData>>,
         projectData: ProjectData?,
         project: Project,
         modelsProvider: IdeModifiableModelsProvider
@@ -57,19 +64,24 @@ class RoboVmModuleDataService : AbstractProjectDataService<RoboVmFacetConfigurat
             val parentNode = nodeToImport.parent ?: return@forEach
             val moduleData = parentNode.data as? ModuleData ?: return@forEach
             val module = modelsProvider.findIdeModule(moduleData) ?: return@forEach
-            val externalModel = nodeToImport.data
+            val externalModel = (nodeToImport.data as? ServiceData.FacetSettings)?.settings
             val facetModel = modelsProvider.getModifiableFacetModel(module)
-            facetModel.getFacetByType(RoboVmFacetType.TYPE_ID)?.let {
-                // facet already attached, replace its settings
-                it.configuration.replaceSettings(externalModel)
-            } ?: run {
-                // create new facet
-                module.attachRoboVmFacet(facetModel, externalModel)
-            }
+            if (externalModel != null) {
+                facetModel.getFacetByType(RoboVmFacetType.TYPE_ID)?.let {
+                    // facet already attached, replace its settings
+                    it.configuration.replaceSettings(externalModel)
+                } ?: run {
+                    // create new facet
+                    module.attachRoboVmFacet(facetModel, externalModel)
+                }
 
-            // setup sdk
-            val moduleModel = modelsProvider.getModifiableRootModel(module)
-            moduleModel.sdk = RoboVmSdkType.setUpSdkIfNeeded(project)
+                // setup sdk
+                val moduleModel = modelsProvider.getModifiableRootModel(module)
+                moduleModel.sdk = RoboVmSdkType.setUpSdkIfNeeded(project)
+            } else {
+                // module tagged with ServiceData.InspectionRequest and facet should be removed from it
+                facetModel.getFacetByType(RoboVmFacetType.TYPE_ID)?.let { facetModel.removeFacet(it) }
+            }
         }
     }
 


### PR DESCRIPTION
(issue was discussed in gitter)

Root case:
in 2.3.24 idea plugin "modules-per-source" was forced off and there was only one `ios` module. in 2.3.25 this was changed and "modules-per-source" is supported. After installing 2.3.25 and opening existing project, gradle will add gradle facet to `ios-main` module but will not remove it from `ios`.

As result `Create IPA` dialog will keep old setting with `ios` module selected but compilation will fail as `ios` modules is empty.

The fix: when adding facet and marking module `ios-main` as `RoboVM`, its parent in inspected and facet removed from it.