### PR TITLE
* [3.0.0] ios launcher: deployment over wifi and device mirroring

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/devicecommon/IOSDeviceLauncher.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/devicecommon/IOSDeviceLauncher.java
@@ -20,17 +20,23 @@ import org.robovm.compiler.Version;
 import org.robovm.compiler.launcher.Launcher;
 import org.robovm.compiler.launcher.ProcessProxy;
 import org.robovm.compiler.log.Logger;
+import org.robovm.compiler.target.ios.devicectl.DeviceCtl;
 import org.robovm.compiler.target.ios.devicectl.DeviceCtlLauncherDelegate;
 import org.robovm.compiler.target.ios.libimobiledevice.AppLauncherDelegate;
 import org.robovm.libimobiledevice.IDevice;
+import org.robovm.libimobiledevice.LibIMobileDeviceException;
 import org.robovm.libimobiledevice.LockdowndClient;
 import org.robovm.libimobiledevice.util.AppLauncher;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * {@link Launcher} IOS device launcher, uses libimobiledevice to list devices and pick the on to launch.
@@ -82,29 +88,29 @@ public class IOSDeviceLauncher implements Launcher {
 
         boolean runningIOS17;
         try {
-            IDevice selectedDevice = AppLauncher.waitForDevice(
-                deviceUdid,
-                20,
-                1,
-                log::info
-            );
+            DeviceResp selectedDevice = waitForDevice(deviceUdid, log::info);
 
             // check cache first before querying device
             Boolean cachedRunningIOS17;
             synchronized (resolvedDevicesCache) {
-                cachedRunningIOS17 = resolvedDevicesCache.get(selectedDevice.getUdid());
+                if (selectedDevice.ios17OrAbove) {
+                    cachedRunningIOS17 = true;
+                    resolvedDevicesCache.put(selectedDevice.udid, true);
+                } else {
+                    cachedRunningIOS17 = resolvedDevicesCache.get(selectedDevice.udid);
+                }
             }
             if (cachedRunningIOS17 != null) {
                 runningIOS17 = cachedRunningIOS17;
             } else {
                 // get device's IOS version
-                try (LockdowndClient lockdowndClient = new LockdowndClient(selectedDevice, "IOSDeviceLauncher", true)) {
+                try (LockdowndClient lockdowndClient = new LockdowndClient(new IDevice(selectedDevice.udid), "IOSDeviceLauncher", true)) {
                     String productVersion = lockdowndClient.getValue(null, "ProductVersion").toString(); // E.g. 7.0.2
                     Version version = Version.parse(productVersion);
                     runningIOS17 = version.getMajor() >= 17;
                     // update cache
                     synchronized (resolvedDevicesCache) {
-                        resolvedDevicesCache.put(selectedDevice.getUdid(), runningIOS17);
+                        resolvedDevicesCache.put(selectedDevice.udid, runningIOS17);
                     }
                 }
             }
@@ -137,6 +143,78 @@ public class IOSDeviceLauncher implements Launcher {
         } catch (Throwable t) {
             log.error("iOS DeviceLauncher failed with an exception: %s", t.getMessage());
             throw t;
+        }
+    }
+
+    /**
+     * look for a specific device or wait for a single device to be connected, with retries.
+     * look in both DeviceCtl and libimobiledevice for connected devices.
+     */
+    private DeviceResp waitForDevice(String deviceUdid, AppLauncher.Logger logger) throws Exception{
+        final int retries = 20;
+        final int secondsBetweenRetries = 1;
+        int retriesLeft = retries;
+
+        while (true) {
+            List<DeviceResp> udids = Stream.concat(
+                DeviceCtl.listDevices().stream().map(d -> new DeviceResp(d.hardwareProperties.udid, true)),
+                Arrays.stream(IDevice.listUdids()).map(s -> new DeviceResp(s, false))
+            ).distinct().collect(Collectors.toList());
+            if (udids.size() == 1 && (deviceUdid == null || deviceUdid.equals(udids.get(0).udid))) {
+                // single device and it's a match
+                return udids.get(0);
+            } else if (udids.size() > 1 && deviceUdid != null) {
+                int idx = udids.indexOf(new DeviceResp(deviceUdid, false));
+                if (idx >= 0) {
+                    // multiple devices connected but specified is there
+                    return udids.get(idx);
+                }
+            }
+
+            String message;
+            if (udids.isEmpty()) {
+                message = "No devices connected";
+            } else if (deviceUdid != null) {
+                message = String.format("Required %s is not connected (%s)", deviceUdid, udids);
+            } else {
+                message = String.format("More than 1 device connected (%s)", udids);
+            }
+
+            if (retriesLeft > 0) {
+                retriesLeft -= 1;
+                logger.log(String.format("Waiting for device: %s. (retry %d of %d)...", message, (retries - retriesLeft), retries));
+                Thread.sleep(secondsBetweenRetries * 1000L);
+            } else throw new LibIMobileDeviceException(message);
+        }
+    }
+
+    // response from waitForDevice, contains device udid and whether it is running iOS 17 or above
+    private static class DeviceResp {
+        private final String udid;
+        private final boolean ios17OrAbove;
+
+        public DeviceResp(String udid, boolean ios17OrAbove) {
+            this.udid = udid;
+            this.ios17OrAbove = ios17OrAbove;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof DeviceResp) {
+                DeviceResp otherResp = (DeviceResp) obj;
+                return this.udid.equals(otherResp.udid);
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return udid.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return udid;
         }
     }
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/devicectl/AppleDevice.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/devicectl/AppleDevice.java
@@ -145,6 +145,8 @@ public class AppleDevice {
 
             // known constants
             public static TunnelState CONNECTED = of("connected");
+            public static TunnelState DISCONNECTED = of("disconnected");
+            public static TunnelState UNAVAILABLE = of("unavailable");
         }
 
         public final AuthenticationType authenticationType;

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/devicectl/DeviceCtlParsers.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/devicectl/DeviceCtlParsers.java
@@ -175,7 +175,10 @@ public final class DeviceCtlParsers {
         JsonObject result = asJson(json, "result");
         return asObjectStream(result, "devices", Stream.empty())
             .map(DeviceCtlParsers::parseAppleDevice)
-            .filter(d -> d.deviceProperties.bootState)
+            .filter(d ->
+                // DISCONNECTED means device is discoverable but tunnel is not established
+                d.connectionProperties.tunnelState == TunnelState.CONNECTED || d.connectionProperties.tunnelState == TunnelState.DISCONNECTED
+            )
             .collect(Collectors.toList());
     }
 

--- a/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmIOSRunConfigurationSettingsEditor.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/running/RoboVmIOSRunConfigurationSettingsEditor.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.NotNull;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
 import org.robovm.compiler.config.CpuArch;
+import org.robovm.compiler.target.ios.devicectl.DeviceCtl;
 import org.robovm.compiler.target.ios.simulator.DeviceType;
 import org.robovm.compiler.target.ios.IOSTarget;
 import org.robovm.compiler.target.ios.ProvisioningProfile;
@@ -45,6 +46,7 @@ import java.util.*;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.robovm.idea.running.RoboVmRunConfiguration.AUTO_PROVISIONING_PROFILE;
 import static org.robovm.idea.running.RoboVmRunConfiguration.AUTO_SIGNING_IDENTITY;
@@ -85,7 +87,7 @@ public class RoboVmIOSRunConfigurationSettingsEditor extends SettingsEditor<Robo
     private final SigningIdentityDecorator signingIdentityAuto = new SigningIdentityDecorator(AUTO_SIGNING_IDENTITY, EntryType.AUTO);
 
     private List<IDeviceDecorator> connectedDevices;
-    private final IDeviceDecorator connectedDeviceAuto = new IDeviceDecorator("Auto (single connected device)", EntryType.AUTO);;
+    private final IDeviceDecorator connectedDeviceAuto = new IDeviceDecorator("Auto (single connected device)", EntryType.AUTO, true);
 
     private boolean moduleHasWatchApp;
     // true if editor internally updating data and listeners should ignore the events
@@ -276,8 +278,10 @@ public class RoboVmIOSRunConfigurationSettingsEditor extends SettingsEditor<Robo
     }
 
     private void populateDevices () {
-        this.connectedDevices = Arrays.stream(IDevice.listUdids()).map(IDeviceDecorator::new).collect(Collectors.toList());
-
+        this.connectedDevices = Stream.concat(
+            DeviceCtl.listDevices().stream().map(d -> new IDeviceDecorator(d.hardwareProperties.udid, d.deviceProperties.name, false)),
+            Arrays.stream(IDevice.listUdids()).map(s -> new IDeviceDecorator(s, s, false))
+        ).distinct().collect(Collectors.toList());
         IDeviceDecorator previousSelection = (IDeviceDecorator) targetDeviceUDID.getSelectedItem();
         Vector<IDeviceDecorator> items = new Vector<>();
         items.add(connectedDeviceAuto);
@@ -344,7 +348,7 @@ public class RoboVmIOSRunConfigurationSettingsEditor extends SettingsEditor<Robo
         }
 
         // check if it is in the list
-        IDeviceDecorator candidate = new IDeviceDecorator(udid);
+        IDeviceDecorator candidate = new IDeviceDecorator(udid, true);
         ComboBoxModel<IDeviceDecorator> model = targetDeviceUDID.getModel();
         for (int i = 0; i < model.getSize(); i++) {
             IDeviceDecorator item = model.getElementAt(i);
@@ -896,14 +900,21 @@ public class RoboVmIOSRunConfigurationSettingsEditor extends SettingsEditor<Robo
      * decorator for connected device
      */
     private static class IDeviceDecorator extends Decorator<String> {
-
+        private final boolean offline;
         private boolean currentlyCompatible = true;
-        IDeviceDecorator (String title, EntryType entryType) {
+        IDeviceDecorator (String title, EntryType entryType, boolean offline) {
             super(null, null, title, entryType);
+            this.offline = offline;
         }
 
-        IDeviceDecorator(String deviceIdentifier) {
+        IDeviceDecorator(String deviceIdentifier, boolean offline) {
             super(deviceIdentifier, deviceIdentifier, deviceIdentifier, EntryType.ID);
+            this.offline = offline;
+        }
+
+        IDeviceDecorator(String deviceIdentifier, String name, boolean offline) {
+            super(deviceIdentifier, deviceIdentifier, name, EntryType.ID);
+            this.offline = offline;
         }
 
         public void setCurrentlyCompatible(boolean currentlyCompatible) {
@@ -920,8 +931,7 @@ public class RoboVmIOSRunConfigurationSettingsEditor extends SettingsEditor<Robo
 
         @Override
         public boolean equals(Object obj) {
-            if (obj instanceof IDeviceDecorator) {
-                IDeviceDecorator other = (IDeviceDecorator) obj;
+            if (obj instanceof IDeviceDecorator other) {
                 if (this.entryType == other.entryType) {
                     if (this.id != null && other.id != null)
                         return this.id.equals(other.id);
@@ -938,20 +948,19 @@ public class RoboVmIOSRunConfigurationSettingsEditor extends SettingsEditor<Robo
             if (id == null) {
                 return name;
             } else {
-                boolean offline = !IDevice.isConnected(id);
-                if (currentlyCompatible && !offline) {
-                    return name;
+                String nameBuffer = "";
+                if (name != null && !name.isEmpty()) {
+                    nameBuffer += name + " - " + id;
                 } else {
-                    String nameBuffer = "";
                     nameBuffer += id;
-                    if (!currentlyCompatible) {
-                        nameBuffer += " [Incompatible]";
-                    }
-                    if (offline) {
-                        nameBuffer += " [Offline]";
-                    }
-                    return nameBuffer;
                 }
+                if (!currentlyCompatible) {
+                    nameBuffer += " [Incompatible]";
+                }
+                if (offline) {
+                    nameBuffer += " [Offline]";
+                }
+                return nameBuffer;
             }
         }
     }


### PR DESCRIPTION
same as https://github.com/MobiVM/robovm/pull/873

- fixed: DeviceCtlParser -- allow devices with missing bootState (available wifi device is not connected)
- launcher -- combining both DeviceCtl and ilibmobile resolved devices
- idea run configuration -- combining both DeviceCtl and ilibmobile resolved devices. Limitation -- dynamic update for mirrored or available over wifi will not work