### PR TITLE
* fixed: ld: framework 'RvmCocoaTouch' not found

### DIFF
--- a/compiler/cocoatouch/pom.xml
+++ b/compiler/cocoatouch/pom.xml
@@ -82,7 +82,7 @@
                 <executions>
                     <execution>
                         <id>build-binaries</id>
-                        <phase>process-resources</phase>
+                        <phase>generate-resources</phase>
                         <goals>
                             <goal>exec</goal>
                         </goals>


### PR DESCRIPTION
root case: wrong phase was used. was working in single thread build, but in multi-thread resources got copied without the lib