### PR TITLE
* fixed: IdeaPlugin -- unpack SDK files on every launch for -SNAPSHOT builds

### DIFF
--- a/plugins/idea/src/main/java/org/robovm/idea/components/RoboVmProjectStartupActivity.kt
+++ b/plugins/idea/src/main/java/org/robovm/idea/components/RoboVmProjectStartupActivity.kt
@@ -20,6 +20,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
 import org.robovm.idea.RoboVmPlugin
 import org.robovm.idea.facet.RoboVmFacetType
+import org.robovm.idea.sdk.RoboVmSdkType
 
 /**
  * Replacement for ProjectComponent/ApplicationComponent.
@@ -33,6 +34,9 @@ class RoboVmProjectStartupActivity: ProjectActivity {
         val modulesWithFacet = ProjectFacetManager.getInstance(project).getModulesWithFacet(RoboVmFacetType.TYPE_ID)
         if (modulesWithFacet.isNotEmpty()) {
             RoboVmPlugin.initializeProject(project)
+
+            // setup Sdk, plugin might be updated and SDK files might be changed, so we need to check if SDK is still valid
+            RoboVmSdkType.setUpSdkIfNeeded(project)
 
             // show xcode dialog if applicable
             val setupService = service<RoboVmAppSetupService>()

--- a/plugins/idea/src/main/java/org/robovm/idea/sdk/RoboVmSdkUnpackService.kt
+++ b/plugins/idea/src/main/java/org/robovm/idea/sdk/RoboVmSdkUnpackService.kt
@@ -42,6 +42,9 @@ import java.util.zip.GZIPInputStream
  */
 @Service(Service.Level.APP)
 class RoboVmSdkUnpackService(private val scope: CoroutineScope) {
+    /// flag, specifies that SDK was extracted
+    private var sdkExtracted = false
+
     private var activeJob: Deferred<Home>? = null
     private fun startUnpackJob(sdkHome: Home): Deferred<Home> = scope.async(Dispatchers.IO) {
         // using parent here as:
@@ -64,11 +67,32 @@ class RoboVmSdkUnpackService(private val scope: CoroutineScope) {
         sdkHome
     }
 
+    /**
+     *
+     */
+    @Synchronized
+    private fun validateExistingSdk(sdkHome: Home): Boolean {
+
+        try {
+            // in case of snapshot version of RoboVM, SDK shall be unconditionally
+            // extracted once per opened project
+            if (!sdkExtracted && Version.getCompilerVersion().endsWith("-SNAPSHOT"))
+                return false
+
+            sdkHome.validate()
+        } catch (_: Exception) {
+            return false
+        }
+
+        // sdk valid and can be reused
+        return true
+    }
+
     fun extractSdkIfNeeded(project: Project): Home {
         // wait till unpack task is complete
         val sdkHome = RoboVmLocations.roboVmHome
         if (sdkHome.isDev) return sdkHome
-        runCatching { sdkHome.validate() }.onSuccess { return sdkHome }
+        if (validateExistingSdk(sdkHome)) return sdkHome
 
         return runBlocking {
             val (job, started) = synchronized(this@RoboVmSdkUnpackService) {
@@ -131,6 +155,7 @@ class RoboVmSdkUnpackService(private val scope: CoroutineScope) {
                     }
                 }
 
+                sdkExtracted = true
                 return filesWereUpdated
             }
         } catch (t: Throwable) {


### PR DESCRIPTION
for snapshot builds SDK files must be extracted on every launch (this logic was lost during refactoring)

@Tom-Ski  nice to have merged