### PR TITLE
Add a root NOTICE.txt indexing the per-module licences

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,55 @@
+MobiVM (RoboVM)
+Copyright (C) 2012-2014 RoboVM AB
+Copyright (C) 2015-2026 MobiVM contributors
+
+This repository has no single repository-wide licence.
+
+It grew out of the original RoboVM project and was later combined into one
+monolithic repository. Each module therefore carries its own LICENSE.txt and,
+where applicable, NOTICE.txt, and those files apply to the directory they are
+located in.
+
+This file is an index for convenience. It is not itself a licence, and it does
+not modify any of the licences it points at. Where this index and a module's
+own LICENSE.txt disagree, the file inside the module governs.
+
+
+Modules under the Apache License 2.0
+------------------------------------
+
+  compiler/rt                 compiler/rt/LICENSE.txt
+  compiler/objc               compiler/objc/LICENSE.txt
+  compiler/bro-bridge         compiler/bro-bridge/LICENSE.txt
+  compiler/cocoatouch         compiler/cocoatouch/LICENSE.txt
+  compiler/vm                 compiler/vm/LICENSE.txt
+  plugins/templates           plugins/templates/LICENSE.txt
+
+  compiler/rt additionally carries compiler/rt/LICENSE_GPL_CE.txt, the GNU
+  General Public License version 2 with the Classpath Exception, which covers
+  the parts of the runtime derived from OpenJDK.
+
+
+Modules under the GNU General Public License version 2
+------------------------------------------------------
+
+  compiler/compiler           compiler/compiler/LICENSE.txt
+  compiler/llvm               compiler/llvm/LICENSE.txt
+  compiler/libimobiledevice   compiler/libimobiledevice/LICENSE.txt
+  compiler/libhfscompressor   compiler/libhfscompressor/LICENSE.txt
+  plugins/eclipse             plugins/eclipse/LICENSE.txt
+  plugins/idea                plugins/idea/LICENSE.txt
+  dist                        dist/LICENSE.txt
+
+
+Third-party components
+----------------------
+
+Third-party components are listed in the NOTICE.txt of the module that contains
+them, not here.
+
+compiler/rt in particular bundles code from the Android Open Source Project,
+ICU, OpenJDK and others. See compiler/rt/NOTICE.txt and the NOTICE and LICENSE
+files below compiler/rt/android/.
+
+compiler/compiler/NOTICE.txt lists the third-party libraries used by the
+compiler itself.


### PR DESCRIPTION
Follow-up to discussion #872, where a root `NOTICE.txt` was suggested.

### Why

The repository has no repository-wide `LICENSE.txt`, and the per-module `LICENSE.txt` / `NOTICE.txt` files are easy to miss. Working out what may be redistributed currently means walking the tree and reading each one — which is what I ended up doing before asking in #872.

### What this is

An index, and explicitly nothing more. The file says so itself:

> This file is an index for convenience. It is not itself a licence, and it does not modify any of the licences it points at. Where this index and a module's own LICENSE.txt disagree, the file inside the module governs.

So it cannot change anything about the existing terms — it only makes them findable.

### How it was compiled

Every entry was read from the `LICENSE.txt` in question at the current head of `dev/3.0.0` (`6bc25df`), not assumed:

- **Apache-2.0** — `compiler/rt`, `compiler/objc`, `compiler/bro-bridge`, `compiler/cocoatouch`, `compiler/vm`, `plugins/templates`
- **GPLv2** — `compiler/compiler`, `compiler/llvm`, `compiler/libimobiledevice`, `compiler/libhfscompressor`, `plugins/eclipse`, `plugins/idea`, `dist`
- `compiler/rt` additionally carries `LICENSE_GPL_CE.txt` for the OpenJDK-derived parts

Third-party components are left where they are, in the `NOTICE.txt` of the module that contains them, with pointers to `compiler/rt/NOTICE.txt` and `compiler/rt/android/`.

### Scope

Targeted at `dev/3.0.0` because that is what I read. **`master` was not examined and the file makes no claim about it** — if you would like it on `master` too, it should be checked against that tree first rather than copied across.

Happy to adjust the wording, the grouping, or drop anything that reads as interpretation rather than description.
