### PR TITLE
* fixed: robovm build fails if project uses configuration cache

### DIFF
--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMTask.java
@@ -79,6 +79,16 @@ abstract public class AbstractRoboVMTask extends DefaultTask {
     protected Logger roboVMLogger;
 
     public AbstractRoboVMTask() {
+        try {
+            // TODO: support configuration cache, disabling as will crash with message
+            // Task `:launchIPhoneSimulator` of type `org.robovm.gradle.tasks.IPhoneSimulatorTask`:
+            // cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject',
+            // a subtype of 'org.gradle.api.Project', as these are not supported with the configuration cache.
+            notCompatibleWithConfigurationCache("Not compatible due internal implementation");
+        } catch (NoSuchMethodError e) {
+            // not available before Gradle 7.4
+        }
+
         project = getProject();
         extension = (RoboVMPluginExtension) project.getExtensions().getByName(RoboVMPluginExtension.NAME);
         repositorySystem = createRepositorySystem();


### PR DESCRIPTION
while robovm plugin doesn't support caching it should not fail build of projects that configured with cache.

steps to reproduce:
> ./gradlew  --configuration-cache  launchIPhoneSimulator

exception:
```
1: Task failed with an exception.
-----------
* What went wrong:
Configuration cache state could not be cached: field `nakedExpressions` of `org.codehaus.plexus.interpolation.PrefixAwareRecursionInterceptor` bean found in field `recursionInterceptor` of `org.apache.maven.model.interpolation.StringSearchModelInterpolator` bean found in field `modelInterpolator` of `org.apache.maven.model.building.DefaultModelBuilder` bean found in field `modelBuilder` of `org.apache.maven.repository.internal.DefaultArtifactDescriptorReader` bean found in field `artifactDescriptorReader` of `org.sonatype.aether.impl.internal.DefaultRepositorySystem` bean found in field `repositorySystem` of task `:launchIPhoneSimulator` of type `org.robovm.gradle.tasks.IPhoneSimulatorTask`: error writing value of type 'java.util.Stack'
> 'ObjectOutputStream.putFields' is not supported by the Gradle configuration cache. See https://docs.gradle.org/9.6.1/userguide/configuration_cache_status.html#config_cache:not_yet_implemented:java_serialization for details.

2: Task failed with an exception.
-----------
* What went wrong:
Configuration cache problems found in this build.

3 problems were found storing the configuration cache, 2 of which seem unique.
- Task `:launchIPhoneSimulator` of type `org.robovm.gradle.tasks.IPhoneSimulatorTask`: cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with the configuration cache.
  See https://docs.gradle.org/9.6.1/userguide/configuration_cache_requirements.html#config_cache:requirements:disallowed_types
- Task `:launchIPhoneSimulator` of type `org.robovm.gradle.tasks.IPhoneSimulatorTask`: error writing value of type 'java.util.Stack'

```