### PR TITLE
* fixed: failed to parse DeviceCtl response on Xcode27 Beta

### DIFF
--- a/compiler/compiler/pom.xml
+++ b/compiler/compiler/pom.xml
@@ -61,14 +61,8 @@
             <artifactId>bcpkix-jdk15on</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.googlecode.json-simple</groupId>
+            <groupId>com.github.cliftonlabs</groupId>
             <artifactId>json-simple</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>

--- a/compiler/compiler/src/main/java/org/robovm/compiler/AppCompiler.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/AppCompiler.java
@@ -17,11 +17,11 @@
  */
 package org.robovm.compiler;
 
+import com.github.cliftonlabs.json_simple.JsonObject;
+import com.github.cliftonlabs.json_simple.Jsoner;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.json.simple.JSONObject;
-import org.json.simple.JSONValue;
 import org.robovm.compiler.clazz.*;
 import org.robovm.compiler.config.*;
 import org.robovm.compiler.config.Config.TreeShakerMode;
@@ -1221,7 +1221,7 @@ public class AppCompiler {
 
     private class UpdateChecker extends Thread {
         private final String address;
-        private volatile JSONObject result;
+        private volatile JsonObject result;
 
         public UpdateChecker(String address) {
             this.address = address;
@@ -1262,7 +1262,7 @@ public class AppCompiler {
                     + "osVersion=" + URLEncoder.encode(osVersion, "UTF-8"));
             t.start();
             t.join(5 * 1000); // Wait for a maximum of 5 seconds
-            JSONObject result = t.result;
+            JsonObject result = t.result;
             if (result != null) {
                 String version = (String) result.get("version");
                 if (version != null && Version.isOlderThan(Version.getCompilerVersion(), version)) {
@@ -1308,14 +1308,14 @@ public class AppCompiler {
         FileUtils.writeStringToFile(timeFile, String.valueOf(System.currentTimeMillis()), "UTF-8");
     }
 
-    private JSONObject fetchJson(String address) {
+    private JsonObject fetchJson(String address) {
         try {
             URL url = new URL(address);
             URLConnection conn = url.openConnection();
             conn.setConnectTimeout(5 * 1000);
             conn.setReadTimeout(5 * 1000);
             try (InputStream in = new BufferedInputStream(conn.getInputStream())) {
-                return (JSONObject) JSONValue.parseWithException(IOUtils.toString(in, "UTF-8"));
+                return (JsonObject) Jsoner.deserialize(IOUtils.toString(in, "UTF-8"));
             }
         } catch (Exception e) {
             if (config.getHome().isDev()) {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/devicectl/DeviceCtl.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/devicectl/DeviceCtl.java
@@ -16,9 +16,9 @@
  */
 package org.robovm.compiler.target.ios.devicectl;
 
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
+import com.github.cliftonlabs.json_simple.JsonException;
+import com.github.cliftonlabs.json_simple.JsonObject;
+import com.github.cliftonlabs.json_simple.Jsoner;
 import org.robovm.compiler.log.Logger;
 import org.robovm.compiler.util.Executor;
 
@@ -37,7 +37,7 @@ public class DeviceCtl {
     /**
      * gets list of devices by invoking `xcrun devicectl list devices -j @dest-file`
      */
-    public static List<AppleDevice> listDevices(Logger log) throws IOException, ParseException {
+    public static List<AppleDevice> listDevices(Logger log) throws IOException, JsonException {
         File f = File.createTempFile("robovm-devicectl-", ".list");
         f.delete();
 
@@ -45,9 +45,8 @@ public class DeviceCtl {
             .args("devicectl", "list", "devices", "-j", f.getAbsolutePath())
             .exec();
 
-        JSONParser parser = new JSONParser();
         try (FileReader reader = new FileReader(f)) {
-            JSONObject root = (JSONObject) parser.parse(reader);
+            JsonObject root = (JsonObject) Jsoner.deserialize(reader);
             return DeviceCtlParsers.parseListResponse(root);
         }
     }
@@ -68,7 +67,7 @@ public class DeviceCtl {
     }
 
 
-    public static AppleDevice getDeviceInfo(Logger log, String udid) throws IOException, ParseException {
+    public static AppleDevice getDeviceInfo(Logger log, String udid) throws IOException, JsonException {
         File f = File.createTempFile("robovm-devicectl-", ".deviceinfo");
         f.delete();
 
@@ -76,14 +75,13 @@ public class DeviceCtl {
             .args("devicectl", "device", "info", "details", "-q", "-d", udid, "-j", f.getAbsolutePath())
             .exec();
 
-        JSONParser parser = new JSONParser();
         try (FileReader reader = new FileReader(f)) {
-            JSONObject root = (JSONObject) parser.parse(reader);
+            JsonObject root = (JsonObject) Jsoner.deserialize(reader);
             return DeviceCtlParsers.parseDeviceInfoResponse(root);
         }
     }
 
-    public static void install(Logger log, String udid, String localAppPath) throws Executor.ExecuteException, IOException, ParseException {
+    public static void install(Logger log, String udid, String localAppPath) throws IOException {
         File f = File.createTempFile("robovm-devicectl-", ".install");
         f.delete();
 
@@ -135,7 +133,7 @@ public class DeviceCtl {
 
     public static void main(String[] args) {
         listDevices().forEach(
-                d -> System.out.println(d)
+            System.out::println
         );
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/devicectl/DeviceCtlParsers.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/devicectl/DeviceCtlParsers.java
@@ -16,8 +16,8 @@
  */
 package org.robovm.compiler.target.ios.devicectl;
 
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
+import com.github.cliftonlabs.json_simple.JsonArray;
+import com.github.cliftonlabs.json_simple.JsonObject;
 import org.robovm.compiler.target.ios.devicectl.AppleDevice.Capability;
 import org.robovm.compiler.target.ios.devicectl.AppleDevice.ConnectionProperties;
 import org.robovm.compiler.target.ios.devicectl.AppleDevice.ConnectionProperties.AuthenticationType;
@@ -48,7 +48,7 @@ public final class DeviceCtlParsers {
      *   }
      * ]
      */
-    public static Set<Capability> parseCapabilities(@Required Stream<JSONObject> stream) {
+    public static Set<Capability> parseCapabilities(@Required Stream<JsonObject> stream) {
         return stream.map(js -> js.get("featureIdentifier"))
                 .filter(s -> s instanceof String)
                 .map(s -> Capability.of((String)s)).collect(Collectors.toSet());
@@ -64,7 +64,7 @@ public final class DeviceCtlParsers {
      *   "tunnelIPAddress" : "fdeb:b11:406e::1",
      * }
      */
-    public static ConnectionProperties parseConnectionProperties(@Optional JSONObject json) {
+    public static ConnectionProperties parseConnectionProperties(@Optional JsonObject json) {
         AuthenticationType authenticationType = AuthenticationType.of(asString(json, "authenticationType"));
         PairingState pairingState = PairingState.of(asString(json, "pairingState"));
         TransportType transportType = TransportType.of(asString(json, "transportType"));
@@ -84,7 +84,7 @@ public final class DeviceCtlParsers {
      *   "osVersionNumber" : "18.5",
      * }
      */
-    public static DeviceProperties parseDeviceProperties(@Optional JSONObject json) {
+    public static DeviceProperties parseDeviceProperties(@Optional JsonObject json) {
         return new DeviceProperties(
             "booted".equals(asString(json, "bootState")),
             "enabled".equals(asString(json, "developerModeStatus")),
@@ -115,7 +115,7 @@ public final class DeviceCtlParsers {
      *   "udid" : "00008020-000123123123123"
      *  }
      */
-    public static HardwareProperties parseHardwareProperties(@Optional JSONObject json) {
+    public static HardwareProperties parseHardwareProperties(@Optional JsonObject json) {
         HardwareProperties.CPUType cpuType = HardwareProperties.CPUType.of(
             asString(asJson(json, "cpuType"), "name")
         );
@@ -153,7 +153,7 @@ public final class DeviceCtlParsers {
      *     "identifier" : "AF319CBD-DC10-5AC0-815E-3774F8270D13",
      *  }
      */
-    public static AppleDevice parseAppleDevice(@Required JSONObject json) {
+    public static AppleDevice parseAppleDevice(@Required JsonObject json) {
         return new AppleDevice(
             asString(json, "identifier"),
             parseCapabilities(asObjectStream(json, "capabilities", Stream.empty())),
@@ -171,8 +171,8 @@ public final class DeviceCtlParsers {
      *   }
      * }
      */
-    public static List<AppleDevice> parseListResponse(@Required JSONObject json) {
-        JSONObject result = asJson(json, "result");
+    public static List<AppleDevice> parseListResponse(@Required JsonObject json) {
+        JsonObject result = asJson(json, "result");
         return asObjectStream(result, "devices", Stream.empty())
             .map(DeviceCtlParsers::parseAppleDevice)
             .filter(d -> d.deviceProperties.bootState)
@@ -186,8 +186,8 @@ public final class DeviceCtlParsers {
      *   }
      * }
      */
-    public static AppleDevice parseDeviceInfoResponse(@Required JSONObject json) {
-        JSONObject result = asJson(json, "result");
+    public static AppleDevice parseDeviceInfoResponse(@Required JsonObject json) {
+        JsonObject result = asJson(json, "result");
         if (result == null) throw new IllegalStateException("Unexpected JSON response: result is missing!");
         return parseAppleDevice(result);
     }
@@ -207,38 +207,38 @@ public final class DeviceCtlParsers {
     // JSON utilities bellow
     //
 
-    public static Stream<JSONObject> toObjectStream(@Required  JSONArray arr) {
+    public static Stream<JsonObject> toObjectStream(@Required JsonArray arr) {
         return ((List<?>) arr).stream()
-            .filter(o -> o instanceof JSONObject)
-            .map(o -> (JSONObject)o);
+            .filter(o -> o instanceof JsonObject)
+            .map(o -> (JsonObject)o);
     }
 
-    public static Stream<JSONObject> asObjectStream(@Optional JSONObject json, String key, Stream<JSONObject> defaultValue) {
+    public static Stream<JsonObject> asObjectStream(@Optional JsonObject json, String key, Stream<JsonObject> defaultValue) {
         if (json == null) return defaultValue;
         Object o = json.get(key);
-        if (o instanceof JSONArray) return toObjectStream((JSONArray) o);
+        if (o instanceof JsonArray) return toObjectStream((JsonArray) o);
         return defaultValue;
     }
 
-    public static String asString(@Optional JSONObject json, String key, String defaultValue) {
+    public static String asString(@Optional JsonObject json, String key, String defaultValue) {
         if (json == null) return defaultValue;
         Object o = json.get(key);
         if (o instanceof String) return (String) o;
         return defaultValue;
     }
 
-    public static String asString(@Optional JSONObject json, String key) {
+    public static String asString(@Optional JsonObject json, String key) {
         return asString(json, key, null);
     }
 
-    public static JSONObject asJson(@Optional JSONObject json, String key) {
+    public static JsonObject asJson(@Optional JsonObject json, String key) {
         if (json == null) return null;
         Object o = json.get(key);
-        if (o instanceof JSONObject) return (JSONObject) o;
+        if (o instanceof JsonObject) return (JsonObject) o;
         return null;
     }
 
-    public static long asLong(@Optional JSONObject json, String key, long defaultValue) {
+    public static long asLong(@Optional JsonObject json, String key, long defaultValue) {
         if (json == null) return defaultValue;
         Object o = json.get(key);
         if (o instanceof Number) return ((Number) o).longValue();

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/simulator/SimCtl.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/simulator/SimCtl.java
@@ -16,8 +16,8 @@
  */
 package org.robovm.compiler.target.ios.simulator;
 
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
+import com.github.cliftonlabs.json_simple.JsonObject;
+import com.github.cliftonlabs.json_simple.Jsoner;
 import org.robovm.compiler.log.Logger;
 import org.robovm.compiler.util.Executor;
 
@@ -49,8 +49,7 @@ public final class SimCtl {
             String capture = new Executor(Logger.NULL_LOGGER, "xcrun").args(
                     "simctl", "list", "devices", "pairs", "-j").execCapture();
 
-            JSONParser parser = new JSONParser();
-            JSONObject root = (JSONObject) parser.parse(capture);
+            JsonObject root = (JsonObject) Jsoner.deserialize(capture);
             return SimCtlParsers.parseListResponse(root);
 
         } catch (Exception e) {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/simulator/SimCtlParsers.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/simulator/SimCtlParsers.java
@@ -17,8 +17,8 @@
  */
 package org.robovm.compiler.target.ios.simulator;
 
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
+import com.github.cliftonlabs.json_simple.JsonArray;
+import com.github.cliftonlabs.json_simple.JsonObject;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.CpuArch;
 import org.robovm.compiler.config.Environment;
@@ -30,18 +30,18 @@ public class SimCtlParsers {
     public static final String[] ONLY_32BIT_DEVICES = {"iPhone 4", "iPhone 4s", "iPhone 5", "iPhone 5c", "iPad 2"};
     public static final DeviceType.Version ARM64_IOS_VERSION = new DeviceType.Version(14, 0, 0);
 
-    public static List<DeviceType> parseListResponse(JSONObject root) {
+    public static List<DeviceType> parseListResponse(JsonObject root) {
         List<DeviceType> types = new ArrayList<>();
         // parse watch pairs to
         Map<String, DeviceType> pairs = new HashMap<>();
-        JSONObject pairList = (JSONObject) root.get("pairs");
+        JsonObject pairList = (JsonObject) root.get("pairs");
         if (pairList != null) {
             for (Object e : pairList.values()) {
-                JSONObject entry = (JSONObject) e;
+                JsonObject entry = (JsonObject) e;
                 if (entry.containsKey("state") && entry.get("state").toString().contains("unavailable"))
                     continue;
-                JSONObject watchEntry = (JSONObject) entry.get("watch");
-                JSONObject phoneEntry = (JSONObject) entry.get("phone");
+                JsonObject watchEntry = (JsonObject) entry.get("watch");
+                JsonObject phoneEntry = (JsonObject) entry.get("phone");
                 if (watchEntry != null && phoneEntry != null) {
                     String phoneUdid = phoneEntry.get("udid").toString();
                     String watchUdid = watchEntry.get("udid").toString();
@@ -56,7 +56,7 @@ public class SimCtlParsers {
             }
         }
 
-        JSONObject deviceList = (JSONObject) root.get("devices");
+        JsonObject deviceList = (JsonObject) root.get("devices");
         for (Object value : deviceList.entrySet()) {
             //noinspection rawtypes
             Map.Entry entry = (Map.Entry) value;
@@ -70,9 +70,9 @@ public class SimCtlParsers {
                 // not iOS
                 continue;
             }
-            JSONArray devices = (JSONArray) entry.getValue();
+            JsonArray devices = (JsonArray) entry.getValue();
             for (Object obj : devices) {
-                JSONObject device = (JSONObject) obj;
+                JsonObject device = (JsonObject) obj;
                 boolean isAvailable = false;
                 if (device.containsKey("isAvailable")) {
                     Object o = device.get("isAvailable");

--- a/pom.xml
+++ b/pom.xml
@@ -184,9 +184,9 @@
                 <version>1.49</version>
             </dependency>
             <dependency>
-                <groupId>com.googlecode.json-simple</groupId>
+                <groupId>com.github.cliftonlabs</groupId>
                 <artifactId>json-simple</artifactId>
-                <version>1.1.1</version>
+                <version>4.0.1</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>


### PR DESCRIPTION
> java.lang.NumberFormatException: For input string: "18446744071562067970"

root case: `com.googlecode.json-simple:1.1.1` supports biggest number that fit into Long only and will fail on any bigger. as a quick fix will switch to last known and maintained fork `com.github.cliftonlabs:4.0.1`

```
"hardware" : {
            "cpuType" : {
              "subtype" : 18446744071562067970,
              "type" : 16777228
            },
            "ecid" : 3502134164946974,
            "productType" : "iPhone14,6",
            "udid" : "00008110-000C712C26DB801E"
          },
```