### PR TITLE
* fix/revert: `bin/` folder is must be present in no-compiler dist package

### DIFF
--- a/dist/package/src/main/assembly/dist-common.xml
+++ b/dist/package/src/main/assembly/dist-common.xml
@@ -18,6 +18,14 @@
       <outputDirectory>lib/vm</outputDirectory>
     </fileSet>
     <fileSet>
+      <directory>${robovmdir}/bin</directory>
+      <includes>
+        <include>*</include>
+      </includes>
+      <fileMode>755</fileMode>
+      <outputDirectory>bin</outputDirectory>
+    </fileSet>
+    <fileSet>
       <directory>${robovmdir}/compiler</directory>
       <outputDirectory>modules/licenses/dist-compiler/compiler</outputDirectory>
       <includes>

--- a/dist/package/src/main/assembly/dist-full.xml
+++ b/dist/package/src/main/assembly/dist-full.xml
@@ -14,18 +14,6 @@
     <componentDescriptor>src/main/assembly/dist-common.xml</componentDescriptor>
   </componentDescriptors>
 
-  <!-- binaries only needed for compiler package -->
-  <fileSets>
-    <fileSet>
-      <directory>${robovmdir}/bin</directory>
-      <includes>
-        <include>*</include>
-      </includes>
-      <fileMode>755</fileMode>
-      <outputDirectory>bin</outputDirectory>
-    </fileSet>
-  </fileSets>
-
   <dependencySets>
     <dependencySet>
       <includes>


### PR DESCRIPTION

otherwise it fails in gradle build with:
> Failed to launch simulator ~/.m2/repository/com/mobidevelop/robovm/robovm-dist/2.3.26-SNAPSHOT/unpacked/robovm-2.3.26-SNAPSHOT/bin does not exist.